### PR TITLE
Add release command

### DIFF
--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -1,0 +1,102 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/lunarway/release-manager/internal/git"
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func NewRelease(options *Options) *cobra.Command {
+	var serviceName, environment, branch, artifact string
+	var command = &cobra.Command{
+		Use:   "release",
+		Short: `Release a specific artifact or latest artifact from a branch into a specific environment.`,
+		Example: `Release artifact 'master-482c9d808e-3bf40478e5' from service 'product' into environemnt 'dev':
+
+  hamctl release --service product --env dev --artifact master-482c9d808e-3bf40478e5
+
+Release latest artifact from branch 'master' of service 'product' into environemnt 'dev':
+
+  hamctl release --service product --env dev --branch master`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if branch != "" && artifact != "" {
+				return errors.New("--branch and --artifact cannot both be specificed")
+			}
+			if branch == "" && artifact == "" {
+				return errors.New("--branch or --artifact is required")
+			}
+			url := options.httpBaseURL + "/release"
+
+			client := &http.Client{
+				Timeout: options.httpTimeout,
+			}
+
+			committerName, committerEmail, err := git.CommitterDetails()
+			if err != nil {
+				return err
+			}
+
+			releaseRequest := httpinternal.ReleaseRequest{
+				Service:        serviceName,
+				Environment:    environment,
+				Branch:         branch,
+				ArtifactID:     artifact,
+				CommitterName:  committerName,
+				CommitterEmail: committerEmail,
+			}
+
+			b := new(bytes.Buffer)
+			err = json.NewEncoder(b).Encode(releaseRequest)
+			if err != nil {
+				return err
+			}
+
+			req, err := http.NewRequest(http.MethodPost, url, b)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Authorization", "Bearer "+options.authToken)
+			resp, err := client.Do(req)
+			if err != nil {
+				return err
+			}
+			decoder := json.NewDecoder(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				var r httpinternal.ErrorResponse
+				err = decoder.Decode(&r)
+				if err != nil {
+					return err
+				}
+				return errors.New(r.Message)
+			}
+
+			var r httpinternal.ReleaseResponse
+
+			err = decoder.Decode(&r)
+			if err != nil {
+				return errors.WithMessage(err, "decode HTTP response")
+			}
+
+			if r.Status != "" {
+				fmt.Printf("%s\n", r.Status)
+			} else {
+				fmt.Printf("[✓] Release of %s to %s initialized\n", r.Tag, r.ToEnvironment)
+			}
+
+			return nil
+		},
+	}
+	command.Flags().StringVar(&serviceName, "service", "", "service from with to release into specified environment (required)")
+	command.MarkFlagRequired("service")
+	command.Flags().StringVar(&environment, "env", "", "environment to release to (required)")
+	command.MarkFlagRequired("env")
+	command.Flags().StringVar(&branch, "branch", "", "release latest artifact from this branch (mutually exclusive with --artifact)")
+	command.Flags().StringVar(&artifact, "artifact", "", "release this artifact id (mutually exclusive with --branch)")
+	return command
+}

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -25,6 +25,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	command.AddCommand(NewPromote(&options))
+	command.AddCommand(NewRelease(&options))
 	command.AddCommand(NewStatus(&options))
 	command.AddCommand(NewPolicy(&options))
 	command.PersistentFlags().StringVar(&options.RootPath, "root", ".", "Root from where builds and releases should be found.")

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -36,6 +36,24 @@ type PromoteResponse struct {
 	ToEnvironment   string `json:"toEnvironment,omitempty"`
 	Tag             string `json:"tag,omitempty"`
 }
+
 type ErrorResponse struct {
 	Message string `json:"message,omitempty"`
+}
+
+type ReleaseRequest struct {
+	Service        string `json:"service,omitempty"`
+	Environment    string `json:"environment,omitempty"`
+	Branch         string `json:"branch,omitempty"`
+	ArtifactID     string `json:"artifactId,omitempty"`
+	CommitterName  string `json:"committerName,omitempty"`
+	CommitterEmail string `json:"committerEmail,omitempty"`
+}
+
+type ReleaseResponse struct {
+	Service       string `json:"service,omitempty"`
+	ReleaseID     string `json:"releaseId,omitempty"`
+	Status        string `json:"status,omitempty"`
+	ToEnvironment string `json:"toEnvironment,omitempty"`
+	Tag           string `json:"tag,omitempty"`
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -24,7 +24,7 @@ func Init() {
 	config.EncoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
 	config.EncoderConfig.EncodeDuration = zapcore.SecondsDurationEncoder
 	config.EncoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
-	zapLogger, _ := config.Build()
+	zapLogger, _ := config.Build(zap.AddCallerSkip(2))
 	logger = &Logger{sugar: zapLogger.Sugar()}
 }
 


### PR DESCRIPTION
It can be used either for specific artifact IDs or from a branch.

I've added a context.Context to our Git operations as well to handle timeouts and aborts from the client for long running actions.

Lastly have I added a skip option to the logger to make the "caller" field in logs be of our source code instead of the logging package's.