### PR TITLE
Use a shared client for hamctl requests

### DIFF
--- a/cmd/hamctl/command/http.go
+++ b/cmd/hamctl/command/http.go
@@ -1,0 +1,83 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/pkg/errors"
+)
+
+type client struct {
+	baseURL   string
+	timeout   time.Duration
+	authToken string
+}
+
+// url returns a URL with provided path added to the client's base URL.
+func (c *client) url(path string) (string, error) {
+	requestURL, err := url.Parse(fmt.Sprintf("%s/%s", c.baseURL, path))
+	if err != nil {
+		return "", err
+	}
+	return requestURL.String(), nil
+}
+
+// urlWithQuery returns a URL with provided path and query params added to the
+// client's base URL. All query param values are escaped.
+func (c *client) urlWithQuery(path string, queryParams url.Values) (string, error) {
+	if queryParams != nil {
+		path += fmt.Sprintf("?%s", queryParams.Encode())
+	}
+	return c.url(path)
+}
+
+// req executes an HTTP request defined by the provided method and path. The
+// base URL is prefixed on the provided path.
+//
+// Request and response bodies are marshalled and unmarshalled as JSON and if
+// the server returns a status code above 399 the response is parsed as an
+// ErrorResponse object and the Message field is returned as an error.
+func (c *client) req(method string, path string, requestBody, responseBody interface{}) error {
+	client := &http.Client{
+		Timeout: c.timeout,
+	}
+
+	var b io.ReadWriter
+	if requestBody != nil {
+		b = &bytes.Buffer{}
+		err := json.NewEncoder(b).Encode(requestBody)
+		if err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequest(method, path, b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.authToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	if resp.StatusCode > http.StatusBadRequest {
+		var responseError httpinternal.ErrorResponse
+		err = decoder.Decode(&responseError)
+		if err != nil {
+			return errors.WithMessagef(err, "response status %s: unmarshal error response", resp.Status)
+		}
+		return errors.New(responseError.Message)
+	}
+	err = decoder.Decode(responseBody)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/hamctl/command/policy.go
+++ b/cmd/hamctl/command/policy.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewPolicy(options *Options) *cobra.Command {
+func NewPolicy(client *client) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "policy",
 		Short: "Promote a service to a specific environment following promoting conventions.",

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -7,16 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type Options struct {
-	RootPath    string
-	httpTimeout time.Duration
-	httpBaseURL string
-	authToken   string
-}
-
 // NewCommand returns a new instance of a hamctl command.
 func NewCommand() *cobra.Command {
-	var options Options
+	var client client
 	var command = &cobra.Command{
 		Use:   "hamctl",
 		Short: "hamctl controls a release manager server",
@@ -24,13 +17,12 @@ func NewCommand() *cobra.Command {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewPromote(&options))
-	command.AddCommand(NewRelease(&options))
-	command.AddCommand(NewStatus(&options))
-	command.AddCommand(NewPolicy(&options))
-	command.PersistentFlags().StringVar(&options.RootPath, "root", ".", "Root from where builds and releases should be found.")
-	command.PersistentFlags().DurationVar(&options.httpTimeout, "http-timeout", 20*time.Second, "HTTP request timeout")
-	command.PersistentFlags().StringVar(&options.httpBaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
-	command.PersistentFlags().StringVar(&options.authToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
+	command.AddCommand(NewPromote(&client))
+	command.AddCommand(NewRelease(&client))
+	command.AddCommand(NewStatus(&client))
+	command.AddCommand(NewPolicy(&client))
+	command.PersistentFlags().DurationVar(&client.timeout, "http-timeout", 20*time.Second, "HTTP request timeout")
+	command.PersistentFlags().StringVar(&client.baseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
+	command.PersistentFlags().StringVar(&client.authToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 	return command
 }


### PR DESCRIPTION
This hides the implementation details of marshalling and unmarshalling
of requests and responses along with authentication.

I removed the "root" flag as well as it is not used anymore.