### PR TITLE
Add authenticate middleware

### DIFF
--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -4,21 +4,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/lunarway/release-manager/cmd/server/http"
 	"github.com/spf13/cobra"
 )
 
-type Options struct {
-	httpPort            int
-	timeout             time.Duration
-	configRepo          string
-	artifactFileName    string
-	sshPrivateKeyPath   string
-	githubWebhookSecret string
-}
-
 // NewCommand returns a new instance of a hamctl command.
 func NewCommand() *cobra.Command {
-	var options Options
+	var options http.Options
 	var command = &cobra.Command{
 		Use:   "server",
 		Short: "server",
@@ -27,12 +19,14 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	command.AddCommand(NewStart(&options))
-	command.PersistentFlags().StringVar(&options.configRepo, "config-repo", "git@github.com:lunarway/k8s-cluster-config.git", "ssh url for the git config repository")
-	command.PersistentFlags().IntVar(&options.httpPort, "http-port", 8080, "port of the http server")
-	command.PersistentFlags().StringVar(&options.artifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
-	command.PersistentFlags().StringVar(&options.sshPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")
-	command.PersistentFlags().DurationVar(&options.timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
-	command.PersistentFlags().StringVar(&options.githubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
+	command.PersistentFlags().IntVar(&options.Port, "http-port", 8080, "port of the http server")
+	command.PersistentFlags().DurationVar(&options.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
+	command.PersistentFlags().StringVar(&options.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")
+	command.PersistentFlags().StringVar(&options.DaemonAuthToken, "daemon-auth-token", os.Getenv("DAEMON_AUTH_TOKEN"), "daemon webhook authentication token")
+	command.PersistentFlags().StringVar(&options.ConfigRepo, "config-repo", "git@github.com:lunarway/k8s-cluster-config.git", "ssh url for the git config repository")
+	command.PersistentFlags().StringVar(&options.ArtifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
+	command.PersistentFlags().StringVar(&options.SSHPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")
+	command.PersistentFlags().StringVar(&options.GithubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
 
 	return command
 }

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewStart(options *Options) *cobra.Command {
+func NewStart(options *http.Options) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "start the release-manager",
@@ -20,7 +20,7 @@ func NewStart(options *Options) *cobra.Command {
 			done := make(chan error, 1)
 
 			go func() {
-				err := http.NewServer(options.httpPort, options.timeout, options.configRepo, options.artifactFileName, options.sshPrivateKeyPath, options.githubWebhookSecret)
+				err := http.NewServer(options)
 				if err != nil {
 					done <- errors.WithMessage(err, "new http server")
 					return

--- a/cmd/server/http/http_test.go
+++ b/cmd/server/http/http_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,6 +90,71 @@ func TestBranchName(t *testing.T) {
 			branchName, ok := branchName(tc.input.files, tc.input.artifactFileName, tc.input.service)
 			assert.Equal(t, tc.ok, ok, "ok bool not as expected")
 			assert.Equal(t, tc.branchName, branchName, "name not as expected")
+		})
+	}
+}
+
+func TestAuthenticate(t *testing.T) {
+	tt := []struct {
+		name          string
+		serverToken   string
+		authorization string
+		status        int
+	}{
+		{
+			name:          "empty authorization",
+			serverToken:   "token",
+			authorization: "",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "whitespace token",
+			serverToken:   "token",
+			authorization: "  ",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "non-bearer authorization",
+			serverToken:   "token",
+			authorization: "non-bearer-token",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "empty bearer authorization",
+			serverToken:   "token",
+			authorization: "Bearer ",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "whitespace bearer authorization",
+			serverToken:   "token",
+			authorization: "Bearer      ",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "wrong bearer authorization",
+			serverToken:   "token",
+			authorization: "Bearer another-token",
+			status:        http.StatusUnauthorized,
+		},
+		{
+			name:          "correct bearer authorization",
+			serverToken:   "token",
+			authorization: "Bearer token",
+			status:        http.StatusOK,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", tc.authorization)
+			w := httptest.NewRecorder()
+			authenticate(tc.serverToken, handler)(w, req)
+
+			assert.Equal(t, tc.status, w.Result().StatusCode, "status code not as expected")
 		})
 	}
 }

--- a/cmd/server/http/policy.go
+++ b/cmd/server/http/policy.go
@@ -13,11 +13,6 @@ import (
 
 func policy(configRepo, sshPrivateKeyPath string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		valid := validateToken(r.Header.Get("Authorization"), "HAMCTL_AUTH_TOKEN")
-		if !valid {
-			Error(w, "not authorized", http.StatusUnauthorized)
-			return
-		}
 		switch r.Method {
 		case http.MethodPatch:
 			// only auto-release policies are available so no other validtion is required here


### PR DESCRIPTION
The added authenticate function takes a token that requests are
authenticated against.

Further more daemon and hamctl tokens are moved into server flags with
fallback to env variabels (current behaviour).

I moved the Options struct to the http NewServer function instead of
having it in the command packaged as it only specified HTTP options.
This simplifies calls to the NewServer function.