### PR TITLE
Fix most of the issues reported by Go Report

### DIFF
--- a/cmd/artifact/command/add_test.go
+++ b/cmd/artifact/command/add_test.go
@@ -24,7 +24,7 @@ func Test(t *testing.T) {
 			},
 			output: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
 				},
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 			desc: "stage already created",
 			spec: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
 				},
@@ -44,7 +44,7 @@ func Test(t *testing.T) {
 			},
 			output: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
 				},
@@ -54,10 +54,10 @@ func Test(t *testing.T) {
 			desc: "multiple stages present",
 			spec: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
-					spec.Stage{
+					{
 						ID: "build",
 					},
 				},
@@ -68,11 +68,11 @@ func Test(t *testing.T) {
 			},
 			output: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID:   "test",
 						Name: "New",
 					},
-					spec.Stage{
+					{
 						ID: "build",
 					},
 				},
@@ -82,10 +82,10 @@ func Test(t *testing.T) {
 			desc: "another stage already present",
 			spec: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
-					spec.Stage{
+					{
 						ID: "build",
 					},
 				},
@@ -95,13 +95,13 @@ func Test(t *testing.T) {
 			},
 			output: spec.Spec{
 				Stages: []spec.Stage{
-					spec.Stage{
+					{
 						ID: "test",
 					},
-					spec.Stage{
+					{
 						ID: "build",
 					},
-					spec.Stage{
+					{
 						ID: "push",
 					},
 				},

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -79,7 +79,6 @@ func (c *Client) WatchPods(ctx context.Context, succeeded, failed NotifyFunc) er
 			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {

--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -15,11 +15,11 @@ func NewRelease(client *httpinternal.Client) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "release",
 		Short: `Release a specific artifact or latest artifact from a branch into a specific environment.`,
-		Example: `Release artifact 'master-482c9d808e-3bf40478e5' from service 'product' into environemnt 'dev':
+		Example: `Release artifact 'master-482c9d808e-3bf40478e5' from service 'product' into environment 'dev':
 
   hamctl release --service product --env dev --artifact master-482c9d808e-3bf40478e5
 
-Release latest artifact from branch 'master' of service 'product' into environemnt 'dev':
+Release latest artifact from branch 'master' of service 'product' into environment 'dev':
 
   hamctl release --service product --env dev --branch master`,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -245,7 +245,7 @@ func githubWebhook(configRepo, artifactFileName, sshPrivateKeyPath, githubWebhoo
 				Error(w, "internal error", http.StatusInternalServerError)
 				return
 			}
-			log.Infof("webhook: handled succesfully: service '%s' branch '%s' commit '%s'", serviceName, branch, push.HeadCommit.ID)
+			log.Infof("webhook: handled successfully: service '%s' branch '%s' commit '%s'", serviceName, branch, push.HeadCommit.ID)
 			w.WriteHeader(http.StatusOK)
 			return
 		default:

--- a/cmd/server/http/log_test.go
+++ b/cmd/server/http/log_test.go
@@ -15,7 +15,7 @@ func TestFlattenHeaders(t *testing.T) {
 		{
 			name: "single value header",
 			input: map[string][]string{
-				"User-Agent": []string{"curl"},
+				"User-Agent": {"curl"},
 			},
 			output: map[string]string{
 				"User-Agent": "curl",
@@ -24,7 +24,7 @@ func TestFlattenHeaders(t *testing.T) {
 		{
 			name: "multi value header",
 			input: map[string][]string{
-				"User-Agent": []string{"curl", "1.2.3"},
+				"User-Agent": {"curl", "1.2.3"},
 			},
 			output: map[string]string{
 				"User-Agent": "curl,1.2.3",
@@ -33,8 +33,8 @@ func TestFlattenHeaders(t *testing.T) {
 		{
 			name: "multiple mixed headers",
 			input: map[string][]string{
-				"Authoriztaion": []string{"Bearer token"},
-				"User-Agent":    []string{"curl", "1.2.3"},
+				"Authoriztaion": {"Bearer token"},
+				"User-Agent":    {"curl", "1.2.3"},
 			},
 			output: map[string]string{
 				"Authoriztaion": "Bearer token",

--- a/cmd/server/http/policy.go
+++ b/cmd/server/http/policy.go
@@ -108,6 +108,11 @@ func listPolicies(configRepo, sshPrivateKeyPath string) http.HandlerFunc {
 			Service:      policies.Service,
 			AutoReleases: mapAutoReleasePolicies(policies.AutoReleases),
 		})
+		if err != nil {
+			log.Errorf("http list policies failed: config repo '%s' service '%s': encode response: %v", configRepo, service, err)
+			Error(w, "unknown error", http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -157,7 +162,7 @@ func deletePolicies(configRepo, sshPrivateKeyPath string) http.HandlerFunc {
 				Error(w, "no policies exist", http.StatusNotFound)
 				return
 			}
-			log.Errorf("http list policies failed: config repo '%s' service '%s': %v", configRepo, req.Service, err)
+			log.Errorf("http delete policies failed: config repo '%s' service '%s' ids %v: %v", configRepo, req.Service, ids, err)
 			Error(w, "unknown error", http.StatusInternalServerError)
 			return
 		}
@@ -168,6 +173,11 @@ func deletePolicies(configRepo, sshPrivateKeyPath string) http.HandlerFunc {
 			Service: req.Service,
 			Count:   deleted,
 		})
+		if err != nil {
+			log.Errorf("http delete policies failed: config repo '%s' service '%s' ids %v: encode response: %v", configRepo, req.Service, ids, err)
+			Error(w, "unknown error", http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -108,7 +108,7 @@ func Status(ctx context.Context, configRepoURL, artifactFileName, service, sshPr
 }
 
 func calculateTotalVulnerabilties(severity string, s spec.Spec) int64 {
-	var result float64 = 0
+	result := float64(0)
 	for _, stage := range s.Stages {
 		if stage.ID == "snyk-code" {
 			data := stage.Data.(map[string]interface{})


### PR DESCRIPTION
GoReport have found a great deal of issues in our code base. This PR fixes most of them.

Only thing I haven't looked into is the documentation of all exported methods. I think we should do this over time, but it's a bit excessive right now.