### PR TITLE
Add push command to artifact CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifact-linux-amd64
 .tmp/
 .idea/
 /.vscode/
+/cmd/artifact/examples

--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -2,7 +2,9 @@ example:
 	rm -rf examples
 	mkdir -p  examples
 	go run main.go init \
+		--service "test-service"\
 	  --artifact-id "master-1234ds13g3-12s46g356g"\
+		--git-branch "master"\
 		--git-author-name "Kasper Nissen"\
 		--git-author-email "kni@lunarway.com"\
 		--git-message "Some message"\
@@ -15,6 +17,7 @@ example:
 		--shuttle-plan-sha "asdasdo300asd0asd90as92"\
 		--shuttle-plan-url "https://someplanurl"\
     --shuttle-plan-message "Some commit"\
+		--shuttle-plan-branch "plan-branch"\
 		--ci-job-url "https://jenkins.dev.lunarway.com/job/asdasd"\
 		--root examples
 
@@ -79,6 +82,4 @@ test_push: example example_resources
 	go run main.go push \
 		--root examples \
 		--config-repo git@github.com:lunarway/release-manager-test-config-repo.git \
-		--git-branch master \
-		--service test \
 		--ssh-private-key ~/.ssh/github_key

--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -1,11 +1,14 @@
 example:
-	- rm -rf examples/artifact.json
+	rm -rf examples
+	mkdir -p  examples
 	go run main.go init \
 	  --artifact-id "master-1234ds13g3-12s46g356g"\
-		--git-author "Kasper Nissen"\
+		--git-author-name "Kasper Nissen"\
+		--git-author-email "kni@lunarway.com"\
 		--git-message "Some message"\
 		--git-sha "asd39sdas0g392"\
-		--git-committer "Bjørn Sørensen"\
+		--git-committer-name "Bjørn Sørensen"\
+		--git-committer-email "bso@lunarway.com"\
 		--provider "BitBucket"\
 		--url "https://someurl.com"\
 		--name "lunar-way-application"\
@@ -55,4 +58,27 @@ example:
 
 	go run main.go end --root examples
 
+define CONFIG_MAP_DEV
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product
+  namespace: dev
+data:
+  cdn.url: 'https://cdn.dev.lunarway.com'
+  log.console.as.json: 'true'
+  log.console.level: 'info'
+endef
+export CONFIG_MAP_DEV
 
+example_resources:
+	mkdir -p examples/dev
+	echo "$$CONFIG_MAP_DEV" > examples/dev/configmap.yaml
+
+test_push: example example_resources
+	go run main.go push \
+		--root examples \
+		--config-repo git@github.com:lunarway/release-manager-test-config-repo.git \
+		--git-branch master \
+		--service test \
+		--ssh-private-key ~/.ssh/github_key

--- a/cmd/artifact/command/init.go
+++ b/cmd/artifact/command/init.go
@@ -31,6 +31,7 @@ func initCommand(options *Options) *cobra.Command {
 	}
 
 	command.Flags().StringVar(&s.ID, "artifact-id", "", "the id of the artifact")
+	command.Flags().StringVar(&s.Service, "service", "", "the service name")
 
 	// Init git data
 	command.Flags().StringVar(&s.Application.AuthorName, "git-author-name", "", "the commit author name")
@@ -39,20 +40,24 @@ func initCommand(options *Options) *cobra.Command {
 	command.Flags().StringVar(&s.Application.CommitterName, "git-committer-name", "", "the commit committer name")
 	command.Flags().StringVar(&s.Application.CommitterEmail, "git-committer-email", "", "the commit committer email")
 	command.Flags().StringVar(&s.Application.SHA, "git-sha", "", "the commit sha")
+	command.Flags().StringVar(&s.Application.Branch, "git-branch", "", "the branch of the repository")
 	command.Flags().StringVar(&s.Application.Provider, "provider", "", "the name of the repository provider")
 	command.Flags().StringVar(&s.Application.URL, "url", "", "the url to the repository commit")
 	command.Flags().StringVar(&s.Application.Name, "name", "", "the name of the repository")
 	command.Flags().StringVar(&s.Shuttle.Plan.SHA, "shuttle-plan-sha", "", "the commit sha of the shuttle plan")
 	command.Flags().StringVar(&s.Shuttle.Plan.URL, "shuttle-plan-url", "", "the url to the shuttle plan commit")
 	command.Flags().StringVar(&s.Shuttle.Plan.Message, "shuttle-plan-message", "", "the shuttle plan commit message")
+	command.Flags().StringVar(&s.Shuttle.Plan.Branch, "shuttle-plan-branch", "", "the shuttle plan branch name")
 
 	command.MarkFlagRequired("artifact-id")
+	command.MarkFlagRequired("service")
 	command.MarkFlagRequired("git-author-name")
 	command.MarkFlagRequired("git-author-email")
 	command.MarkFlagRequired("git-message")
 	command.MarkFlagRequired("git-committer-name")
 	command.MarkFlagRequired("git-committer-email")
 	command.MarkFlagRequired("git-sha")
+	command.MarkFlagRequired("git-branch")
 
 	// Init ci data
 	command.Flags().StringVar(&s.CI.JobURL, "ci-job-url", "", "the URL of the Job in CI")

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -1,0 +1,28 @@
+package command
+
+import (
+	"context"
+
+	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/spf13/cobra"
+)
+
+func pushCommand(options *Options) *cobra.Command {
+	var branch, configGitRepo, service, sshPrivateKeyPath string
+	command := &cobra.Command{
+		Use:   "push",
+		Short: "push artifact to a configuration repository",
+		RunE: func(c *cobra.Command, args []string) error {
+			return flow.PushArtifact(context.Background(), configGitRepo, options.FileName, options.RootPath, service, branch, sshPrivateKeyPath)
+		},
+	}
+	command.Flags().StringVar(&branch, "git-branch", "", "origin branch of the artifact")
+	command.MarkFlagRequired("git-branch")
+	command.Flags().StringVar(&service, "service", "", "servce name")
+	command.MarkFlagRequired("service")
+	command.Flags().StringVar(&sshPrivateKeyPath, "ssh-private-key", "", "private key for the config repo")
+	command.MarkFlagRequired("ssh-private-key")
+	command.Flags().StringVar(&configGitRepo, "config-repo", "", "ssh url for the git config repository")
+	command.MarkFlagRequired("config-repo")
+	return command
+}

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -8,18 +8,14 @@ import (
 )
 
 func pushCommand(options *Options) *cobra.Command {
-	var branch, configGitRepo, service, sshPrivateKeyPath string
+	var configGitRepo, sshPrivateKeyPath string
 	command := &cobra.Command{
 		Use:   "push",
 		Short: "push artifact to a configuration repository",
 		RunE: func(c *cobra.Command, args []string) error {
-			return flow.PushArtifact(context.Background(), configGitRepo, options.FileName, options.RootPath, service, branch, sshPrivateKeyPath)
+			return flow.PushArtifact(context.Background(), configGitRepo, options.FileName, options.RootPath, sshPrivateKeyPath)
 		},
 	}
-	command.Flags().StringVar(&branch, "git-branch", "", "origin branch of the artifact")
-	command.MarkFlagRequired("git-branch")
-	command.Flags().StringVar(&service, "service", "", "servce name")
-	command.MarkFlagRequired("service")
 	command.Flags().StringVar(&sshPrivateKeyPath, "ssh-private-key", "", "private key for the config repo")
 	command.MarkFlagRequired("ssh-private-key")
 	command.Flags().StringVar(&configGitRepo, "config-repo", "", "ssh url for the git config repository")

--- a/cmd/artifact/command/root.go
+++ b/cmd/artifact/command/root.go
@@ -22,5 +22,6 @@ func NewCommand() (*cobra.Command, error) {
 	command.AddCommand(initCommand(&options))
 	command.AddCommand(endCommand(&options))
 	command.AddCommand(addCommand(&options))
+	command.AddCommand(pushCommand(&options))
 	return command, nil
 }

--- a/internal/artifact/spec.go
+++ b/internal/artifact/spec.go
@@ -21,6 +21,7 @@ var (
 
 type Spec struct {
 	ID          string     `json:"id,omitempty"`
+	Service     string     `json:"service,omitempty"`
 	Application Repository `json:"application,omitempty"`
 	CI          CI         `json:"ci,omitempty"`
 	Squad       string     `json:"squad,omitempty"`
@@ -29,6 +30,7 @@ type Spec struct {
 }
 
 type Repository struct {
+	Branch         string `json:"branch,omitempty"`
 	SHA            string `json:"sha,omitempty"`
 	AuthorName     string `json:"authorName,omitempty"`
 	AuthorEmail    string `json:"authorEmail,omitempty"`

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -388,12 +388,11 @@ func ReleaseArtifactID(ctx context.Context, configRepoURL, artifactFileName, ser
 	return artifactID, nil
 }
 
-// PushArtifact pushes an artifact into the configuration repository for a
-// specific service and branch.
+// PushArtifact pushes an artifact into the configuration repository.
 //
 // The resourceRoot specifies the path to the artifact files. All files in this
 // path will be pushed.
-func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resourceRoot, service, branch, sshPrivateKeyPath string) error {
+func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resourceRoot, sshPrivateKeyPath string) error {
 	artifactSpecPath := path.Join(resourceRoot, artifactFileName)
 	artifactSpec, err := artifact.Get(artifactSpecPath)
 	if err != nil {
@@ -405,7 +404,7 @@ func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resource
 	if err != nil {
 		return errors.WithMessage(err, "clone config repo")
 	}
-	destinationPath := artifactPath(artifactConfigRepoPath, service, branch)
+	destinationPath := artifactPath(artifactConfigRepoPath, artifactSpec.Service, artifactSpec.Application.Branch)
 	fmt.Printf("Artifacts destination '%s'\n", destinationPath)
 	fmt.Printf("Removing existing files\n")
 	err = os.RemoveAll(destinationPath)
@@ -428,7 +427,7 @@ func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resource
 	artifactID := artifactSpec.ID
 	authorName := artifactSpec.Application.AuthorName
 	authorEmail := artifactSpec.Application.AuthorEmail
-	commitMsg := git.ArtifactCommitMessage(service, artifactID, authorName)
+	commitMsg := git.ArtifactCommitMessage(artifactSpec.Service, artifactID, authorName)
 	fmt.Printf("Committing changes\n")
 	err = git.Commit(context.Background(), repo, ".", authorName, authorEmail, committerName, committerEmail, commitMsg, sshPrivateKeyPath)
 	if err != nil {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	artifactConfigRepoPath    = path.Join(".tmp", "k8s-config-artifact")
 	sourceConfigRepoPath      = path.Join(".tmp", "k8s-config-source")
 	destinationConfigRepoPath = path.Join(".tmp", "k8s-config-destination")
 	ErrUnknownEnvironment     = errors.New("unknown environment")
@@ -204,7 +205,7 @@ func Promote(ctx context.Context, configRepoURL, artifactFileName, service, env,
 
 	authorName := sourceSpec.Application.AuthorName
 	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := fmt.Sprintf("[%s/%s] release %s", env, service, release)
+	releaseMessage := git.ReleaseCommitMessage(env, service, release)
 	log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, committerName, committerEmail)
 	err = git.Commit(ctx, destinationRepo, releasePath(".", service, env), authorName, authorEmail, committerName, committerEmail, releaseMessage, sshPrivateKeyPath)
 	if err != nil {
@@ -302,7 +303,7 @@ func ReleaseBranch(ctx context.Context, configRepoURL, artifactFileName, service
 	authorName := artifactSpec.Application.AuthorName
 	authorEmail := artifactSpec.Application.AuthorEmail
 	artifactID := artifactSpec.ID
-	releaseMessage := fmt.Sprintf("[%s/%s] release %s", env, service, artifactID)
+	releaseMessage := git.ReleaseCommitMessage(env, service, artifactID)
 	err = git.Commit(ctx, repo, releasePath(".", service, env), authorName, authorEmail, committerName, committerEmail, releaseMessage, sshPrivateKeyPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
@@ -377,7 +378,7 @@ func ReleaseArtifactID(ctx context.Context, configRepoURL, artifactFileName, ser
 
 	authorName := sourceSpec.Application.AuthorName
 	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := fmt.Sprintf("[%s/%s] release %s", env, service, artifactID)
+	releaseMessage := git.ReleaseCommitMessage(env, service, artifactID)
 	err = git.Commit(ctx, destinationRepo, releasePath(".", service, env), authorName, authorEmail, committerName, committerEmail, releaseMessage, sshPrivateKeyPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
@@ -385,4 +386,56 @@ func ReleaseArtifactID(ctx context.Context, configRepoURL, artifactFileName, ser
 	log.Infof("flow: ReleaseArtifactID: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, committerName, committerEmail)
 
 	return artifactID, nil
+}
+
+// PushArtifact pushes an artifact into the configuration repository for a
+// specific service and branch.
+//
+// The resourceRoot specifies the path to the artifact files. All files in this
+// path will be pushed.
+func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resourceRoot, service, branch, sshPrivateKeyPath string) error {
+	artifactSpecPath := path.Join(resourceRoot, artifactFileName)
+	artifactSpec, err := artifact.Get(artifactSpecPath)
+	if err != nil {
+		return errors.WithMessagef(err, "path '%s'", artifactSpecPath)
+	}
+	// fmt.Printf is used for logging as this is called from artifact cli only
+	fmt.Printf("Checkout config repository from '%s' into '%s'\n", configRepoURL, resourceRoot)
+	repo, err := git.CloneDepth(context.Background(), configRepoURL, artifactConfigRepoPath, sshPrivateKeyPath, 1)
+	if err != nil {
+		return errors.WithMessage(err, "clone config repo")
+	}
+	destinationPath := artifactPath(artifactConfigRepoPath, service, branch)
+	fmt.Printf("Artifacts destination '%s'\n", destinationPath)
+	fmt.Printf("Removing existing files\n")
+	err = os.RemoveAll(destinationPath)
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+	}
+	err = os.MkdirAll(destinationPath, os.ModePerm)
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+	}
+	fmt.Printf("Copy configuration into destination\n")
+	err = copy.Copy(resourceRoot, destinationPath)
+	if err != nil {
+		return errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", resourceRoot, destinationPath))
+	}
+	committerName, committerEmail, err := git.CommitterDetails()
+	if err != nil {
+		return errors.WithMessage(err, "get committer details")
+	}
+	artifactID := artifactSpec.ID
+	authorName := artifactSpec.Application.AuthorName
+	authorEmail := artifactSpec.Application.AuthorEmail
+	commitMsg := git.ArtifactCommitMessage(service, artifactID, authorName)
+	fmt.Printf("Committing changes\n")
+	err = git.Commit(context.Background(), repo, ".", authorName, authorEmail, committerName, committerEmail, commitMsg, sshPrivateKeyPath)
+	if err != nil {
+		if err == git.ErrNothingToCommit {
+			return nil
+		}
+		return errors.WithMessage(err, "commit files")
+	}
+	return nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -66,12 +66,22 @@ func Checkout(r *git.Repository, hash plumbing.Hash) error {
 	return nil
 }
 
-func LocateRelease(r *git.Repository, release string) (plumbing.Hash, error) {
+// LocateRelease traverses the git log to find a release commit with id
+// artifactID.
+//
+// It expects the commit to have a commit messages as the one returned by
+// ReleaseCommitMessage.
+func LocateRelease(r *git.Repository, artifactID string) (plumbing.Hash, error) {
 	return locate(r, func(commitMsg string) bool {
-		return strings.Contains(commitMsg, release)
+		return strings.Contains(commitMsg, artifactID)
 	}, ErrReleaseNotFound)
 }
 
+// LocateArtifact traverses the git log to find an artifact commit with id
+// artifactID.
+//
+// It expects the commit to have a commit messages as the one returned by
+// ArtifactCommitMessage.
 func LocateArtifact(r *git.Repository, artifactID string) (plumbing.Hash, error) {
 	return locate(r, func(commitMsg string) bool {
 		return strings.Contains(commitMsg, fmt.Sprintf("artifact %s", artifactID))

--- a/internal/git/messages.go
+++ b/internal/git/messages.go
@@ -1,0 +1,23 @@
+package git
+
+import "fmt"
+
+// ArtifactCommitMessage returns an artifact commit message.
+func ArtifactCommitMessage(service, artifactID, author string) string {
+	return fmt.Sprintf("[%s] artifact %s by %s", service, artifactID, author)
+}
+
+// ReleaseCommitMessage returns an artifact release commit message.
+func ReleaseCommitMessage(env, service, artifactID string) string {
+	return fmt.Sprintf("[%s/%s] release %s", env, service, artifactID)
+}
+
+// PolicyUpdateApplyCommitMessage returns an apply policy commit message.
+func PolicyUpdateApplyCommitMessage(env, service, branch, policy string) string {
+	return fmt.Sprintf("[%s] policy update: apply %s from '%s' to '%s'", service, policy, branch, env)
+}
+
+// PolicyUpdateDeleteCommitMessage returns a delete policy commit message.
+func PolicyUpdateDeleteCommitMessage(service string) string {
+	return fmt.Sprintf("[%s] policy update: delete policies", service)
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -86,7 +86,7 @@ func Get(ctx context.Context, configRepoURL, sshPrivateKeyPath string, svc strin
 // ApplyAutoRelease applies an auto-release policy for service svc from branch
 // to environment env.
 func ApplyAutoRelease(ctx context.Context, configRepoURL, sshPrivateKeyPath string, svc, branch, env, committerName, committerEmail string) (string, error) {
-	commitMsg := fmt.Sprintf("[%s] policy update: apply auto-release from '%s' to '%s'", svc, branch, env)
+	commitMsg := git.PolicyUpdateApplyCommitMessage(env, svc, branch, "auto-release")
 	var policyID string
 	err := updatePolicies(ctx, configRepoURL, sshPrivateKeyPath, svc, commitMsg, committerName, committerEmail, func(p *Policies) {
 		policyID = p.SetAutoRelease(branch, env)
@@ -99,7 +99,7 @@ func ApplyAutoRelease(ctx context.Context, configRepoURL, sshPrivateKeyPath stri
 
 // Delete deletes policies by ID for service svc.
 func Delete(ctx context.Context, configRepoURL, sshPrivateKeyPath string, svc string, ids []string, committerName, committerEmail string) (int, error) {
-	commitMsg := fmt.Sprintf("[%s] policy update: delete policies", svc)
+	commitMsg := git.PolicyUpdateDeleteCommitMessage(svc)
 	var deleted int
 	err := updatePolicies(ctx, configRepoURL, sshPrivateKeyPath, svc, commitMsg, committerName, committerEmail, func(p *Policies) {
 		deleted = p.Delete(ids...)


### PR DESCRIPTION
This will commit a directory as an artifact to a configuration
repository.

The `test_push` make target will generate an artifact specification and a
config map yaml file and push it to a config repo.

I moved the commit messages into a central file as well as we depend
on the format of these messages in the release flows.