### PR TITLE
Detect service name for shuttle services

### DIFF
--- a/cmd/hamctl/command/policy.go
+++ b/cmd/hamctl/command/policy.go
@@ -7,8 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewPolicy(client *http.Client) *cobra.Command {
-	var service string
+func NewPolicy(client *http.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "policy",
 		Short: "Manage release policies for services.",
@@ -29,11 +28,8 @@ func NewPolicy(client *http.Client) *cobra.Command {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(policy.NewApply(client, &service))
-	command.AddCommand(policy.NewList(client, &service))
-	command.AddCommand(policy.NewDelete(client, &service))
-
-	command.PersistentFlags().StringVar(&service, "service", "", "Service to manage policies for (required)")
-	command.MarkPersistentFlagRequired("service")
+	command.AddCommand(policy.NewApply(client, service))
+	command.AddCommand(policy.NewList(client, service))
+	command.AddCommand(policy.NewDelete(client, service))
 	return command
 }

--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewPromote(client *httpinternal.Client) *cobra.Command {
-	var serviceName, environment string
+func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
+	var environment string
 	var command = &cobra.Command{
 		Use:   "promote",
 		Short: "Promote a service to a specific environment following promoting conventions.",
@@ -26,7 +26,7 @@ func NewPromote(client *httpinternal.Client) *cobra.Command {
 				return err
 			}
 			err = client.Do(http.MethodPost, url, httpinternal.PromoteRequest{
-				Service:        serviceName,
+				Service:        *service,
 				Environment:    environment,
 				CommitterName:  committerName,
 				CommitterEmail: committerEmail,
@@ -43,8 +43,6 @@ func NewPromote(client *httpinternal.Client) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&serviceName, "service", "", "Service to promote to specified environment (required)")
-	command.MarkFlagRequired("service")
 	command.Flags().StringVar(&environment, "env", "", "Environment to promote to (required)")
 	command.MarkFlagRequired("env")
 	return command

--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewRelease(client *httpinternal.Client) *cobra.Command {
-	var serviceName, environment, branch, artifact string
+func NewRelease(client *httpinternal.Client, service *string) *cobra.Command {
+	var environment, branch, artifact string
 	var command = &cobra.Command{
 		Use:   "release",
 		Short: `Release a specific artifact or latest artifact from a branch into a specific environment.`,
@@ -39,7 +39,7 @@ Release latest artifact from branch 'master' of service 'product' into environme
 				return err
 			}
 			err = client.Do(http.MethodPost, path, httpinternal.ReleaseRequest{
-				Service:        serviceName,
+				Service:        *service,
 				Environment:    environment,
 				Branch:         branch,
 				ArtifactID:     artifact,
@@ -58,8 +58,6 @@ Release latest artifact from branch 'master' of service 'product' into environme
 			return nil
 		},
 	}
-	command.Flags().StringVar(&serviceName, "service", "", "service from with to release into specified environment (required)")
-	command.MarkFlagRequired("service")
 	command.Flags().StringVar(&environment, "env", "", "environment to release to (required)")
 	command.MarkFlagRequired("env")
 	command.Flags().StringVar(&branch, "branch", "", "release latest artifact from this branch (mutually exclusive with --artifact)")

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -1,11 +1,14 @@
 package command
 
 import (
+	"errors"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 // NewCommand returns a new instance of a hamctl command.
@@ -15,6 +18,16 @@ func NewCommand() (*cobra.Command, error) {
 	var command = &cobra.Command{
 		Use:   "hamctl",
 		Short: "hamctl controls a release manager server",
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			service = strings.TrimSpace(service)
+			if service == "" {
+				service = readShuttleService()
+			}
+			if service == "" {
+				return errors.New("required flag(s) \"service\" not set")
+			}
+			return nil
+		},
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 		},
@@ -27,6 +40,28 @@ func NewCommand() (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
 	command.PersistentFlags().StringVar(&client.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")
-	command.MarkPersistentFlagRequired("service")
 	return command, nil
+}
+
+type shuttleSpec struct {
+	Vars struct {
+		Service string `yaml:"service"`
+	}
+}
+
+// readShuttleService tries to read the service name from a shuttle
+// specification.
+// If the file is not found or cannot be parsed, we just fall back to the flag.
+func readShuttleService() string {
+	f, err := os.Open("shuttle.yaml")
+	if err != nil {
+		return ""
+	}
+	var spec shuttleSpec
+	decoder := yaml.NewDecoder(f)
+	err = decoder.Decode(&spec)
+	if err != nil {
+		return ""
+	}
+	return spec.Vars.Service
 }

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -27,6 +27,6 @@ func NewCommand() (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
 	command.PersistentFlags().StringVar(&client.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")
-	command.MarkFlagRequired("service")
+	command.MarkPersistentFlagRequired("service")
 	return command, nil
 }

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -11,6 +11,7 @@ import (
 // NewCommand returns a new instance of a hamctl command.
 func NewCommand() (*cobra.Command, error) {
 	var client http.Client
+	var service string
 	var command = &cobra.Command{
 		Use:   "hamctl",
 		Short: "hamctl controls a release manager server",
@@ -18,12 +19,14 @@ func NewCommand() (*cobra.Command, error) {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewPromote(&client))
-	command.AddCommand(NewRelease(&client))
-	command.AddCommand(NewStatus(&client))
-	command.AddCommand(NewPolicy(&client))
+	command.AddCommand(NewPromote(&client, &service))
+	command.AddCommand(NewRelease(&client, &service))
+	command.AddCommand(NewStatus(&client, &service))
+	command.AddCommand(NewPolicy(&client, &service))
 	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 20*time.Second, "HTTP request timeout")
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
 	command.PersistentFlags().StringVar(&client.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
+	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")
+	command.MarkFlagRequired("service")
 	return command, nil
 }

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -11,15 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewStatus(client *httpinternal.Client) *cobra.Command {
-	var serviceName string
+func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "status",
 		Short: "List the status of the environments",
 		RunE: func(c *cobra.Command, args []string) error {
 			var resp httpinternal.StatusResponse
 			params := url.Values{}
-			params.Add("service", serviceName)
+			params.Add("service", *service)
 			path, err := client.URLWithQuery("status", params)
 			if err != nil {
 				return err
@@ -41,8 +40,6 @@ func NewStatus(client *httpinternal.Client) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&serviceName, "service", "", "service to output current status for")
-	command.MarkFlagRequired("service")
 	return command
 }
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.10.0
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190111032252-67edc246be36
 	k8s.io/apimachinery v0.0.0-20190320104356-82cbdc1b6ac2
 	k8s.io/client-go v10.0.0+incompatible


### PR DESCRIPTION
Try to parse a `shuttle.yaml` file for a service name when issuing `hamctl` commands, if no `--service` flag is provided.

This change also moves the `service` flag up as a persistent flag on the root command instead of a required flag on all subcommands.
