### PR TITLE
Rollback command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ artifact-linux-amd64
 .idea/
 /.vscode/
 /cmd/artifact/examples
+/cmd/artifact/artifact
 message.json
 artifact.json

--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -1,7 +1,8 @@
 example:
 	rm -rf examples
 	mkdir -p  examples
-	go run main.go init \
+	go build
+	./artifact init \
 		--service "test-service"\
 	  --artifact-id "master-1234ds13g3-12s46g356g"\
 		--git-branch "master"\
@@ -21,26 +22,26 @@ example:
 		--ci-job-url "https://jenkins.dev.lunarway.com/job/asdasd"\
 		--root examples
 
-	go run main.go add build\
+	./artifact add build\
 		--image "quay.io/lunarway/application"\
 		--tag "master-1234ds13g3-12s46g356g"\
 		--docker-version "1.18.6"\
 		--root examples
 
-	go run main.go add push\
+	./artifact add push\
 		--image "quay.io/lunarway/application"\
 		--tag "master-1234ds13g3-12s46g356g"\
 		--docker-version "1.18.6"\
 		--root examples
 
-	go run main.go add test\
+	./artifact add test\
 		--url "https://jenkins.dev.lunarway.com"\
 		--passed 563\
 		--skipped 0\
 		--failed 0\
 		--root examples
 
-	go run main.go add snyk-code\
+	./artifact add snyk-code\
 		--language "go"\
 		--snyk-version "1.144.23"\
 		--url "https://snyk.io/aslkdasdlas"\
@@ -49,7 +50,7 @@ example:
 		--low 134\
 		--root examples
 
-	go run main.go add snyk-docker\
+	./artifact add snyk-docker\
 		--base-image "node"\
 		--snyk-version "1.144.23"\
 		--tag "8.15.0-alpine"\
@@ -59,9 +60,9 @@ example:
 		--low 0\
 		--root examples
 
-	go run main.go end --root examples
+	./artifact end --root examples
 
-define CONFIG_MAP_DEV
+define CONFIG_MAP
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -72,14 +73,16 @@ data:
   log.console.as.json: 'true'
   log.console.level: 'info'
 endef
-export CONFIG_MAP_DEV
+export CONFIG_MAP
 
 example_resources:
-	mkdir -p examples/dev
-	echo "$$CONFIG_MAP_DEV" > examples/dev/configmap.yaml
+	mkdir -p examples/{dev,staging,prod}
+	echo "$$CONFIG_MAP" > examples/dev/configmap.yaml
+	echo "$$CONFIG_MAP" > examples/staging/configmap.yaml
+	echo "$$CONFIG_MAP" > examples/prod/configmap.yaml
 
 test_push: example example_resources
-	go run main.go push \
+	./artifact push \
 		--root examples \
 		--config-repo git@github.com:lunarway/release-manager-test-config-repo.git \
 		--ssh-private-key ~/.ssh/github_key

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -1,0 +1,56 @@
+package command
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/lunarway/release-manager/internal/git"
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func NewRollback(client *httpinternal.Client, service *string) *cobra.Command {
+	var environment string
+	var command = &cobra.Command{
+		Use:   "rollback",
+		Short: `Rollback to the previous artifact in an environment.`,
+		Long: `Rollback to the previous artifact in an environment.
+
+The command will release the artifact running in an environment before the
+current one, ie. rollback a single release.
+
+Note that 'rollback' does not traverse futher than one release. This means that
+if you perform to rollbacks on the same environment after each other, the latter
+has no effect.`,
+		Example: `Rollback to the previous artifact for service 'product' in environment 'dev':
+
+  hamctl rollback --service product --env dev`,
+		RunE: func(c *cobra.Command, args []string) error {
+			committerName, committerEmail, err := git.CommitterDetails()
+			if err != nil {
+				return err
+			}
+			var resp httpinternal.RollbackResponse
+			path, err := client.URL("rollback")
+			if err != nil {
+				return err
+			}
+			err = client.Do(http.MethodPost, path, httpinternal.RollbackRequest{
+				Service:        *service,
+				Environment:    environment,
+				CommitterName:  committerName,
+				CommitterEmail: committerEmail,
+			}, &resp)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("[✓] Rollback of artifact '%s' initiated\n", resp.PreviousArtifactID)
+			fmt.Printf("    Release of '%s' to '%s'\n", resp.NewArtifactID, resp.Environment)
+
+			return nil
+		},
+	}
+	command.Flags().StringVar(&environment, "env", "", "environment to release to (required)")
+	command.MarkFlagRequired("env")
+	return command
+}

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -35,6 +35,7 @@ func NewCommand() (*cobra.Command, error) {
 	command.AddCommand(NewPromote(&client, &service))
 	command.AddCommand(NewRelease(&client, &service))
 	command.AddCommand(NewStatus(&client, &service))
+	command.AddCommand(NewRollback(&client, &service))
 	command.AddCommand(NewPolicy(&client, &service))
 	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 20*time.Second, "HTTP request timeout")
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 var (
@@ -161,10 +162,18 @@ func Promote(ctx context.Context, configRepoURL, artifactFileName, service, env,
 	// find release identifier in artifact.json
 	release := sourceSpec.ID
 	// ckechout commit of release
-	hash, err := git.LocateRelease(sourceRepo, release)
+	var hash plumbing.Hash
+	// when promoting to dev we use should look for the artifact instead of
+	// release as the artifact have never been released.
+	if env == "dev" {
+		hash, err = git.LocateArtifact(sourceRepo, release)
+	} else {
+		hash, err = git.LocateRelease(sourceRepo, release)
+	}
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("locate release '%s' from '%s'", release, configRepoURL))
 	}
+	log.Debugf("internal/flow: Promote: release hash '%v'", hash)
 	err = git.Checkout(sourceRepo, hash)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("checkout release hash '%s' from '%s'", hash, configRepoURL))

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -1,0 +1,102 @@
+package flow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/otiai10/copy"
+	"github.com/pkg/errors"
+)
+
+type RollbackResult struct {
+	Previous string
+	New      string
+}
+
+func Rollback(ctx context.Context, configRepoURL, artifactFileName, service, env, committerName, committerEmail, sshPrivateKeyPath string) (RollbackResult, error) {
+	r, err := git.Clone(ctx, configRepoURL, sourceConfigRepoPath, sshPrivateKeyPath)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "clone '%s' into '%s'", configRepoURL, sourceConfigRepoPath)
+	}
+
+	// locate current release
+	currentHash, err := git.LocateServiceRelease(r, env, service)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "locate current release in '%s' at '%s'", configRepoURL, sourceConfigRepoPath)
+	}
+	log.Debugf("flow: Rollback: current release hash '%v'", currentHash)
+	err = git.Checkout(r, currentHash)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "checkout current release hash '%v' in '%s'", currentHash, configRepoURL)
+	}
+	currentSpec, err := envSpec(sourceConfigRepoPath, artifactFileName, service, env)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "get spec of current release hash '%v' in '%s'", currentHash, configRepoURL)
+	}
+
+	// locate new release (the previous released artifact for this service)
+	newHash, err := git.LocateServiceReleaseRollbackSkip(r, env, service, 1)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "locate previous release in '%s' at '%s'", configRepoURL, sourceConfigRepoPath)
+	}
+	log.Debugf("flow: Rollback: new release hash '%v'", newHash)
+	err = git.Checkout(r, newHash)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "checkout previous release hash '%v' in '%s'", newHash, configRepoURL)
+	}
+	newSpec, err := envSpec(sourceConfigRepoPath, artifactFileName, service, env)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessagef(err, "get spec of previous release hash '%v' in '%s'", newHash, configRepoURL)
+	}
+
+	// copy current release artifacts into env
+	destinationRepo, err := git.CloneDepth(ctx, configRepoURL, destinationConfigRepoPath, sshPrivateKeyPath, 1)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("clone destination repo '%s' into '%s'", configRepoURL, destinationConfigRepoPath))
+	}
+
+	// release service to env from original release
+	sourcePath := releasePath(sourceConfigRepoPath, service, env)
+	destinationPath := releasePath(destinationConfigRepoPath, service, env)
+	log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
+
+	// empty existing resources in destination
+	err = os.RemoveAll(destinationPath)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+	}
+	err = os.MkdirAll(destinationPath, os.ModePerm)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+	}
+	// copy previous env. files into destination
+	err = copy.Copy(sourcePath, destinationPath)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
+	}
+	// copy artifact spec
+	artifactSourcePath := path.Join(releasePath(sourceConfigRepoPath, service, env), artifactFileName)
+	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, env), artifactFileName)
+	log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
+	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
+	}
+
+	authorName := newSpec.Application.AuthorName
+	authorEmail := newSpec.Application.AuthorEmail
+	releaseMessage := git.RollbackCommitMessage(env, service, currentSpec.ID, newSpec.ID)
+	err = git.Commit(ctx, destinationRepo, releasePath(".", service, env), authorName, authorEmail, committerName, committerEmail, releaseMessage, sshPrivateKeyPath)
+	if err != nil {
+		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+	}
+	log.Infof("flow: Rollback: rollback committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, committerName, committerEmail)
+	return RollbackResult{
+		Previous: currentSpec.ID,
+		New:      newSpec.ID,
+	}, nil
+}

--- a/internal/git/messages.go
+++ b/internal/git/messages.go
@@ -12,6 +12,11 @@ func ReleaseCommitMessage(env, service, artifactID string) string {
 	return fmt.Sprintf("[%s/%s] release %s", env, service, artifactID)
 }
 
+// RollbackCommitMessage returns an artifact rollback commit message.
+func RollbackCommitMessage(env, service, oldArtifactID, newArtifactID string) string {
+	return fmt.Sprintf("[%s/%s] rollback %s to %s", env, service, oldArtifactID, newArtifactID)
+}
+
 // PolicyUpdateApplyCommitMessage returns an apply policy commit message.
 func PolicyUpdateApplyCommitMessage(env, service, branch, policy string) string {
 	return fmt.Sprintf("[%s] policy update: apply %s from '%s' to '%s'", service, policy, branch, env)

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -121,3 +121,17 @@ type DeletePolicyResponse struct {
 	Service string `json:"service,omitempty"`
 	Count   int    `json:"count,omitempty"`
 }
+
+type RollbackRequest struct {
+	Service        string `json:"service,omitempty"`
+	Environment    string `json:"environment,omitempty"`
+	CommitterName  string `json:"committerName,omitempty"`
+	CommitterEmail string `json:"committerEmail,omitempty"`
+}
+
+type RollbackResponse struct {
+	Service            string `json:"service,omitempty"`
+	Environment        string `json:"environment,omitempty"`
+	PreviousArtifactID string `json:"previousArtifactId,omitempty"`
+	NewArtifactID      string `json:"newArtifactId,omitempty"`
+}


### PR DESCRIPTION
This PR implements a `rollback` command. It will release the artifact that was running in an environment before the current one.

```
$ hamctl rollback --service a --env dev
[✓] Rollback of artifact 'master-a-2' initiated
    Release of 'master-a-1' to 'dev'
```

The result is seen here: https://github.com/lunarway/release-manager-test-config-repo/commit/db32c5ac0c17b2b495791df77b17b6679c1ea1f4

### Other changes
I made the `make` targets for `artifact` build the CLI once instead of on every step. Increases the speed of the targets by much!

I also ensured that function `git.LocateRelease()` only identifies release commits, ie. `release <some-artifact-id>`. The current implementation just matches the artifact ID, which will clash with the `rollback <artfifact-current> to <artifact-previous>` messages of this command.