### PR TITLE
add build notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ artifact-failure:
 artifact-successful:
 	./dist/artifact successful --slack-token ${SLACK_TOKEN}
 
-artifact-slack: build_artifact artifact-init artifact-build artifact-test artifact-snyk-docker artifact-snyk-code artifact-push artifact-successful
+artifact-slack: build_artifact artifact-init artifact-build artifact-test artifact-snyk-docker artifact-snyk-code artifact-push artifact-failure
 
 release:
 	goreleaser --rm-dist --skip-publish

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/lunarway/release-manager/internal/slack"
-
 	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,6 @@ func pushCommand(options *Options) *cobra.Command {
 				return err
 			}
 			err = slack.Update(path.Join(options.RootPath, options.MessageFileName), options.SlackToken, func(m slack.Message) slack.Message {
-				m.Color = slack.MsgColorGreen
 				m.Text += fmt.Sprintf(":white_check_mark: *Artifact pushed:* %s", artifactId)
 				return m
 			})

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -152,3 +152,31 @@ func (c *Client) NotifySlackReleasesChannel(options ReleaseOptions) error {
 	}
 	return err
 }
+
+type BuildsOptions struct {
+	Service       string
+	ArtifactID    string
+	Branch        string
+	CommitSHA     string
+	CommitLink    string
+	CommitMessage string
+	CommitAuthor  string
+	CIJobURL      string
+	Color         string
+}
+
+func (c *Client) NotifySlackBuildsChannel(options BuildsOptions) error {
+	asUser := slack.MsgOptionAsUser(true)
+	attachments := slack.MsgOptionAttachments(slack.Attachment{
+		Title:      fmt.Sprintf("%s (%s)", options.Service, options.ArtifactID),
+		TitleLink:  options.CIJobURL,
+		Color:      options.Color,
+		Text:       fmt.Sprintf("*Author:* %s (<%s|%s>)\n*Message:* _%s_", options.CommitAuthor, options.CommitLink, options.CommitSHA[0:10], options.CommitMessage),
+		MarkdownIn: []string{"text", "fields"},
+	})
+	_, _, err := c.client.PostMessage("#builds", asUser, attachments)
+	if err != nil {
+		return err
+	}
+	return err
+}


### PR DESCRIPTION
This PR adds notifications when running either: `artifact failure` or `artifact successful`. 

On of the two commands should always end a CI run. These commands are used to mark both the #builds channel messages either green or red, but also the personal messages received by developers 