### PR TITLE
Align http errors

### DIFF
--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -23,6 +23,10 @@ func Error(w http.ResponseWriter, message string, statusCode int) {
 	}
 }
 
+func unknownError(w http.ResponseWriter) {
+	Error(w, "unkown error", http.StatusInternalServerError)
+}
+
 func requiredFieldError(w http.ResponseWriter, field string) {
 	Error(w, fmt.Sprintf("field %s required but was empty", field), http.StatusBadRequest)
 }

--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -18,8 +18,6 @@ func Error(w http.ResponseWriter, message string, statusCode int) {
 	})
 	if err != nil {
 		log.Errorf("json encoding failed in error response: %v", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
 	}
 }
 

--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -25,6 +25,10 @@ func unknownError(w http.ResponseWriter) {
 	Error(w, "unkown error", http.StatusInternalServerError)
 }
 
+func invalidBodyError(w http.ResponseWriter) {
+	Error(w, "invalid body", http.StatusBadRequest)
+}
+
 func requiredFieldError(w http.ResponseWriter, field string) {
 	Error(w, fmt.Sprintf("field %s required but was empty", field), http.StatusBadRequest)
 }

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -330,7 +330,7 @@ func promote(configRepo, artifactFileName, sshPrivateKeyPath, slackToken string)
 			Status:          statusString,
 		})
 		if err != nil {
-			logger.Infof("http: promote: service '%s' environment '%s': marshal response failed: %v", req.Service, req.Environment, err)
+			logger.Errorf("http: promote: service '%s' environment '%s': marshal response failed: %v", req.Service, req.Environment, err)
 		}
 	}
 }

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -155,15 +155,15 @@ func daemonWebhook(configRepo, artifactFileName, sshPrivateKeyPath string, slack
 
 		err := decoder.Decode(&podNotify)
 		if err != nil {
-			log.Errorf("daemon webhook failed: decode request body failed: %v", err)
-			http.Error(w, "Invalid payload", http.StatusBadRequest)
+			log.Errorf("http: daemon webhook: decode request body failed: %v", err)
+			invalidBodyError(w)
 			return
 		}
 
 		err = flow.NotifyCommitter(context.Background(), configRepo, artifactFileName, sshPrivateKeyPath, &podNotify, slackClient)
 		if err != nil {
-			log.Errorf("daemon webhook failed: notify committer: %v", err)
-			Error(w, "internal server error", http.StatusInternalServerError)
+			log.Errorf("http: daemon webhook failed: notify committer: %v", err)
+			unknownError(w)
 			return
 		}
 


### PR DESCRIPTION
This change set will align error responses and error logging in our HTTP handlers.

This should help to avoid `invalid character 'p' in beginnig(...)` errors in the clients.

It further ensures that we log the HTTP endpoints we call in case of errors and I've added fields to all handler logs with a minimum of a `fields.service` field with the incoming service name.
