### PR TITLE
Create unique temporary folders for all Git operations

### DIFF
--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -14,6 +14,11 @@ import (
 )
 
 func NotifyCommitter(ctx context.Context, configRepoURL, artifactFileName, sshPrivateKeyPath string, event *http.PodNotifyRequest, client *slack.Client) error {
+	sourceConfigRepoPath, close, err := tempDir("k8s-config-notify")
+	if err != nil {
+		return err
+	}
+	defer close()
 	sourceRepo, err := git.Clone(ctx, configRepoURL, sourceConfigRepoPath, sshPrivateKeyPath)
 	if err != nil {
 		return errors.WithMessagef(err, "clone '%s' into '%s'", configRepoURL, sourceConfigRepoPath)

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -36,6 +36,16 @@ import (
 // Copy artifacts from the current release into the new environment and commit
 // the changes
 func Promote(ctx context.Context, opts FlowOptions) (string, error) {
+	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-promote-source")
+	if err != nil {
+		return "", err
+	}
+	defer closeSource()
+	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-promote-destination")
+	if err != nil {
+		return "", err
+	}
+	defer closeDestination()
 	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
 	log.Debugf("Cloning source config repo %s into %s", opts.ConfigRepoURL, sourceConfigRepoPath)
 	sourceRepo, err := git.Clone(ctx, opts.ConfigRepoURL, sourceConfigRepoPath, opts.SSHPrivateKeyPath)

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -23,6 +23,11 @@ import (
 //
 // Copy artifacts from the artifacts into the environment and commit the changes.
 func ReleaseBranch(ctx context.Context, opts FlowOptions) (string, error) {
+	sourceConfigRepoPath, close, err := tempDir("k8s-config-release-branch")
+	if err != nil {
+		return "", err
+	}
+	defer close()
 	repo, err := git.CloneDepth(ctx, opts.ConfigRepoURL, sourceConfigRepoPath, opts.SSHPrivateKeyPath, 1)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", opts.ConfigRepoURL, sourceConfigRepoPath))
@@ -103,6 +108,16 @@ func ReleaseBranch(ctx context.Context, opts FlowOptions) (string, error) {
 // Copy resources from the artifact commit into the environment and commit
 // the changes
 func ReleaseArtifactID(ctx context.Context, opts FlowOptions) (string, error) {
+	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-release-artifact-source")
+	if err != nil {
+		return "", err
+	}
+	defer closeSource()
+	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-release-artifact-destination")
+	if err != nil {
+		return "", err
+	}
+	defer closeDestination()
 	sourceRepo, err := git.Clone(ctx, opts.ConfigRepoURL, sourceConfigRepoPath, opts.SSHPrivateKeyPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", opts.ConfigRepoURL, sourceConfigRepoPath))

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -18,6 +18,16 @@ type RollbackResult struct {
 }
 
 func Rollback(ctx context.Context, opts FlowOptions) (RollbackResult, error) {
+	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-rollback-source")
+	if err != nil {
+		return RollbackResult{}, err
+	}
+	defer closeSource()
+	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-rollback-destination")
+	if err != nil {
+		return RollbackResult{}, err
+	}
+	defer closeDestination()
 	r, err := git.Clone(ctx, opts.ConfigRepoURL, sourceConfigRepoPath, opts.SSHPrivateKeyPath)
 	if err != nil {
 		return RollbackResult{}, errors.WithMessagef(err, "clone '%s' into '%s'", opts.ConfigRepoURL, sourceConfigRepoPath)

--- a/internal/flow/temp_dir.go
+++ b/internal/flow/temp_dir.go
@@ -1,0 +1,21 @@
+package flow
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/lunarway/release-manager/internal/log"
+)
+
+func tempDir(prefix string) (string, func(), error) {
+	path, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return "", func() {}, err
+	}
+	return path, func() {
+		err := os.RemoveAll(path)
+		if err != nil {
+			log.Errorf("Removing temporary directory failed: path '%s': %v", path, err)
+		}
+	}, nil
+}


### PR DESCRIPTION
To avoid conflicting Git operations each flow will use unique temporary
directories handled by the `os` package.

This should reduce the errors related to racing webhooks and `status`
commands etc.

A `tempDir` function implements the creation and logs any errors on the
close function.