### PR TITLE
Detect request cancellation and return HTTP 400

### DIFF
--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -29,6 +29,10 @@ func invalidBodyError(w http.ResponseWriter) {
 	Error(w, "invalid body", http.StatusBadRequest)
 }
 
+func cancelled(w http.ResponseWriter) {
+	Error(w, "request cancelled", http.StatusBadRequest)
+}
+
 func requiredFieldError(w http.ResponseWriter, field string) {
 	Error(w, fmt.Sprintf("field %s required but was empty", field), http.StatusBadRequest)
 }


### PR DESCRIPTION
The status code and error body is properly ignored by the caller as the
connection is dropped by the client right away.

This change does however avoid logging an error and 500 response in
these cases.