### PR TITLE
 Validate user mapping input

### DIFF
--- a/cmd/artifact/command/init.go
+++ b/cmd/artifact/command/init.go
@@ -133,7 +133,7 @@ func initCommand(options *Options) *cobra.Command {
 	command.Flags().StringVar(&s.Shuttle.Plan.URL, "shuttle-plan-url", "", "the url to the shuttle plan commit")
 	command.Flags().StringVar(&s.Shuttle.Plan.Message, "shuttle-plan-message", "", "the shuttle plan commit message")
 	command.Flags().StringVar(&s.Shuttle.Plan.Branch, "shuttle-plan-branch", "", "the shuttle plan branch name")
-	command.Flags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between to emails used by Slack, key-value pair: <email>=<slack-email>")
+	command.Flags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
 
 	command.MarkFlagRequired("artifact-id")
 	command.MarkFlagRequired("service")

--- a/cmd/artifact/command/init.go
+++ b/cmd/artifact/command/init.go
@@ -28,15 +28,14 @@ func initCommand(options *Options) *cobra.Command {
 				userMappingString := os.Getenv("USER_MAPPINGS")
 				users = strings.Split(userMappingString, ",")
 			}
-			m := make(map[string]string)
-			for _, u := range users {
-				s := strings.Split(u, "=")
-				m[s[0]] = s[1]
+			var err error
+			options.UserMappings, err = slack.ParseUserMappings(users)
+			if err != nil {
+				return err
 			}
-			options.UserMappings = m
 
 			if !flow.IsLunarWayEmail(s.Application.AuthorEmail) {
-				lwEmail, ok := m[s.Application.AuthorEmail]
+				lwEmail, ok := options.UserMappings[s.Application.AuthorEmail]
 				if !ok {
 					// Don't break, just continue and use the provided email
 					fmt.Printf("user mappings for %s not found", s.Application.AuthorEmail)
@@ -134,6 +133,7 @@ func initCommand(options *Options) *cobra.Command {
 	command.Flags().StringVar(&s.Shuttle.Plan.URL, "shuttle-plan-url", "", "the url to the shuttle plan commit")
 	command.Flags().StringVar(&s.Shuttle.Plan.Message, "shuttle-plan-message", "", "the shuttle plan commit message")
 	command.Flags().StringVar(&s.Shuttle.Plan.Branch, "shuttle-plan-branch", "", "the shuttle plan branch name")
+	command.Flags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between to emails used by Slack, key-value pair: <email>=<slack-email>")
 
 	command.MarkFlagRequired("artifact-id")
 	command.MarkFlagRequired("service")

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lunarway/release-manager/cmd/server/http"
+	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/spf13/cobra"
 )
 
@@ -21,12 +22,11 @@ func NewCommand() (*cobra.Command, error) {
 				userMappingString := os.Getenv("USER_MAPPINGS")
 				users = strings.Split(userMappingString, ",")
 			}
-			m := make(map[string]string)
-			for _, u := range users {
-				s := strings.Split(u, "=")
-				m[s[0]] = s[1]
+			var err error
+			options.UserMappings, err = slack.ParseUserMappings(users)
+			if err != nil {
+				return err
 			}
-			options.UserMappings = m
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -49,7 +49,7 @@ func NewCommand() (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&options.GrafanaDevUrl, "grafana-dev-url", os.Getenv("GRAFANA_DEV_URL"), "grafana dev url")
 	command.PersistentFlags().StringVar(&options.GrafanaStagingUrl, "grafana-staging-url", os.Getenv("GRAFANA_STAGING_URL"), "grafana staging url")
 	command.PersistentFlags().StringVar(&options.GrafanaProdUrl, "grafana-prod-url", os.Getenv("GRAFANA_PROD_URL"), "grafana prod url")
-	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between to emails used by Slack, key-value pair: <email>=<slack-email>")
+	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
 
 	return command, nil
 }

--- a/internal/slack/mapping.go
+++ b/internal/slack/mapping.go
@@ -1,0 +1,37 @@
+package slack
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ParseUserMappings parses the slice users as key-value pairs separated with an
+// equal (=) sign.
+//
+// If any of the provided mappings are invalid or conflicting mappings are
+// provided an error is returned.
+func ParseUserMappings(users []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, u := range users {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		s := strings.Split(u, "=")
+		if len(s) != 2 {
+			return nil, errors.Errorf("invalid user mapping '%s'", u)
+		}
+		src := strings.TrimSpace(s[0])
+		dest := strings.TrimSpace(s[1])
+		_, exist := m[src]
+		if exist {
+			return nil, errors.Errorf("conflicting user mappings for %s", src)
+		}
+		if src == "" || dest == "" {
+			return nil, errors.Errorf("invalid user mapping '%s'", u)
+		}
+		m[src] = dest
+	}
+	return m, nil
+}

--- a/internal/slack/mapping_test.go
+++ b/internal/slack/mapping_test.go
@@ -1,0 +1,130 @@
+package slack
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUserMappings(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  []string
+		output map[string]string
+		err    error
+	}{
+		{
+			name:   "nil slice",
+			input:  nil,
+			output: map[string]string{},
+			err:    nil,
+		},
+		{
+			name:   "empty slice",
+			input:  []string{},
+			output: map[string]string{},
+			err:    nil,
+		},
+		{
+			name: "single empty entry",
+			input: []string{
+				"",
+			},
+			output: map[string]string{},
+			err:    nil,
+		},
+		{
+			name: "single whitespace entry",
+			input: []string{
+				" ",
+			},
+			output: map[string]string{},
+			err:    nil,
+		},
+		{
+			name: "single email entry",
+			input: []string{
+				"foo@bar.com=foo@lunarway.com",
+			},
+			output: map[string]string{
+				"foo@bar.com": "foo@lunarway.com",
+			},
+			err: nil,
+		},
+		{
+			name: "multiple different email entries",
+			input: []string{
+				"foo@bar.com=foo@lunarway.com",
+				"bar@foo.com=bar@lunarway.com",
+			},
+			output: map[string]string{
+				"foo@bar.com": "foo@lunarway.com",
+				"bar@foo.com": "bar@lunarway.com",
+			},
+			err: nil,
+		},
+		{
+			name: "single mapping with whitespace",
+			input: []string{
+				"foo@bar.com=  foo@lunarway.com",
+			},
+			output: map[string]string{
+				"foo@bar.com": "foo@lunarway.com",
+			},
+			err: nil,
+		},
+		{
+			name: "multiple conflicting email entries",
+			input: []string{
+				"foo@bar.com=foo@lunarway.com",
+				"foo@bar.com=bar@lunarway.com",
+			},
+			output: nil,
+			err:    errors.New("conflicting user mappings for foo@bar.com"),
+		},
+		{
+			name: "incomplete mapping of source",
+			input: []string{
+				"=foo@bar.com",
+			},
+			output: nil,
+			err:    errors.New("invalid user mapping '=foo@bar.com'"),
+		},
+		{
+			name: "incomplete mapping of destination",
+			input: []string{
+				"foo@bar.com=",
+			},
+			output: nil,
+			err:    errors.New("invalid user mapping 'foo@bar.com='"),
+		},
+		{
+			name: "missing equal sign",
+			input: []string{
+				"foo@bar.com",
+			},
+			output: nil,
+			err:    errors.New("invalid user mapping 'foo@bar.com'"),
+		},
+		{
+			name: "multiple equal signs",
+			input: []string{
+				"foo@bar.com=foo@lunarway.com=bar@lunarway.com",
+			},
+			output: nil,
+			err:    errors.New("invalid user mapping 'foo@bar.com=foo@lunarway.com=bar@lunarway.com'"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := ParseUserMappings(tc.input)
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "output error not as expected")
+			} else {
+				assert.NoError(t, err, "unexpected output error")
+			}
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}


### PR DESCRIPTION
If an empty user mapping was provided artifact and server commands would
panic.

This change adds input validation and sanitisation of the user-mappings
flag and environment variable.
Empty strings are filtered out and whitespaces are trimmed. Conflicting
mappings are detected as well as incomplete mappings.

A user-mappings flag is added to `artifact init` command to make the
configuration discoverable as well.