### PR TITLE
Harden commit message lookup functions

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -79,3 +79,277 @@ func TestCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestLocateReleaseCondition(t *testing.T) {
+	tt := []struct {
+		name       string
+		artifactID string
+		message    string
+		output     bool
+	}{
+		{
+			name:       "empty artifact ID",
+			artifactID: "",
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     false,
+		},
+		{
+			name:       "regexp like artifact id",
+			artifactID: `(\`,
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     false,
+		},
+		{
+			name:       "partial artifact id",
+			artifactID: "master-1234",
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     false,
+		},
+		{
+			name:       "partial artifact id with complete application hash",
+			artifactID: "master-1234567890",
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     false,
+		},
+		{
+			name:       "exact artifact id",
+			artifactID: "master-1234567890-1234567890",
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     true,
+		},
+		{
+			name:       "wrong cased artifact id",
+			artifactID: "MASTER-1234567890-1234567890",
+			message:    "[env/service-name] release master-1234567890-1234567890",
+			output:     true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := locateReleaseCondition(tc.artifactID)(tc.message)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}
+
+func TestLocateServiceReleaseCondition(t *testing.T) {
+	commitMessage := "[env/service-name] release master-1234567890-1234567890"
+	tt := []struct {
+		name    string
+		env     string
+		service string
+		output  bool
+	}{
+		{
+			name:    "empty env",
+			env:     "",
+			service: "service-name",
+			output:  false,
+		},
+		{
+			name:    "empty service",
+			env:     "env",
+			service: "",
+			output:  false,
+		},
+		{
+			name:    "regexp like env",
+			env:     `(\`,
+			service: "",
+			output:  false,
+		},
+		{
+			name:    "regexp like service",
+			env:     "",
+			service: `(\`,
+			output:  false,
+		},
+		{
+			name:    "partial env",
+			env:     "nv",
+			service: "service-name",
+			output:  false,
+		},
+		{
+			name:    "partial service",
+			env:     "env",
+			service: "service",
+			output:  false,
+		},
+		{
+			name:    "exact env and service",
+			env:     "env",
+			service: "service-name",
+			output:  true,
+		},
+		{
+			name:    "wrong cased env",
+			env:     "ENV",
+			service: "service-name",
+			output:  true,
+		},
+		{
+			name:    "wrong cased service",
+			env:     "env",
+			service: "SERVICE-NAME",
+			output:  true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := locateServiceReleaseCondition(tc.env, tc.service)(commitMessage)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}
+
+func TestLocateServiceReleaseRollbackSkipCondition(t *testing.T) {
+	type result struct {
+		commitMessage string
+		located       bool
+	}
+	tt := []struct {
+		name    string
+		env     string
+		service string
+		skip    uint
+		cases   []result
+	}{
+		{
+			name:    "empty env",
+			env:     "",
+			service: "service",
+			skip:    0,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+			},
+		},
+		{
+			name:    "empty service",
+			env:     "env",
+			service: "",
+			skip:    0,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+			},
+		},
+		{
+			name:    "exact release commit on first case and 0 skip",
+			env:     "env",
+			service: "service-name",
+			skip:    0,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", true},
+				{"[env/service-name] release master-0123456789-0123456789", false},
+			},
+		},
+		{
+			name:    "exact release commit on second case and 1 skip",
+			env:     "env",
+			service: "service-name",
+			skip:    1,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+				{"[env/service-name] release master-0123456789-0123456789", true},
+			},
+		},
+		{
+			name:    "wrong case release commit on second case and 1 skip",
+			env:     "env",
+			service: "SERVICE-NAME",
+			skip:    1,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+				{"[env/service-name] release master-0123456789-0123456789", true},
+			},
+		},
+		{
+			name:    "exact rollback commit on second case and 1 skip",
+			env:     "env",
+			service: "service-name",
+			skip:    1,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+				{"[env/service-name] rollback master-1234567890-1234567890 to master-0123456789-0123456789", true},
+			},
+		},
+		{
+			name:    "wrong case service rollback commit on second case and 1 skip",
+			env:     "env",
+			service: "SERVICE-NAME",
+			skip:    1,
+			cases: []result{
+				{"[env/service-name] release master-1234567890-1234567890", false},
+				{"[env/service-name] rollback master-1234567890-1234567890 to master-0123456789-0123456789", true},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			f := locateServiceReleaseRollbackSkipCondition(tc.env, tc.service, tc.skip)
+			for _, c := range tc.cases {
+				output := f(c.commitMessage)
+				if assert.Equalf(t, c.located, output, "output not as expected for message '%s'", c.commitMessage) {
+					// break on first successful condition
+					// this mimiks the logic of locate()
+					if output {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLocateArtifactCondition(t *testing.T) {
+	tt := []struct {
+		name       string
+		artifactID string
+		message    string
+		output     bool
+		err        error
+	}{
+		{
+			name:       "empty artifact id",
+			artifactID: "",
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     false,
+		},
+		{
+			name:       "regexp like artifact id",
+			artifactID: `(\`,
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     false,
+		},
+		{
+			name:       "partial artifact id",
+			artifactID: "master-1234",
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     false,
+		},
+		{
+			name:       "partial artifact id with complete application hash",
+			artifactID: "master-1234567890",
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     false,
+		},
+		{
+			name:       "exact artifact id",
+			artifactID: "master-1234567890-1234567890",
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     true,
+		},
+		{
+			name:       "wrong cased artifact id",
+			artifactID: "MASTER-1234567890-1234567890",
+			message:    "[service-name] artifact master-1234567890-1234567890 by Author",
+			output:     true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := locateArtifactCondition(tc.artifactID)(tc.message)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -133,71 +133,80 @@ func TestLocateReleaseCondition(t *testing.T) {
 }
 
 func TestLocateServiceReleaseCondition(t *testing.T) {
-	commitMessage := "[env/service-name] release master-1234567890-1234567890"
 	tt := []struct {
 		name    string
 		env     string
 		service string
+		message string
 		output  bool
 	}{
 		{
 			name:    "empty env",
 			env:     "",
 			service: "service-name",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "empty service",
 			env:     "env",
 			service: "",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "regexp like env",
 			env:     `(\`,
 			service: "",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "regexp like service",
 			env:     "",
 			service: `(\`,
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "partial env",
 			env:     "nv",
 			service: "service-name",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "partial service",
 			env:     "env",
 			service: "service",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  false,
 		},
 		{
 			name:    "exact env and service",
 			env:     "env",
 			service: "service-name",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  true,
 		},
 		{
 			name:    "wrong cased env",
 			env:     "ENV",
 			service: "service-name",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  true,
 		},
 		{
 			name:    "wrong cased service",
 			env:     "env",
 			service: "SERVICE-NAME",
+			message: "[env/service-name] release master-1234567890-1234567890",
 			output:  true,
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			output := locateServiceReleaseCondition(tc.env, tc.service)(commitMessage)
+			output := locateServiceReleaseCondition(tc.env, tc.service)(tc.message)
 			assert.Equal(t, tc.output, output, "output not as expected")
 		})
 	}


### PR DESCRIPTION
When looking up releases, artifacts etc. we did it using
strings.Contains() calls. This made partial matches appear to be valid,
ie. `release master-123` would match any artifact starting with that
string.

This change ensures that we match on the exact fields and at the same
ignores casing in the results.