### PR TITLE
Implement service structs

### DIFF
--- a/cmd/artifact/command/add.go
+++ b/cmd/artifact/command/add.go
@@ -225,8 +225,12 @@ func setStage(s artifact.Spec, stage artifact.Stage) artifact.Spec {
 }
 
 func notifySlack(options *Options, text, color string) error {
+	client, err := slack.NewClient(options.SlackToken, options.UserMappings)
+	if err != nil {
+		return err
+	}
 	messageFilePath := path.Join(options.RootPath, options.MessageFileName)
-	err := slack.Update(messageFilePath, options.SlackToken, func(m slack.Message) slack.Message {
+	err = client.UpdateMessage(messageFilePath, func(m slack.Message) slack.Message {
 		m.Text += text + "\n"
 		m.Color = color
 		return m

--- a/cmd/artifact/command/failure.go
+++ b/cmd/artifact/command/failure.go
@@ -14,7 +14,12 @@ func failureCommand(options *Options) *cobra.Command {
 		Use:   "failure",
 		Short: "report failure in the pipeline",
 		RunE: func(c *cobra.Command, args []string) error {
-			err := slack.Update(path.Join(options.RootPath, options.MessageFileName), options.SlackToken, func(m slack.Message) slack.Message {
+			client, err := slack.NewClient(options.SlackToken, options.UserMappings)
+			if err != nil {
+				fmt.Printf("Error, not able to create Slack client in failure command: %v", err)
+				return nil
+			}
+			err = client.UpdateMessage(path.Join(options.RootPath, options.MessageFileName), func(m slack.Message) slack.Message {
 				m.Color = slack.MsgColorRed
 				m.Text += ":no_entry: *Unexpected error in pipeline*"
 				m.Title = m.Service + " :no_entry:"
@@ -22,12 +27,6 @@ func failureCommand(options *Options) *cobra.Command {
 			})
 			if err != nil {
 				fmt.Printf("Error, not able to update slack message with failure message: %v", err)
-				return nil
-			}
-
-			client, err := slack.NewClient(options.SlackToken)
-			if err != nil {
-				fmt.Printf("Error, not able to create Slack client in failure command: %v", err)
 				return nil
 			}
 

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -20,7 +20,12 @@ func pushCommand(options *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = slack.Update(path.Join(options.RootPath, options.MessageFileName), options.SlackToken, func(m slack.Message) slack.Message {
+			client, err := slack.NewClient(options.SlackToken, options.UserMappings)
+			if err != nil {
+				fmt.Printf("Error, not able to create Slack client in successful command: %v", err)
+				return nil
+			}
+			err = client.UpdateMessage(path.Join(options.RootPath, options.MessageFileName), func(m slack.Message) slack.Message {
 				m.Text += fmt.Sprintf(":white_check_mark: *Artifact pushed:* %s", artifactId)
 				return m
 			})

--- a/cmd/artifact/command/successful.go
+++ b/cmd/artifact/command/successful.go
@@ -14,19 +14,18 @@ func successfulCommand(options *Options) *cobra.Command {
 		Use:   "successful",
 		Short: "report successful in the pipeline",
 		RunE: func(c *cobra.Command, args []string) error {
-			err := slack.Update(path.Join(options.RootPath, options.MessageFileName), options.SlackToken, func(m slack.Message) slack.Message {
+			client, err := slack.NewClient(options.SlackToken, options.UserMappings)
+			if err != nil {
+				fmt.Printf("Error, not able to create Slack client in successful command: %v", err)
+				return nil
+			}
+			err = client.UpdateMessage(path.Join(options.RootPath, options.MessageFileName), func(m slack.Message) slack.Message {
 				m.Color = slack.MsgColorGreen
 				m.Title = m.Service + " :white_check_mark:"
 				return m
 			})
 			if err != nil {
 				fmt.Printf("Error, not able to update slack message with successful message: %v", err)
-				return nil
-			}
-
-			client, err := slack.NewClient(options.SlackToken)
-			if err != nil {
-				fmt.Printf("Error, not able to create Slack client in successful command: %v", err)
 				return nil
 			}
 

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -12,8 +12,13 @@ import (
 
 // NewCommand returns a new instance of a hamctl command.
 func NewCommand() (*cobra.Command, error) {
-	var options http.Options
+	var httpOpts http.Options
+	var grafanaOpts grafanaOptions
+	var slackAuthToken string
+	var configRepoOpts configRepoOptions
 	var users []string
+	var userMappings map[string]string
+
 	var command = &cobra.Command{
 		Use:   "server",
 		Short: "server",
@@ -23,32 +28,33 @@ func NewCommand() (*cobra.Command, error) {
 				users = strings.Split(userMappingString, ",")
 			}
 			var err error
-			options.UserMappings, err = slack.ParseUserMappings(users)
+			userMappings, err = slack.ParseUserMappings(users)
 			if err != nil {
 				return err
 			}
+			httpOpts.UserMappings = userMappings
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewStart(&options))
-	command.PersistentFlags().IntVar(&options.Port, "http-port", 8080, "port of the http server")
-	command.PersistentFlags().DurationVar(&options.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
-	command.PersistentFlags().StringVar(&options.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")
-	command.PersistentFlags().StringVar(&options.DaemonAuthToken, "daemon-auth-token", os.Getenv("DAEMON_AUTH_TOKEN"), "daemon webhook authentication token")
-	command.PersistentFlags().StringVar(&options.ConfigRepo, "config-repo", os.Getenv("CONFIG_REPO"), "ssh url for the git config repository")
-	command.PersistentFlags().StringVar(&options.ArtifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
-	command.PersistentFlags().StringVar(&options.SSHPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")
-	command.PersistentFlags().StringVar(&options.GithubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
-	command.PersistentFlags().StringVar(&options.SlackAuthToken, "slack-token", os.Getenv("SLACK_TOKEN"), "token to be used to communicate with the slack api")
-	command.PersistentFlags().StringVar(&options.GrafanaDevAPIKey, "grafana-api-key-dev", os.Getenv("GRAFANA_DEV_API_KEY"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&options.GrafanaStagingAPIKey, "grafana-api-key-staging", os.Getenv("GRAFANA_STAGING_API_KEY"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&options.GrafanaProdAPIKey, "grafana-api-key-prod", os.Getenv("GRAFANA_PROD_API_KEY"), "api key to be used to annotate in prod")
-	command.PersistentFlags().StringVar(&options.GrafanaDevUrl, "grafana-dev-url", os.Getenv("GRAFANA_DEV_URL"), "grafana dev url")
-	command.PersistentFlags().StringVar(&options.GrafanaStagingUrl, "grafana-staging-url", os.Getenv("GRAFANA_STAGING_URL"), "grafana staging url")
-	command.PersistentFlags().StringVar(&options.GrafanaProdUrl, "grafana-prod-url", os.Getenv("GRAFANA_PROD_URL"), "grafana prod url")
+	command.AddCommand(NewStart(&grafanaOpts, &slackAuthToken, &configRepoOpts, &httpOpts, userMappings))
+	command.PersistentFlags().IntVar(&httpOpts.Port, "http-port", 8080, "port of the http server")
+	command.PersistentFlags().DurationVar(&httpOpts.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
+	command.PersistentFlags().StringVar(&httpOpts.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")
+	command.PersistentFlags().StringVar(&httpOpts.DaemonAuthToken, "daemon-auth-token", os.Getenv("DAEMON_AUTH_TOKEN"), "daemon webhook authentication token")
+	command.PersistentFlags().StringVar(&configRepoOpts.ConfigRepo, "config-repo", os.Getenv("CONFIG_REPO"), "ssh url for the git config repository")
+	command.PersistentFlags().StringVar(&configRepoOpts.ArtifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
+	command.PersistentFlags().StringVar(&configRepoOpts.SSHPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")
+	command.PersistentFlags().StringVar(&httpOpts.GithubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
+	command.PersistentFlags().StringVar(&slackAuthToken, "slack-token", os.Getenv("SLACK_TOKEN"), "token to be used to communicate with the slack api")
+	command.PersistentFlags().StringVar(&grafanaOpts.DevAPIKey, "grafana-api-key-dev", os.Getenv("GRAFANA_DEV_API_KEY"), "api key to be used to annotate in dev")
+	command.PersistentFlags().StringVar(&grafanaOpts.StagingAPIKey, "grafana-api-key-staging", os.Getenv("GRAFANA_STAGING_API_KEY"), "api key to be used to annotate in dev")
+	command.PersistentFlags().StringVar(&grafanaOpts.ProdAPIKey, "grafana-api-key-prod", os.Getenv("GRAFANA_PROD_API_KEY"), "api key to be used to annotate in prod")
+	command.PersistentFlags().StringVar(&grafanaOpts.DevURL, "grafana-dev-url", os.Getenv("GRAFANA_DEV_URL"), "grafana dev url")
+	command.PersistentFlags().StringVar(&grafanaOpts.StagingURL, "grafana-staging-url", os.Getenv("GRAFANA_STAGING_URL"), "grafana staging url")
+	command.PersistentFlags().StringVar(&grafanaOpts.ProdURL, "grafana-prod-url", os.Getenv("GRAFANA_PROD_URL"), "grafana prod url")
 	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
 
 	return command, nil

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -32,7 +32,6 @@ func NewCommand() (*cobra.Command, error) {
 			if err != nil {
 				return err
 			}
-			httpOpts.UserMappings = userMappings
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -37,7 +37,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 		Short: "start the release-manager",
 		RunE: func(c *cobra.Command, args []string) error {
 			done := make(chan error, 1)
-			slackClient, err := slack.NewClient(*slackAuthToken)
+			slackClient, err := slack.NewClient(*slackAuthToken, userMappings)
 			if err != nil {
 				return err
 			}

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -7,24 +7,70 @@ import (
 	"syscall"
 
 	"github.com/lunarway/release-manager/cmd/server/http"
+	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/grafana"
 	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/policy"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func NewStart(options *http.Options) *cobra.Command {
+type grafanaOptions struct {
+	DevAPIKey     string
+	DevURL        string
+	StagingAPIKey string
+	StagingURL    string
+	ProdAPIKey    string
+	ProdURL       string
+}
+
+type configRepoOptions struct {
+	ConfigRepo        string
+	ArtifactFileName  string
+	SSHPrivateKeyPath string
+}
+
+func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpts *configRepoOptions, httpOpts *http.Options, userMappings map[string]string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "start the release-manager",
 		RunE: func(c *cobra.Command, args []string) error {
 			done := make(chan error, 1)
-			client, err := slack.NewClient(options.SlackAuthToken)
+			slackClient, err := slack.NewClient(*slackAuthToken)
 			if err != nil {
 				return err
 			}
+			grafana := grafana.Service{
+				Environments: map[string]grafana.Environment{
+					"dev": {
+						APIKey:  grafanaOpts.DevAPIKey,
+						BaseURL: grafanaOpts.DevURL,
+					},
+					"staging": {
+						APIKey:  grafanaOpts.StagingAPIKey,
+						BaseURL: grafanaOpts.StagingURL,
+					},
+					"prod": {
+						APIKey:  grafanaOpts.ProdAPIKey,
+						BaseURL: grafanaOpts.ProdURL,
+					},
+				},
+			}
+			flowSvc := flow.Service{
+				ConfigRepoURL:     configRepoOpts.ConfigRepo,
+				ArtifactFileName:  configRepoOpts.ArtifactFileName,
+				SSHPrivateKeyPath: configRepoOpts.SSHPrivateKeyPath,
+				UserMappings:      userMappings,
+				Slack:             slackClient,
+				Grafana:           &grafana,
+			}
+			policySvc := policy.Service{
+				ConfigRepoURL:     configRepoOpts.ConfigRepo,
+				SSHPrivateKeyPath: configRepoOpts.SSHPrivateKeyPath,
+			}
 			go func() {
-				err := http.NewServer(options, client)
+				err := http.NewServer(httpOpts, slackClient, &flowSvc, &policySvc)
 				if err != nil {
 					done <- errors.WithMessage(err, "new http server")
 					return

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -22,36 +22,24 @@ import (
 )
 
 type Options struct {
-	Port                 int
-	Timeout              time.Duration
-	GithubWebhookSecret  string
-	HamCtlAuthToken      string
-	DaemonAuthToken      string
-	SlackAuthToken       string
-	GrafanaDevAPIKey     string
-	GrafanaStagingAPIKey string
-	GrafanaProdAPIKey    string
-	GrafanaDevUrl        string
-	GrafanaStagingUrl    string
-	GrafanaProdUrl       string
-
-	UserMappings map[string]string
-
-	ConfigRepo        string
-	ArtifactFileName  string
-	SSHPrivateKeyPath string
+	Port                int
+	Timeout             time.Duration
+	GithubWebhookSecret string
+	HamCtlAuthToken     string
+	DaemonAuthToken     string
+	UserMappings        map[string]string
 }
 
-func NewServer(opts *Options, client *slack.Client) error {
+func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, policySvc *policyinternal.Service) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", ping)
-	mux.HandleFunc("/promote", authenticate(opts.HamCtlAuthToken, promote(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath, opts.SlackAuthToken, opts.GrafanaDevAPIKey, opts.GrafanaStagingAPIKey, opts.GrafanaProdAPIKey, opts.GrafanaDevUrl, opts.GrafanaStagingUrl, opts.GrafanaProdUrl)))
-	mux.HandleFunc("/release", authenticate(opts.HamCtlAuthToken, release(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath, opts.SlackAuthToken, opts.GrafanaDevAPIKey, opts.GrafanaStagingAPIKey, opts.GrafanaProdAPIKey, opts.GrafanaDevUrl, opts.GrafanaStagingUrl, opts.GrafanaProdUrl)))
-	mux.HandleFunc("/status", authenticate(opts.HamCtlAuthToken, status(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath)))
-	mux.HandleFunc("/rollback", authenticate(opts.HamCtlAuthToken, rollback(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath, opts.SlackAuthToken, opts.GrafanaDevAPIKey, opts.GrafanaStagingAPIKey, opts.GrafanaProdAPIKey, opts.GrafanaDevUrl, opts.GrafanaStagingUrl, opts.GrafanaProdUrl)))
-	mux.HandleFunc("/policies", authenticate(opts.HamCtlAuthToken, policy(opts.ConfigRepo, opts.SSHPrivateKeyPath)))
-	mux.HandleFunc("/webhook/github", githubWebhook(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath, opts.GithubWebhookSecret, opts.SlackAuthToken, opts.GrafanaDevAPIKey, opts.GrafanaStagingAPIKey, opts.GrafanaProdAPIKey, opts.GrafanaDevUrl, opts.GrafanaStagingUrl, opts.GrafanaProdUrl, opts.UserMappings))
-	mux.HandleFunc("/webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(opts.ConfigRepo, opts.ArtifactFileName, opts.SSHPrivateKeyPath, client, opts.UserMappings)))
+	mux.HandleFunc("/promote", authenticate(opts.HamCtlAuthToken, promote(flowSvc)))
+	mux.HandleFunc("/release", authenticate(opts.HamCtlAuthToken, release(flowSvc)))
+	mux.HandleFunc("/status", authenticate(opts.HamCtlAuthToken, status(flowSvc)))
+	mux.HandleFunc("/rollback", authenticate(opts.HamCtlAuthToken, rollback(flowSvc)))
+	mux.HandleFunc("/policies", authenticate(opts.HamCtlAuthToken, policy(policySvc)))
+	mux.HandleFunc("/webhook/github", githubWebhook(flowSvc, policySvc, slackClient, opts.GithubWebhookSecret, opts.UserMappings))
+	mux.HandleFunc("/webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(flowSvc)))
 
 	s := http.Server{
 		Addr:              fmt.Sprintf(":%d", opts.Port),
@@ -90,7 +78,7 @@ func ping(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "pong")
 }
 
-func status(configRepo, artifactFileName, sshPrivateKeyPath string) http.HandlerFunc {
+func status(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
 		service := values.Get("service")
@@ -99,9 +87,9 @@ func status(configRepo, artifactFileName, sshPrivateKeyPath string) http.Handler
 			return
 		}
 
-		logger := log.WithFields("configRepo", configRepo, "artifactFileName", artifactFileName, "service", service)
+		logger := log.WithFields("service", service)
 		ctx := r.Context()
-		s, err := flow.Status(ctx, configRepo, artifactFileName, service, sshPrivateKeyPath)
+		s, err := flowSvc.Status(ctx, service)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
 				logger.Infof("http: status: get status cancelled: service '%s'", service)
@@ -163,7 +151,7 @@ func status(configRepo, artifactFileName, sshPrivateKeyPath string) http.Handler
 	}
 }
 
-func rollback(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl string) http.HandlerFunc {
+func rollback(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			Error(w, "not found", http.StatusNotFound)
@@ -194,20 +182,12 @@ func rollback(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafa
 			return
 		}
 
-		logger := log.WithFields("configRepo", configRepo, "artifactFileName", artifactFileName, "service", req.Service, "req", req)
+		logger := log.WithFields("service", req.Service, "req", req)
 		ctx := r.Context()
-		res, err := flow.Rollback(ctx, flow.FlowOptions{
-			ConfigRepoURL:     configRepo,
-			ArtifactFileName:  artifactFileName,
-			Service:           req.Service,
-			Environment:       req.Environment,
-			CommitterName:     req.CommitterName,
-			CommitterEmail:    req.CommitterEmail,
-			SSHPrivateKeyPath: sshPrivateKeyPath,
-			SlackToken:        slackToken,
-			GrafanaAPIKey:     getGrafanaVarForEnv(req.Environment, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd),
-			GrafanaUrl:        getGrafanaVarForEnv(req.Environment, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl),
-		})
+		res, err := flowSvc.Rollback(ctx, flow.Actor{
+			Name:  req.CommitterName,
+			Email: req.CommitterEmail,
+		}, req.Environment, req.Service)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
 				logger.Infof("http: rollback cancelled: env '%s' service '%s'", req.Environment, req.Service)
@@ -245,7 +225,7 @@ func rollback(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafa
 	}
 }
 
-func daemonWebhook(configRepo, artifactFileName, sshPrivateKeyPath string, slackClient *slack.Client, userMappings map[string]string) http.HandlerFunc {
+func daemonWebhook(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
 		var podNotify httpinternal.PodNotifyRequest
@@ -257,7 +237,7 @@ func daemonWebhook(configRepo, artifactFileName, sshPrivateKeyPath string, slack
 			return
 		}
 
-		err = flow.NotifyCommitter(context.Background(), configRepo, artifactFileName, sshPrivateKeyPath, &podNotify, slackClient, userMappings)
+		err = flowSvc.NotifyCommitter(context.Background(), &podNotify)
 		if err != nil {
 			log.Errorf("http: daemon webhook failed: notify committer: %v", err)
 			unknownError(w)
@@ -274,7 +254,7 @@ func daemonWebhook(configRepo, artifactFileName, sshPrivateKeyPath string, slack
 	}
 }
 
-func githubWebhook(configRepo, artifactFileName, sshPrivateKeyPath, githubWebhookSecret, slackToken, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl string, userMappings map[string]string) http.HandlerFunc {
+func githubWebhook(flowSvc *flow.Service, policySvc *policyinternal.Service, slackClient *slack.Client, githubWebhookSecret string, userMappings map[string]string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		hook, _ := github.New(github.Options.Secret(githubWebhookSecret))
 		payload, err := hook.Parse(r, github.PushEvent)
@@ -300,7 +280,7 @@ func githubWebhook(configRepo, artifactFileName, sshPrivateKeyPath, githubWebhoo
 			serviceName := matches[1]
 
 			// locate branch of commit
-			branch, ok := branchName(push.HeadCommit.Modified, artifactFileName, serviceName)
+			branch, ok := branchName(push.HeadCommit.Modified, flowSvc.ArtifactFileName, serviceName)
 			if !ok {
 				log.Debugf("http: github webhook: service '%s': branch name not found", serviceName)
 				w.WriteHeader(http.StatusOK)
@@ -309,29 +289,20 @@ func githubWebhook(configRepo, artifactFileName, sshPrivateKeyPath, githubWebhoo
 
 			logger := log.WithFields("branch", branch, "service", serviceName, "commit", push.HeadCommit)
 			// lookup policies for branch
-			autoReleases, err := policyinternal.GetAutoReleases(context.Background(), configRepo, sshPrivateKeyPath, serviceName, branch)
+			autoReleases, err := policySvc.GetAutoReleases(context.Background(), serviceName, branch)
 			if err != nil {
 				logger.Errorf("http: github webhook: service '%s' branch '%s': get auto release policies failed: %v", serviceName, branch, err)
-				notifyPolicyFailure(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("failed for branch: %s, env: %s", serviceName, branch), slackToken, userMappings)
+				notifyPolicyFailure(slackClient, push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("failed for branch: %s, env: %s", serviceName, branch), userMappings)
 				unknownError(w)
 				return
 			}
 			logger.Debugf("http: github webhook: service '%s' branch '%s': found %d release policies", serviceName, branch, len(autoReleases))
 			var errs error
 			for _, autoRelease := range autoReleases {
-				releaseID, err := flow.ReleaseBranch(context.Background(), flow.FlowOptions{
-					ConfigRepoURL:     configRepo,
-					ArtifactFileName:  artifactFileName,
-					Service:           serviceName,
-					Environment:       autoRelease.Environment,
-					Branch:            autoRelease.Branch,
-					CommitterName:     push.HeadCommit.Author.Name,
-					CommitterEmail:    push.HeadCommit.Author.Email,
-					SSHPrivateKeyPath: sshPrivateKeyPath,
-					SlackToken:        slackToken,
-					GrafanaAPIKey:     getGrafanaVarForEnv(autoRelease.Environment, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd),
-					GrafanaUrl:        getGrafanaVarForEnv(autoRelease.Environment, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl),
-				})
+				releaseID, err := flowSvc.ReleaseBranch(context.Background(), flow.Actor{
+					Name:  push.HeadCommit.Author.Name,
+					Email: push.HeadCommit.Author.Email,
+				}, autoRelease.Environment, serviceName, autoRelease.Branch)
 				if err != nil {
 					if errors.Cause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
@@ -344,7 +315,7 @@ func githubWebhook(configRepo, artifactFileName, sshPrivateKeyPath, githubWebhoo
 			}
 			if errs != nil {
 				log.Errorf("http: github webhook: service '%s' branch '%s': auto-release failed with one or more errors: %v", serviceName, branch, errs)
-				notifyPolicyFailure(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("failed for branch: %s, env: %s", serviceName, branch), slackToken, userMappings)
+				notifyPolicyFailure(slackClient, push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("failed for branch: %s, env: %s", serviceName, branch), userMappings)
 				unknownError(w)
 				return
 			}
@@ -383,7 +354,7 @@ func branchName(modifiedFiles []string, artifactFileName, svc string) (string, b
 	return strings.TrimSuffix(branch, fmt.Sprintf("/%s", artifactFileName)), true
 }
 
-func promote(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl string) http.HandlerFunc {
+func promote(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
 		var req httpinternal.PromoteRequest
@@ -395,20 +366,12 @@ func promote(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafan
 			return
 		}
 
-		logger := log.WithFields("configRepo", configRepo, "artifactFileName", artifactFileName, "service", req.Service, "req", req)
+		logger := log.WithFields("service", req.Service, "req", req)
 		ctx := r.Context()
-		releaseID, err := flow.Promote(ctx, flow.FlowOptions{
-			ConfigRepoURL:     configRepo,
-			ArtifactFileName:  artifactFileName,
-			Service:           req.Service,
-			Environment:       req.Environment,
-			CommitterName:     req.CommitterName,
-			CommitterEmail:    req.CommitterEmail,
-			SSHPrivateKeyPath: sshPrivateKeyPath,
-			SlackToken:        slackToken,
-			GrafanaAPIKey:     getGrafanaVarForEnv(req.Environment, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd),
-			GrafanaUrl:        getGrafanaVarForEnv(req.Environment, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl),
-		})
+		releaseID, err := flowSvc.Promote(ctx, flow.Actor{
+			Name:  req.CommitterName,
+			Email: req.CommitterEmail,
+		}, req.Environment, req.Service)
 
 		var statusString string
 		if err != nil {
@@ -463,7 +426,7 @@ func promote(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafan
 	}
 }
 
-func release(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl string) http.HandlerFunc {
+func release(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
 		var req httpinternal.ReleaseRequest
@@ -476,8 +439,6 @@ func release(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafan
 		}
 		ctx := r.Context()
 		logger := log.WithFields(
-			"configRepo", configRepo,
-			"artifactFileName", artifactFileName,
 			"service", req.Service,
 			"req", req)
 		var releaseID string
@@ -492,34 +453,16 @@ func release(configRepo, artifactFileName, sshPrivateKeyPath, slackToken, grafan
 			return
 		case req.Branch != "":
 			logger.Infof("http: release: service '%s' environment '%s' branch '%s': releasing branch", req.Service, req.Environment, req.Branch)
-			releaseID, err = flow.ReleaseBranch(ctx, flow.FlowOptions{
-				ConfigRepoURL:     configRepo,
-				ArtifactFileName:  artifactFileName,
-				Service:           req.Service,
-				Environment:       req.Environment,
-				Branch:            req.Branch,
-				CommitterName:     req.CommitterName,
-				CommitterEmail:    req.CommitterEmail,
-				SSHPrivateKeyPath: sshPrivateKeyPath,
-				SlackToken:        slackToken,
-				GrafanaAPIKey:     getGrafanaVarForEnv(req.Environment, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd),
-				GrafanaUrl:        getGrafanaVarForEnv(req.Environment, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl),
-			})
+			releaseID, err = flowSvc.ReleaseBranch(ctx, flow.Actor{
+				Name:  req.CommitterName,
+				Email: req.CommitterEmail,
+			}, req.Environment, req.Service, req.Branch)
 		case req.ArtifactID != "":
 			logger.Infof("http: release: service '%s' environment '%s' artifact id '%s': releasing artifact", req.Service, req.Environment, req.ArtifactID)
-			releaseID, err = flow.ReleaseArtifactID(ctx, flow.FlowOptions{
-				ConfigRepoURL:     configRepo,
-				ArtifactFileName:  artifactFileName,
-				Service:           req.Service,
-				Environment:       req.Environment,
-				ArtifactID:        req.ArtifactID,
-				CommitterName:     req.CommitterName,
-				CommitterEmail:    req.CommitterEmail,
-				SSHPrivateKeyPath: sshPrivateKeyPath,
-				SlackToken:        slackToken,
-				GrafanaAPIKey:     getGrafanaVarForEnv(req.Environment, grafanaApiKeyDev, grafanaApiKeyStaging, grafanaApiKeyProd),
-				GrafanaUrl:        getGrafanaVarForEnv(req.Environment, grafanaDevUrl, grafanaStagingUrl, grafanaProdUrl),
-			})
+			releaseID, err = flowSvc.ReleaseArtifactID(ctx, flow.Actor{
+				Name:  req.CommitterName,
+				Email: req.CommitterEmail,
+			}, req.Environment, req.Service, req.ArtifactID)
 		default:
 			logger.Infof("http: release: service '%s' environment '%s' artifact id '%s' branch '%s': neither brand nor artifact id specified", req.Service, req.Environment, req.ArtifactID, req.Branch)
 			Error(w, "either branch or artifact id must be specified", http.StatusBadRequest)
@@ -575,25 +518,7 @@ func convertTimeToEpoch(t time.Time) int64 {
 	return t.UnixNano() / int64(time.Millisecond)
 }
 
-func getGrafanaVarForEnv(env, dev, staging, prod string) string {
-	switch env {
-	case "dev":
-		return dev
-	case "staging":
-		return staging
-	case "prod":
-		return prod
-	}
-	return ""
-}
-
-func notifyPolicyFailure(email, title, errorMessage, token string, userMappings map[string]string) {
-	client, err := slack.NewClient(token)
-	if err != nil {
-		log.Errorf("error initializing Slack Client in notifyPolicyFailure: %v", err)
-		return
-	}
-
+func notifyPolicyFailure(client *slack.Client, email, title, errorMessage string, userMappings map[string]string) {
 	if !flow.IsLunarWayEmail(email) {
 		//check UserMappings
 		lwEmail, ok := userMappings[email]

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -53,7 +53,7 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 
 	log.Infof("Commit: %+v", commit)
 
-	if !IsLunarWayEmail(commit.Author.Email) {
+	if !strings.Contains(commit.Author.Email, "@lunarway.com") {
 		//check UserMappings
 		lwEmail, ok := s.UserMappings[commit.Author.Email]
 		if !ok {
@@ -63,19 +63,10 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 		commit.Author.Email = lwEmail
 	}
 
-	slackUserId, err := s.Slack.GetSlackIdByEmail(commit.Author.Email)
-	if err != nil {
-		return errors.WithMessage(err, "locate slack userId")
-	}
-
-	err = s.Slack.PostPrivateMessage(slackUserId, env, service, sourceSpec, event)
+	err = s.Slack.PostPrivateMessage(commit.Author.Email, env, service, sourceSpec, event)
 	if err != nil {
 		return errors.WithMessage(err, "post private message")
 	}
 
 	return nil
-}
-
-func IsLunarWayEmail(email string) bool {
-	return strings.Contains(email, "@lunarway.com")
 }

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -35,7 +35,7 @@ import (
 //
 // Copy artifacts from the current release into the new environment and commit
 // the changes
-func Promote(ctx context.Context, opts FlowOptions) (string, error) {
+func (s *Service) Promote(ctx context.Context, actor Actor, environment, service string) (string, error) {
 	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-promote-source")
 	if err != nil {
 		return "", err
@@ -47,12 +47,12 @@ func Promote(ctx context.Context, opts FlowOptions) (string, error) {
 	}
 	defer closeDestination()
 	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
-	log.Debugf("Cloning source config repo %s into %s", opts.ConfigRepoURL, sourceConfigRepoPath)
-	sourceRepo, err := git.Clone(ctx, opts.ConfigRepoURL, sourceConfigRepoPath, opts.SSHPrivateKeyPath)
+	log.Debugf("Cloning source config repo %s into %s", s.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := git.Clone(ctx, s.ConfigRepoURL, sourceConfigRepoPath, s.SSHPrivateKeyPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", opts.ConfigRepoURL, sourceConfigRepoPath))
+		return "", errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", s.ConfigRepoURL, sourceConfigRepoPath))
 	}
-	sourceSpec, err := sourceSpec(sourceConfigRepoPath, opts.ArtifactFileName, opts.Service, opts.Environment)
+	sourceSpec, err := sourceSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 	}
@@ -63,28 +63,28 @@ func Promote(ctx context.Context, opts FlowOptions) (string, error) {
 	var hash plumbing.Hash
 	// when promoting to dev we use should look for the artifact instead of
 	// release as the artifact have never been released.
-	if opts.Environment == "dev" {
+	if environment == "dev" {
 		hash, err = git.LocateArtifact(sourceRepo, release)
 	} else {
 		hash, err = git.LocateRelease(sourceRepo, release)
 	}
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("locate release '%s' from '%s'", release, opts.ConfigRepoURL))
+		return "", errors.WithMessage(err, fmt.Sprintf("locate release '%s' from '%s'", release, s.ConfigRepoURL))
 	}
 	log.Debugf("internal/flow: Promote: release hash '%v'", hash)
 	err = git.Checkout(sourceRepo, hash)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("checkout release hash '%s' from '%s'", hash, opts.ConfigRepoURL))
+		return "", errors.WithMessage(err, fmt.Sprintf("checkout release hash '%s' from '%s'", hash, s.ConfigRepoURL))
 	}
 
-	destinationRepo, err := git.Clone(ctx, opts.ConfigRepoURL, destinationConfigRepoPath, opts.SSHPrivateKeyPath)
+	destinationRepo, err := git.Clone(ctx, s.ConfigRepoURL, destinationConfigRepoPath, s.SSHPrivateKeyPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("clone destination repo '%s' into '%s'", opts.ConfigRepoURL, destinationConfigRepoPath))
+		return "", errors.WithMessage(err, fmt.Sprintf("clone destination repo '%s' into '%s'", s.ConfigRepoURL, destinationConfigRepoPath))
 	}
 
 	// release service to env from original release
-	sourcePath := srcPath(sourceConfigRepoPath, opts.Service, "master", opts.Environment)
-	destinationPath := releasePath(destinationConfigRepoPath, opts.Service, opts.Environment)
+	sourcePath := srcPath(sourceConfigRepoPath, service, "master", environment)
+	destinationPath := releasePath(destinationConfigRepoPath, service, environment)
 	log.Debugf("Copy resources from: %s to %s", sourcePath, destinationPath)
 
 	// empty existing resources in destination
@@ -102,8 +102,8 @@ func Promote(ctx context.Context, opts FlowOptions) (string, error) {
 		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
 	}
 	// copy artifact spec
-	artifactSourcePath := srcPath(sourceConfigRepoPath, opts.Service, "master", opts.ArtifactFileName)
-	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, opts.Service, opts.Environment), opts.ArtifactFileName)
+	artifactSourcePath := srcPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
+	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment), s.ArtifactFileName)
 	log.Debugf("Copy artifact from: %s to %s", artifactSourcePath, artifactDestinationPath)
 	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
 	if err != nil {
@@ -112,24 +112,21 @@ func Promote(ctx context.Context, opts FlowOptions) (string, error) {
 
 	authorName := sourceSpec.Application.AuthorName
 	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := git.ReleaseCommitMessage(opts.Environment, opts.Service, release)
-	log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, opts.CommitterName, opts.CommitterEmail)
-	err = git.Commit(ctx, destinationRepo, releasePath(".", opts.Service, opts.Environment), authorName, authorEmail, opts.CommitterName, opts.CommitterEmail, releaseMessage, opts.SSHPrivateKeyPath)
+	releaseMessage := git.ReleaseCommitMessage(environment, service, release)
+	log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+	err = git.Commit(ctx, destinationRepo, releasePath(".", service, environment), authorName, authorEmail, actor.Name, actor.Email, releaseMessage, s.SSHPrivateKeyPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
 	}
-	err = notifyRelease(NotifyReleaseOptions{
-		SlackToken:     opts.SlackToken,
-		GrafanaApiKey:  opts.GrafanaAPIKey,
-		GrafanaBaseUrl: opts.GrafanaUrl,
-		Service:        opts.Service,
-		Environment:    opts.Environment,
-		ArtifactID:     sourceSpec.ID,
-		CommitAuthor:   sourceSpec.Application.AuthorName,
-		CommitMessage:  sourceSpec.Application.Message,
-		CommitSHA:      sourceSpec.Application.SHA,
-		CommitLink:     sourceSpec.Application.URL,
-		Releaser:       opts.CommitterName,
+	err = s.notifyRelease(NotifyReleaseOptions{
+		Service:       service,
+		Environment:   environment,
+		ArtifactID:    sourceSpec.ID,
+		CommitAuthor:  sourceSpec.Application.AuthorName,
+		CommitMessage: sourceSpec.Application.Message,
+		CommitSHA:     sourceSpec.Application.SHA,
+		CommitLink:    sourceSpec.Application.URL,
+		Releaser:      actor.Name,
 	})
 	if err != nil {
 		log.Errorf("flow: Promote: error notifying release: %v", err)

--- a/internal/slack/message.go
+++ b/internal/slack/message.go
@@ -23,7 +23,6 @@ var (
 )
 
 type Message struct {
-	UserID    string `json:"userId,omitempty"`
 	Color     string `json:"color,omitempty"`
 	Channel   string `json:"channel,omitempty"`
 	Text      string `json:"text,omitempty"`
@@ -84,20 +83,18 @@ func Persist(path string, message Message) error {
 	return nil
 }
 
-func Update(path, token string, f func(Message) Message) error {
+// UpdateMessage updates the message in the file located at path by applying f
+// on the contents.
+//
+// The stored Slack build message is updated accordingly.
+func (c *Client) UpdateMessage(path string, f func(Message) Message) error {
 	m, err := Get(path)
 	if err != nil {
 		return errors.WithMessagef(err, "read artifact '%s'", path)
 	}
 	m = f(m)
 
-	// Setup Slack client
-	client, err := NewClient(token)
-	if err != nil {
-		return err
-	}
-
-	m.Channel, m.Timestamp, err = client.UpdateSlackBuildStatus(m.Channel, m.Title, m.TitleLink, m.Text, m.Color, m.Timestamp)
+	m.Channel, m.Timestamp, err = c.UpdateSlackBuildStatus(m.Channel, m.Title, m.TitleLink, m.Text, m.Color, m.Timestamp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Change `flow`, `policy` and `grafana` functions to methods. This reduces the
number of arguments and the general overhead of non-important arguments
on each function call.

I'm unsure how to handle the user email mapping in the `notifyPolicyFailure` function. It seems a bit weird that you need to lookup the email up front instead of just letting the `slack.Client` handle this.
What do you think of letting the `Client` handle the mapping. The general API of the `Client` struct is based on Slack user IDs. We could change this to emails instead of do the lookup first thing?