### PR TITLE
add option to post custom messages in case of failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,12 @@ artifact-snyk-code:
 	./dist/artifact add snyk-code --slack-token ${SLACK_TOKEN} --high 0 --medium 0 --low 0 --url "https://example.com"
 
 artifact-failure:
-	./dist/artifact failure --slack-token ${SLACK_TOKEN}
+	./dist/artifact failure --slack-token ${SLACK_TOKEN} --error-message "Build failed"
 
 artifact-successful:
 	./dist/artifact successful --slack-token ${SLACK_TOKEN}
 
-artifact-slack: build_artifact artifact-init artifact-build artifact-test artifact-snyk-docker artifact-snyk-code artifact-push artifact-successful
+artifact-slack: build_artifact artifact-init artifact-build artifact-test artifact-snyk-docker artifact-snyk-code artifact-push artifact-failure
 
 release:
 	goreleaser --rm-dist --skip-publish

--- a/cmd/artifact/command/failure.go
+++ b/cmd/artifact/command/failure.go
@@ -14,12 +14,6 @@ func failureCommand(options *Options) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "failure",
 		Short: "report failure in the pipeline",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if errorMessage == "" {
-				errorMessage = "Unexpected error in pipeline"
-			}
-			return nil
-		},
 		RunE: func(c *cobra.Command, args []string) error {
 			client, err := slack.NewClient(options.SlackToken, options.UserMappings)
 			if err != nil {
@@ -62,6 +56,6 @@ func failureCommand(options *Options) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&errorMessage, "error-message", "", "error message to send to slack")
+	command.Flags().StringVar(&errorMessage, "error-message", "Unexpected error in pipeline", "error message to send to slack")
 	return command
 }


### PR DESCRIPTION
This PR adds an option for adding an error-message to the `artifact failure` command to post custom error messages