### PR TITLE
Add namespace support

### DIFF
--- a/cmd/hamctl/command/root_test.go
+++ b/cmd/hamctl/command/root_test.go
@@ -1,0 +1,67 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultShuttleString(t *testing.T) {
+	tt := []struct {
+		name      string
+		flagValue string
+		spec      shuttleSpec
+		output    string
+	}{
+		{
+			name:      "flag value",
+			flagValue: "value",
+			spec: shuttleSpec{
+				Vars: shuttleSpecVars{
+					Service: "service",
+				},
+			},
+			output: "value",
+		},
+		{
+			name:      "empty flag value",
+			flagValue: "",
+			spec: shuttleSpec{
+				Vars: shuttleSpecVars{
+					Service: "service",
+				},
+			},
+			output: "service",
+		},
+		{
+			name:      "whitespace flag value",
+			flagValue: "   ",
+			spec: shuttleSpec{
+				Vars: shuttleSpecVars{
+					Service: "service",
+				},
+			},
+			output: "service",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			defaultShuttleString(func() (shuttleSpec, bool) {
+				return tc.spec, true
+			}, &tc.flagValue, func(s *shuttleSpec) string {
+				return s.Vars.Service
+			})
+			assert.Equal(t, tc.output, tc.flagValue, "flag value not as expected")
+		})
+	}
+}
+
+func TestDefaultShuttleString_noSpec(t *testing.T) {
+	var flagValue string
+	defaultShuttleString(func() (shuttleSpec, bool) {
+		return shuttleSpec{}, false
+	}, &flagValue, func(s *shuttleSpec) string {
+		return s.Vars.Service
+	})
+	assert.Equal(t, "", flagValue, "flag value not as expected")
+}

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -12,13 +12,22 @@ import (
 )
 
 func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
+	var namespace string
 	var command = &cobra.Command{
 		Use:   "status",
 		Short: "List the status of the environments",
+		PreRun: func(c *cobra.Command, args []string) {
+			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
+				return s.Vars.Namespace
+			})
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			var resp httpinternal.StatusResponse
 			params := url.Values{}
 			params.Add("service", *service)
+			if namespace != "" {
+				params.Add("namespace", namespace)
+			}
 			path, err := client.URLWithQuery("status", params)
 			if err != nil {
 				return err
@@ -40,6 +49,7 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 			return nil
 		},
 	}
+	command.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace the service is deployed to (defaults to env)")
 	return command
 }
 

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -37,6 +37,12 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if !someManaged(resp.Dev, resp.Staging, resp.Prod) {
+				if resp.DefaultNamespaces {
+					fmt.Printf("Using default namespaces. ")
+				}
+				fmt.Printf("Are you setting the right namespace?\n")
+			}
 			fmt.Printf("\n")
 			color.Green("dev:\n")
 			printStatus(resp.Dev)
@@ -53,6 +59,15 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 	return command
 }
 
+// someManaged returns true if any of provided environments are managed.
+func someManaged(envs ...*httpinternal.Environment) bool {
+	for _, e := range envs {
+		if e != nil && e.Tag != "" {
+			return true
+		}
+	}
+	return false
+}
 func Time(epoch int64) time.Time {
 	return time.Unix(epoch/1000, 0)
 }

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -141,9 +141,10 @@ func status(flowSvc *flow.Service) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 
 		err = json.NewEncoder(w).Encode(httpinternal.StatusResponse{
-			Dev:     &dev,
-			Staging: &staging,
-			Prod:    &prod,
+			DefaultNamespaces: s.DefaultNamespaces,
+			Dev:               &dev,
+			Staging:           &staging,
+			Prod:              &prod,
 		})
 		if err != nil {
 			logger.Errorf("http: status: service '%s': marshal response failed: %v", service, err)

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -80,15 +80,16 @@ func ping(w http.ResponseWriter, r *http.Request) {
 func status(flowSvc *flow.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		values := r.URL.Query()
+		namespace := values.Get("namespace")
 		service := values.Get("service")
 		if emptyString(service) {
 			requiredQueryError(w, "service")
 			return
 		}
 
-		logger := log.WithFields("service", service)
+		logger := log.WithFields("service", service, "namespace", namespace)
 		ctx := r.Context()
-		s, err := flowSvc.Status(ctx, service)
+		s, err := flowSvc.Status(ctx, namespace, service)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
 				logger.Infof("http: status: get status cancelled: service '%s'", service)
@@ -180,13 +181,18 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 			requiredFieldError(w, "committerEmail")
 			return
 		}
+		// default namespace to environment if it's empty. For most devlopers this
+		// allows them to avoid setting the namespac flag for services.
+		if emptyString(req.Namespace) {
+			req.Namespace = req.Environment
+		}
 
-		logger := log.WithFields("service", req.Service, "req", req)
+		logger := log.WithFields("service", req.Service, "namespace", req.Namespace, "req", req)
 		ctx := r.Context()
 		res, err := flowSvc.Rollback(ctx, flow.Actor{
 			Name:  req.CommitterName,
 			Email: req.CommitterEmail,
-		}, req.Environment, req.Service)
+		}, req.Environment, req.Namespace, req.Service)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
 				logger.Infof("http: rollback cancelled: env '%s' service '%s'", req.Environment, req.Service)
@@ -194,9 +200,17 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 				return
 			}
 			switch errors.Cause(err) {
+			case flow.ErrNamespaceNotAllowedByArtifact:
+				logger.Infof("http: rollback rejcted: env '%s' service '%s': %v", req.Environment, req.Service, err)
+				Error(w, "namespace not allowed by artifact", http.StatusBadRequest)
+				return
 			case git.ErrReleaseNotFound:
 				logger.Infof("http: rollback rejected: env '%s' service '%s': %v", req.Environment, req.Service, err)
 				Error(w, fmt.Sprintf("no release of service '%s' available for rollback in environment '%s'", req.Service, req.Environment), http.StatusBadRequest)
+				return
+			case artifact.ErrFileNotFound:
+				logger.Infof("http: rollback rejected: env '%s' namespace '%s' service '%s': %v", req.Environment, req.Namespace, req.Service, err)
+				Error(w, fmt.Sprintf("no release of service '%s' available for rollback in environment '%s'. Are you missing a namespace?", req.Service, req.Environment), http.StatusBadRequest)
 				return
 			case git.ErrNothingToCommit:
 				logger.Infof("http: rollback rejected: env '%s' service '%s': already rolled back", req.Environment, req.Service)
@@ -208,11 +222,16 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 				return
 			}
 		}
+		var status string
+		if res.NamespaceOverwritten != "" {
+			status = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, res.NamespaceOverwritten)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		err = json.NewEncoder(w).Encode(httpinternal.RollbackResponse{
+			Status:             status,
 			Service:            req.Service,
 			Environment:        req.Environment,
 			PreviousArtifactID: res.Previous,
@@ -350,13 +369,18 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 			invalidBodyError(w)
 			return
 		}
+		// default namespace to environment if it's empty. For most devlopers this
+		// allows them to avoid setting the namespac flag for services.
+		if emptyString(req.Namespace) {
+			req.Namespace = req.Environment
+		}
 
-		logger := log.WithFields("service", req.Service, "req", req)
+		logger := log.WithFields("service", req.Service, "namespace", req.Namespace, "req", req)
 		ctx := r.Context()
-		releaseID, err := flowSvc.Promote(ctx, flow.Actor{
+		result, err := flowSvc.Promote(ctx, flow.Actor{
 			Name:  req.CommitterName,
 			Email: req.CommitterEmail,
-		}, req.Environment, req.Service)
+		}, req.Environment, req.Namespace, req.Service)
 
 		var statusString string
 		if err != nil {
@@ -373,9 +397,13 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 				logger.Infof("http: promote: service '%s' environment '%s': promote rejected: %v", req.Service, req.Environment, err)
 				Error(w, fmt.Sprintf("unknown environment: %s", req.Environment), http.StatusBadRequest)
 				return
+			case flow.ErrNamespaceNotAllowedByArtifact:
+				logger.Infof("http: promote: service '%s' environment '%s': promote rejected: %v", req.Service, req.Environment, err)
+				Error(w, "namespace not allowed by artifact", http.StatusBadRequest)
+				return
 			case artifact.ErrFileNotFound:
 				logger.Infof("http: promote: service '%s' environment '%s': promote rejected: artifact not found", req.Service, req.Environment)
-				Error(w, fmt.Sprintf("artifact not found for service '%s'", req.Service), http.StatusBadRequest)
+				Error(w, fmt.Sprintf("artifact not found for service '%s'. Are you missing a namespace?", req.Service), http.StatusBadRequest)
 				return
 			default:
 				logger.Infof("http: promote: service '%s' environment '%s': promote failed: %v", req.Service, req.Environment, err)
@@ -396,13 +424,17 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 			fromEnvironment = req.Environment
 		}
 
+		if result.NamespaceOverwritten != "" {
+			statusString = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, result.NamespaceOverwritten)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		err = json.NewEncoder(w).Encode(httpinternal.PromoteResponse{
 			Service:         req.Service,
 			FromEnvironment: fromEnvironment,
 			ToEnvironment:   req.Environment,
-			Tag:             releaseID,
+			Tag:             result.ReleaseID,
 			Status:          statusString,
 		})
 		if err != nil {

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -183,7 +183,7 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 			return
 		}
 		// default namespace to environment if it's empty. For most devlopers this
-		// allows them to avoid setting the namespac flag for services.
+		// allows them to avoid setting the namespace flag for requests.
 		if emptyString(req.Namespace) {
 			req.Namespace = req.Environment
 		}
@@ -202,7 +202,7 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 			}
 			switch errors.Cause(err) {
 			case flow.ErrNamespaceNotAllowedByArtifact:
-				logger.Infof("http: rollback rejcted: env '%s' service '%s': %v", req.Environment, req.Service, err)
+				logger.Infof("http: rollback rejected: env '%s' service '%s': %v", req.Environment, req.Service, err)
 				Error(w, "namespace not allowed by artifact", http.StatusBadRequest)
 				return
 			case git.ErrReleaseNotFound:
@@ -210,7 +210,7 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 				Error(w, fmt.Sprintf("no release of service '%s' available for rollback in environment '%s'", req.Service, req.Environment), http.StatusBadRequest)
 				return
 			case artifact.ErrFileNotFound:
-				logger.Infof("http: rollback rejected: env '%s' namespace '%s' service '%s': %v", req.Environment, req.Namespace, req.Service, err)
+				logger.Infof("http: rollback rejected: env '%s' service '%s': %v", req.Environment, req.Service, err)
 				Error(w, fmt.Sprintf("no release of service '%s' available for rollback in environment '%s'. Are you missing a namespace?", req.Service, req.Environment), http.StatusBadRequest)
 				return
 			case git.ErrNothingToCommit:
@@ -371,7 +371,7 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 			return
 		}
 		// default namespace to environment if it's empty. For most devlopers this
-		// allows them to avoid setting the namespac flag for services.
+		// allows them to avoid setting the namespace flag for requests.
 		if emptyString(req.Namespace) {
 			req.Namespace = req.Environment
 		}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -224,8 +224,8 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 			}
 		}
 		var status string
-		if res.NamespaceOverwritten != "" {
-			status = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, res.NamespaceOverwritten)
+		if res.OverwritingNamespace != "" {
+			status = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, res.OverwritingNamespace)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -425,8 +425,8 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 			fromEnvironment = req.Environment
 		}
 
-		if result.NamespaceOverwritten != "" {
-			statusString = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, result.NamespaceOverwritten)
+		if result.OverwritingNamespace != "" {
+			statusString = fmt.Sprintf("Namespace '%s' did not match that of the artifact and was overwritten to '%s'", req.Namespace, result.OverwritingNamespace)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -18,7 +18,8 @@ import (
 )
 
 var (
-	ErrUnknownEnvironment = errors.New("unknown environment")
+	ErrUnknownEnvironment            = errors.New("unknown environment")
+	ErrNamespaceNotAllowedByArtifact = errors.New("namespace not allowed by artifact")
 )
 
 type Service struct {
@@ -53,7 +54,7 @@ type Actor struct {
 	Name  string
 }
 
-func (s *Service) Status(ctx context.Context, service string) (StatusResponse, error) {
+func (s *Service) Status(ctx context.Context, namespace, service string) (StatusResponse, error) {
 	sourceConfigRepoPath, close, err := tempDir("k8s-config-status")
 	if err != nil {
 		return StatusResponse{}, err
@@ -66,7 +67,11 @@ func (s *Service) Status(ctx context.Context, service string) (StatusResponse, e
 		return StatusResponse{}, errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", s.ConfigRepoURL, sourceConfigRepoPath))
 	}
 
-	devSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "dev")
+	devNamespace := namespace
+	if devNamespace == "" {
+		devNamespace = namespace
+	}
+	devSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "dev", devNamespace)
 	if err != nil {
 		cause := errors.Cause(err)
 		if cause != artifact.ErrFileNotFound && cause != artifact.ErrNotParsable && cause != artifact.ErrUnknownFields {
@@ -74,7 +79,11 @@ func (s *Service) Status(ctx context.Context, service string) (StatusResponse, e
 		}
 	}
 
-	stagingSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "staging")
+	stagingNamespace := namespace
+	if stagingNamespace == "" {
+		stagingNamespace = namespace
+	}
+	stagingSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "staging", stagingNamespace)
 	if err != nil {
 		cause := errors.Cause(err)
 		if cause != artifact.ErrFileNotFound && cause != artifact.ErrNotParsable && cause != artifact.ErrUnknownFields {
@@ -82,7 +91,11 @@ func (s *Service) Status(ctx context.Context, service string) (StatusResponse, e
 		}
 	}
 
-	prodSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "prod")
+	prodNamespace := namespace
+	if prodNamespace == "" {
+		prodNamespace = namespace
+	}
+	prodSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "prod", prodNamespace)
 	if err != nil {
 		cause := errors.Cause(err)
 		if cause != artifact.ErrFileNotFound && cause != artifact.ErrNotParsable && cause != artifact.ErrUnknownFields {
@@ -144,24 +157,24 @@ func calculateTotalVulnerabilties(severity string, s artifact.Spec) int64 {
 	return int64(result + 0.5)
 }
 
-func envSpec(root, artifactFileName, service, env string) (artifact.Spec, error) {
-	return artifact.Get(path.Join(releasePath(root, service, env), artifactFileName))
+func envSpec(root, artifactFileName, service, env, namespace string) (artifact.Spec, error) {
+	return artifact.Get(path.Join(releasePath(root, service, env, namespace), artifactFileName))
 }
 
 // sourceSpec returns the Spec of the current release.
-func sourceSpec(root, artifactFileName, service, env string) (artifact.Spec, error) {
+func sourceSpec(root, artifactFileName, service, env, namespace string) (artifact.Spec, error) {
 	var specPath string
 	switch env {
 	case "dev":
 		specPath = path.Join(artifactPath(root, service, "master"), artifactFileName)
 	case "staging":
-		specPath = path.Join(releasePath(root, service, "dev"), artifactFileName)
+		specPath = path.Join(releasePath(root, service, "dev", namespace), artifactFileName)
 	case "prod":
-		specPath = path.Join(releasePath(root, service, "staging"), artifactFileName)
+		specPath = path.Join(releasePath(root, service, "staging", namespace), artifactFileName)
 	default:
 		return artifact.Spec{}, ErrUnknownEnvironment
 	}
-	log.Debugf("Get artifact spec from %s\n", specPath)
+	log.Debugf("Get artifact spec from %s", specPath)
 	return artifact.Get(specPath)
 }
 
@@ -173,8 +186,8 @@ func artifactPath(root, service, branch string) string {
 	return path.Join(root, "artifacts", service, branch)
 }
 
-func releasePath(root, service, env string) string {
-	return path.Join(root, env, "releases", env, service)
+func releasePath(root, service, env, namespace string) string {
+	return path.Join(root, env, "releases", namespace, service)
 }
 
 // PushArtifact pushes an artifact into the configuration repository.
@@ -235,6 +248,7 @@ func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resource
 
 type NotifyReleaseOptions struct {
 	Environment   string
+	Namespace     string
 	Service       string
 	ArtifactID    string
 	Squad         string
@@ -271,6 +285,7 @@ func (s *Service) notifyRelease(opts NotifyReleaseOptions) error {
 
 	log.WithFields("service", opts.Service,
 		"environment", opts.Environment,
+		"namespace", opts.Namespace,
 		"artifact-id", opts.ArtifactID,
 		"commit-message", opts.CommitMessage,
 		"commit-author", opts.CommitAuthor,

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -46,7 +46,7 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 	env := matches[1]
 	service := matches[2]
 
-	sourceSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, env)
+	sourceSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, env, event.Namespace)
 	if err != nil {
 		return errors.WithMessage(err, "locate source spec")
 	}

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -35,92 +35,117 @@ import (
 //
 // Copy artifacts from the current release into the new environment and commit
 // the changes
-func (s *Service) Promote(ctx context.Context, actor Actor, environment, service string) (string, error) {
+func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespace, service string) (PromoteResult, error) {
 	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-promote-source")
 	if err != nil {
-		return "", err
+		return PromoteResult{}, err
 	}
 	defer closeSource()
 	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-promote-destination")
 	if err != nil {
-		return "", err
+		return PromoteResult{}, err
 	}
 	defer closeDestination()
 	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
 	log.Debugf("Cloning source config repo %s into %s", s.ConfigRepoURL, sourceConfigRepoPath)
 	sourceRepo, err := git.Clone(ctx, s.ConfigRepoURL, sourceConfigRepoPath, s.SSHPrivateKeyPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", s.ConfigRepoURL, sourceConfigRepoPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("clone '%s' into '%s'", s.ConfigRepoURL, sourceConfigRepoPath))
 	}
-	sourceSpec, err := sourceSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment)
+
+	// default to environment name for the namespace if none is specified
+	if namespace == "" {
+		namespace = environment
+	}
+	log.Infof("flow: Promote: using namespace '%s'", namespace)
+
+	sourceSpec, err := sourceSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+	}
+
+	// if artifact has no namespace we only allow using the environment as
+	// nameespace.
+	if sourceSpec.Namespace == "" && namespace != environment {
+		return PromoteResult{}, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
+	}
+
+	var result PromoteResult
+	// a developer can mistakenly specify the wrong namespace when promoting and
+	// we will not be able to detect it before this point.
+	// It only affects "dev" promotes as we read from the artifacts here where we
+	// can find the artifact without taking the namespace into account.
+	if sourceSpec.Namespace != "" && namespace != sourceSpec.Namespace {
+		log.Infof("flow: Promote: overwriting namespace '%s' to '%s'", namespace, sourceSpec.Namespace)
+		namespace = sourceSpec.Namespace
+		result.NamespaceOverwritten = sourceSpec.Namespace
 	}
 
 	// find release identifier in artifact.json
-	release := sourceSpec.ID
+	result.ReleaseID = sourceSpec.ID
 	// ckechout commit of release
 	var hash plumbing.Hash
 	// when promoting to dev we use should look for the artifact instead of
 	// release as the artifact have never been released.
 	if environment == "dev" {
-		hash, err = git.LocateArtifact(sourceRepo, release)
+		hash, err = git.LocateArtifact(sourceRepo, result.ReleaseID)
 	} else {
-		hash, err = git.LocateRelease(sourceRepo, release)
+		hash, err = git.LocateRelease(sourceRepo, result.ReleaseID)
 	}
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("locate release '%s' from '%s'", release, s.ConfigRepoURL))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("locate release '%s' from '%s'", result.ReleaseID, s.ConfigRepoURL))
 	}
 	log.Debugf("internal/flow: Promote: release hash '%v'", hash)
 	err = git.Checkout(sourceRepo, hash)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("checkout release hash '%s' from '%s'", hash, s.ConfigRepoURL))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("checkout release hash '%s' from '%s'", hash, s.ConfigRepoURL))
 	}
 
 	destinationRepo, err := git.Clone(ctx, s.ConfigRepoURL, destinationConfigRepoPath, s.SSHPrivateKeyPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("clone destination repo '%s' into '%s'", s.ConfigRepoURL, destinationConfigRepoPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("clone destination repo '%s' into '%s'", s.ConfigRepoURL, destinationConfigRepoPath))
 	}
 
 	// release service to env from original release
 	sourcePath := srcPath(sourceConfigRepoPath, service, "master", environment)
-	destinationPath := releasePath(destinationConfigRepoPath, service, environment)
+	destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
 	log.Debugf("Copy resources from: %s to %s", sourcePath, destinationPath)
 
 	// empty existing resources in destination
 	err = os.RemoveAll(destinationPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
 	}
 	err = os.MkdirAll(destinationPath, os.ModePerm)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
 	}
 	// copy previous env. files into destination
 	err = copy.Copy(sourcePath, destinationPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
 	}
 	// copy artifact spec
 	artifactSourcePath := srcPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
-	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment), s.ArtifactFileName)
+	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 	log.Debugf("Copy artifact from: %s to %s", artifactSourcePath, artifactDestinationPath)
 	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 	}
 
 	authorName := sourceSpec.Application.AuthorName
 	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := git.ReleaseCommitMessage(environment, service, release)
+	releaseMessage := git.ReleaseCommitMessage(environment, service, result.ReleaseID)
 	log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
-	err = git.Commit(ctx, destinationRepo, releasePath(".", service, environment), authorName, authorEmail, actor.Name, actor.Email, releaseMessage, s.SSHPrivateKeyPath)
+	err = git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage, s.SSHPrivateKeyPath)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
 	}
 	err = s.notifyRelease(NotifyReleaseOptions{
 		Service:       service,
 		Environment:   environment,
+		Namespace:     namespace,
 		ArtifactID:    sourceSpec.ID,
 		CommitAuthor:  sourceSpec.Application.AuthorName,
 		CommitMessage: sourceSpec.Application.Message,
@@ -132,5 +157,10 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, service
 		log.Errorf("flow: Promote: error notifying release: %v", err)
 	}
 
-	return release, nil
+	return result, nil
+}
+
+type PromoteResult struct {
+	ReleaseID            string
+	NamespaceOverwritten string
 }

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -65,7 +65,7 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 	}
 
 	// if artifact has no namespace we only allow using the environment as
-	// nameespace.
+	// namespace.
 	if sourceSpec.Namespace == "" && namespace != environment {
 		return PromoteResult{}, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
 	}

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -78,7 +78,7 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 	if sourceSpec.Namespace != "" && namespace != sourceSpec.Namespace {
 		log.Infof("flow: Promote: overwriting namespace '%s' to '%s'", namespace, sourceSpec.Namespace)
 		namespace = sourceSpec.Namespace
-		result.NamespaceOverwritten = sourceSpec.Namespace
+		result.OverwritingNamespace = sourceSpec.Namespace
 	}
 
 	// find release identifier in artifact.json
@@ -162,5 +162,5 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 
 type PromoteResult struct {
 	ReleaseID            string
-	NamespaceOverwritten string
+	OverwritingNamespace string
 }

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -15,7 +15,7 @@ import (
 type RollbackResult struct {
 	Previous             string
 	New                  string
-	NamespaceOverwritten string
+	OverwritingNamespace string
 }
 
 func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namespace, service string) (RollbackResult, error) {
@@ -69,7 +69,7 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 	if currentSpec.Namespace != "" && namespace != currentSpec.Namespace {
 		log.Infof("flow: Rollback: overwriting namespace '%s' to '%s'", namespace, currentSpec.Namespace)
 		namespace = currentSpec.Namespace
-		result.NamespaceOverwritten = currentSpec.Namespace
+		result.OverwritingNamespace = currentSpec.Namespace
 	}
 	// locate new release (the previous released artifact for this service)
 	newHash, err := git.LocateServiceReleaseRollbackSkip(r, environment, service, 1)

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -56,7 +56,7 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 	}
 
 	// if artifact has no namespace we only allow using the environment as
-	// nameespace.
+	// namespace.
 	if currentSpec.Namespace == "" && namespace != environment {
 		return RollbackResult{}, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
 	}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -24,6 +24,7 @@ type Environment struct {
 
 type PromoteRequest struct {
 	Service        string `json:"service,omitempty"`
+	Namespace      string `json:"namespace,omitempty"`
 	Environment    string `json:"environment,omitempty"`
 	CommitterName  string `json:"committerName,omitempty"`
 	CommitterEmail string `json:"committerEmail,omitempty"`
@@ -124,6 +125,7 @@ type DeletePolicyResponse struct {
 
 type RollbackRequest struct {
 	Service        string `json:"service,omitempty"`
+	Namespace      string `json:"namespace,omitempty"`
 	Environment    string `json:"environment,omitempty"`
 	CommitterName  string `json:"committerName,omitempty"`
 	CommitterEmail string `json:"committerEmail,omitempty"`
@@ -131,6 +133,7 @@ type RollbackRequest struct {
 
 type RollbackResponse struct {
 	Service            string `json:"service,omitempty"`
+	Status             string `json:"status,omitempty"`
 	Environment        string `json:"environment,omitempty"`
 	PreviousArtifactID string `json:"previousArtifactId,omitempty"`
 	NewArtifactID      string `json:"newArtifactId,omitempty"`

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -5,9 +5,10 @@ type StatusRequest struct {
 }
 
 type StatusResponse struct {
-	Dev     *Environment `json:"dev,omitempty"`
-	Staging *Environment `json:"staging,omitempty"`
-	Prod    *Environment `json:"prod,omitempty"`
+	DefaultNamespaces bool         `json:"defaultNamespaces,omitempty"`
+	Dev               *Environment `json:"dev,omitempty"`
+	Staging           *Environment `json:"staging,omitempty"`
+	Prod              *Environment `json:"prod,omitempty"`
 }
 
 type Environment struct {


### PR DESCRIPTION
This change adds support for custom namespaces for deployments.
Previously we used the environment for namespaces always, but this change allows users and artifacts to specify what namespace we release to.

We still fallback to a namespace named after the environment if non is
specified.

`status` will report if it is looking in default namespaces and a message if we cannot find any managed releases for the used namespace.

This change also fixes the `git.BranchFromHead()`. It was mistakenly looking into all files in the Git tree instead of only the changes on the current HEAD commit.

Lastly a `fmt.Printf()` is removed from `flow. ReleaseArtifactID()` that was mistakenly added in #59.