### PR TITLE
Look for namespace under k8s.namespace

### DIFF
--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -16,7 +16,7 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 		Short: "Promote a service to a specific environment following promoting conventions.",
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
-				return s.Vars.Namespace
+				return s.Vars.K8S.Namespace
 			})
 		},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -27,7 +27,7 @@ has no effect.`,
   hamctl rollback --service product --env dev`,
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
-				return s.Vars.Namespace
+				return s.Vars.K8S.Namespace
 			})
 		},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -58,8 +58,10 @@ type shuttleSpec struct {
 }
 
 type shuttleSpecVars struct {
-	Service   string `yaml:"service"`
-	Namespace string `yaml:"namespace"`
+	Service string `yaml:"service"`
+	K8S     struct {
+		Namespace string `yaml:"namespace"`
+	} `yaml:"k8s"`
 }
 
 // shuttleSpecFromFile tries to read a shuttle specification.

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -18,7 +18,7 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 		Short: "List the status of the environments",
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
-				return s.Vars.Namespace
+				return s.Vars.K8S.Namespace
 			})
 		},
 		RunE: func(c *cobra.Command, args []string) error {


### PR DESCRIPTION
Before it looked in the root of `vars`, but it should be `k8s.namespace`.