### PR TITLE
Add debug logging of artifact resources on push

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -206,7 +206,7 @@ func Commit(ctx context.Context, repo *git.Repository, changesPath, authorName, 
 	if err != nil {
 		return errors.WithMessage(err, "status")
 	}
-
+	log.Infof("internal/git: Commit status:\n%s", status)
 	// if commit is empty
 	if status.IsClean() {
 		log.Debugf("internal/git: Commit: message '%s': nothing to commit", msg)


### PR DESCRIPTION
This allows for simpler debugging in the pipelines when using artifact.

A push command will output something like this.

```
$ artifact push --root .shuttle/temp/k8s-config --config-repo git@***/cluster-config.git --ssh-private-key ***

Checkout config repository from 'git@***/cluster-config.git' into '.shuttle/temp/k8s-config'
Files in path '.shuttle/temp/k8s-config'
  .shuttle/temp/k8s-config
  .shuttle/temp/k8s-config/artifact.json
  .shuttle/temp/k8s-config/dev
  .shuttle/temp/k8s-config/dev/40-deployment.yaml
  .shuttle/temp/k8s-config/dev/50-service.yaml
  .shuttle/temp/k8s-config/dev/60-ingress.yaml
  .shuttle/temp/k8s-config/prod
  .shuttle/temp/k8s-config/prod/40-deployment.yaml
  .shuttle/temp/k8s-config/prod/50-service.yaml
  .shuttle/temp/k8s-config/prod/60-ingress.yaml
  .shuttle/temp/k8s-config/staging
Artifacts destination '/var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master'
Files in path '/var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master'
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/artifact.json
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/40-deployment.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/50-service.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/60-ingress.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/message.json
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/40-deployment.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/50-service.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/60-ingress.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/staging
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/staging/40-deployment.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/staging/50-service.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/staging/60-ingress.yaml
Removing existing files
Copy configuration into destination
Files in path '/var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master'
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/artifact.json
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/40-deployment.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/50-service.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/dev/60-ingress.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/40-deployment.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/50-service.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/prod/60-ingress.yaml
  /var/folders/6v/g99pz09s29jft5n1j4ry_tqh0000gn/T/k8s-config-artifact944665601/artifacts/crashlytics2humio/master/staging
Committing changes
internal/git: Commit status:
M  artifacts/crashlytics2humio/master/artifact.json
 D artifacts/crashlytics2humio/master/message.json
 D artifacts/crashlytics2humio/master/staging/40-deployment.yaml
 D artifacts/crashlytics2humio/master/staging/50-service.yaml
 D artifacts/crashlytics2humio/master/staging/60-ingress.yaml
```