### PR TITLE
Commit deleted files

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -214,6 +214,7 @@ func Commit(ctx context.Context, repo *git.Repository, changesPath, authorName, 
 	}
 
 	_, err = w.Commit(msg, &git.CommitOptions{
+		All: true,
 		Author: &object.Signature{
 			Name:  authorName,
 			Email: authorEmail,


### PR DESCRIPTION
When commiting files to Git we currently ignore deleted files.
This introduces a subtle bug where removing some resources are not
reflected in the config repository.

This will then become stale files that are never updated nor removed on
future releases.