### PR TITLE
Add service context output to hamctl commands

### DIFF
--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -40,6 +40,7 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			fmt.Printf("Promote service: %s\n", *service)
 			if resp.Status != "" {
 				fmt.Printf("%s\n", resp.Status)
 			} else {

--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -49,6 +49,7 @@ Release latest artifact from branch 'master' of service 'product' into environme
 			if err != nil {
 				return err
 			}
+			fmt.Printf("Release of service: %s\n", *service)
 			if resp.Status != "" {
 				fmt.Printf("%s\n", resp.Status)
 			} else {

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -50,6 +50,7 @@ has no effect.`,
 			if err != nil {
 				return err
 			}
+			fmt.Printf("Rollback of service: %s\n", *service)
 			if resp.Status != "" {
 				fmt.Printf("%s\n", resp.Status)
 			}

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -43,6 +43,7 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 				}
 				fmt.Printf("Are you setting the right namespace?\n")
 			}
+			fmt.Printf("Status for service: %s\n", *service)
 			fmt.Printf("\n")
 			color.Green("dev:\n")
 			printStatus(resp.Dev)


### PR DESCRIPTION
This adds context to the output of commands so the users are not in
doubt of what service name is used.

This is a feature request from users.

Output is generally like below example:

```
$ hamctl status
Status for service: release-manager

dev:
  ...

staging:
  ...

prod:
  ...
```