### PR TITLE
Use temporary path for policy functions

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -57,7 +57,7 @@ type Actor struct {
 }
 
 func (s *Service) Status(ctx context.Context, namespace, service string) (StatusResponse, error) {
-	sourceConfigRepoPath, close, err := tempDir("k8s-config-status")
+	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-status")
 	if err != nil {
 		return StatusResponse{}, err
 	}
@@ -206,7 +206,7 @@ func PushArtifact(ctx context.Context, configRepoURL, artifactFileName, resource
 	if err != nil {
 		return "", errors.WithMessagef(err, "path '%s'", artifactSpecPath)
 	}
-	artifactConfigRepoPath, close, err := tempDir("k8s-config-artifact")
+	artifactConfigRepoPath, close, err := git.TempDir("k8s-config-artifact")
 	if err != nil {
 		return "", err
 	}

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequest) error {
-	sourceConfigRepoPath, close, err := tempDir("k8s-config-notify")
+	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-notify")
 	if err != nil {
 		return err
 	}

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -36,12 +36,12 @@ import (
 // Copy artifacts from the current release into the new environment and commit
 // the changes
 func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespace, service string) (PromoteResult, error) {
-	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-promote-source")
+	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-promote-source")
 	if err != nil {
 		return PromoteResult{}, err
 	}
 	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-promote-destination")
+	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-promote-destination")
 	if err != nil {
 		return PromoteResult{}, err
 	}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -23,7 +23,7 @@ import (
 //
 // Copy artifacts from the artifacts into the environment and commit the changes.
 func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, service, branch string) (string, error) {
-	sourceConfigRepoPath, close, err := tempDir("k8s-config-release-branch")
+	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-release-branch")
 	if err != nil {
 		return "", err
 	}
@@ -112,12 +112,12 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 // Copy resources from the artifact commit into the environment and commit
 // the changes
 func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environment, service, artifactID string) (string, error) {
-	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-release-artifact-source")
+	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-release-artifact-source")
 	if err != nil {
 		return "", err
 	}
 	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-release-artifact-destination")
+	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-release-artifact-destination")
 	if err != nil {
 		return "", err
 	}

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -19,12 +19,12 @@ type RollbackResult struct {
 }
 
 func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namespace, service string) (RollbackResult, error) {
-	sourceConfigRepoPath, closeSource, err := tempDir("k8s-config-rollback-source")
+	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-rollback-source")
 	if err != nil {
 		return RollbackResult{}, err
 	}
 	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := tempDir("k8s-config-rollback-destination")
+	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-rollback-destination")
 	if err != nil {
 		return RollbackResult{}, err
 	}

--- a/internal/git/temp_dir.go
+++ b/internal/git/temp_dir.go
@@ -1,4 +1,4 @@
-package flow
+package git
 
 import (
 	"io/ioutil"
@@ -7,7 +7,10 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 )
 
-func tempDir(prefix string) (string, func(), error) {
+// TempDir returns a temporary directory with provided prefix.
+// The first return argument is the path. The second is a close function to
+// remove the path.
+func TempDir(prefix string) (string, func(), error) {
 	path, err := ioutil.TempDir("", prefix)
 	if err != nil {
 		return "", func() {}, err


### PR DESCRIPTION
This expands on the setup of the flow package where each function call
creates a new temporary directory to stor the repository contents in.