### PR TITLE
Add git.Service struct

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -6,17 +6,18 @@ import (
 	"path"
 
 	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/spf13/cobra"
 )
 
 func pushCommand(options *Options) *cobra.Command {
-	var configGitRepo, sshPrivateKeyPath string
+	var gitSvc git.Service
 	command := &cobra.Command{
 		Use:   "push",
 		Short: "push artifact to a configuration repository",
 		RunE: func(c *cobra.Command, args []string) error {
-			artifactId, err := flow.PushArtifact(context.Background(), configGitRepo, options.FileName, options.RootPath, sshPrivateKeyPath)
+			artifactId, err := flow.PushArtifact(context.Background(), &gitSvc, options.FileName, options.RootPath)
 			if err != nil {
 				return err
 			}
@@ -36,9 +37,9 @@ func pushCommand(options *Options) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&sshPrivateKeyPath, "ssh-private-key", "", "private key for the config repo")
+	command.Flags().StringVar(&gitSvc.SSHPrivateKeyPath, "ssh-private-key", "", "private key for the config repo")
 	command.MarkFlagRequired("ssh-private-key")
-	command.Flags().StringVar(&configGitRepo, "config-repo", "", "ssh url for the git config repository")
+	command.Flags().StringVar(&gitSvc.ConfigRepoURL, "config-repo", "", "ssh url for the git config repository")
 	command.MarkFlagRequired("config-repo")
 	return command
 }

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lunarway/release-manager/cmd/server/http"
 	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/grafana"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/policy"
@@ -56,17 +57,19 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 					},
 				},
 			}
-			flowSvc := flow.Service{
-				ConfigRepoURL:     configRepoOpts.ConfigRepo,
-				ArtifactFileName:  configRepoOpts.ArtifactFileName,
+			gitSvc := git.Service{
 				SSHPrivateKeyPath: configRepoOpts.SSHPrivateKeyPath,
-				UserMappings:      userMappings,
-				Slack:             slackClient,
-				Grafana:           &grafana,
+				ConfigRepoURL:     configRepoOpts.ConfigRepo,
+			}
+			flowSvc := flow.Service{
+				ArtifactFileName: configRepoOpts.ArtifactFileName,
+				UserMappings:     userMappings,
+				Slack:            slackClient,
+				Grafana:          &grafana,
+				Git:              &gitSvc,
 			}
 			policySvc := policy.Service{
-				ConfigRepoURL:     configRepoOpts.ConfigRepo,
-				SSHPrivateKeyPath: configRepoOpts.SSHPrivateKeyPath,
+				Git: &gitSvc,
 			}
 			go func() {
 				err := http.NewServer(httpOpts, slackClient, &flowSvc, &policySvc)

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -18,20 +18,20 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 		return err
 	}
 	defer close()
-	sourceRepo, err := git.Clone(ctx, s.ConfigRepoURL, sourceConfigRepoPath, s.SSHPrivateKeyPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
 	if err != nil {
-		return errors.WithMessagef(err, "clone '%s' into '%s'", s.ConfigRepoURL, sourceConfigRepoPath)
+		return errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
 	}
 
-	hash, err := git.LocateEnvRelease(sourceRepo, event.Environment, event.ArtifactID)
+	hash, err := s.Git.LocateEnvRelease(sourceRepo, event.Environment, event.ArtifactID)
 	if err != nil {
-		return errors.WithMessagef(err, "locate release '%s' from '%s'", event.ArtifactID, s.ConfigRepoURL)
+		return errors.WithMessagef(err, "locate release '%s'", event.ArtifactID)
 	}
 	log.Infof("internal/flow: NotifyCommitter: located release of '%s' on hash '%s'", event.ArtifactID, hash)
 
-	err = git.Checkout(sourceRepo, hash)
+	err = s.Git.Checkout(sourceRepo, hash)
 	if err != nil {
-		return errors.WithMessagef(err, "checkout release hash '%s' from '%s'", hash, s.ConfigRepoURL)
+		return errors.WithMessagef(err, "checkout release hash '%s'", hash)
 	}
 
 	commit, err := sourceRepo.CommitObject(hash)


### PR DESCRIPTION
Changes most functions in package git to methods on the git.Service
struct.

This allows for easier testing and reduces the number of pass-through.