### PR TITLE
Reduce config repo clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ github-webhook:
 		} \
 	}' \
 	localhost:8080/webhook/github
+	
+hamctl-status:
+	curl -X GET \
+	-H 'Content-Type: application/json' \
+	-H 'Authorization: Bearer test' \
+	"localhost:8080/status?service=a"
 
 daemon-webhook-success:
 	curl -X POST \

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -17,6 +17,11 @@ func pushCommand(options *Options) *cobra.Command {
 		Use:   "push",
 		Short: "push artifact to a configuration repository",
 		RunE: func(c *cobra.Command, args []string) error {
+			close, err := gitSvc.InitMasterRepo()
+			if err != nil {
+				return err
+			}
+			defer close()
 			artifactId, err := flow.PushArtifact(context.Background(), &gitSvc, options.FileName, options.RootPath)
 			if err != nil {
 				return err

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -61,6 +61,11 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 				SSHPrivateKeyPath: configRepoOpts.SSHPrivateKeyPath,
 				ConfigRepoURL:     configRepoOpts.ConfigRepo,
 			}
+			close, err := gitSvc.InitMasterRepo()
+			if err != nil {
+				return err
+			}
+			defer close()
 			flowSvc := flow.Service{
 				ArtifactFileName: configRepoOpts.ArtifactFileName,
 				UserMappings:     userMappings,
@@ -72,7 +77,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 				Git: &gitSvc,
 			}
 			go func() {
-				err := http.NewServer(httpOpts, slackClient, &flowSvc, &policySvc)
+				err := http.NewServer(httpOpts, slackClient, &flowSvc, &policySvc, &gitSvc)
 				if err != nil {
 					done <- errors.WithMessage(err, "new http server")
 					return

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -213,7 +213,7 @@ func PushArtifact(ctx context.Context, gitSvc *git.Service, artifactFileName, re
 	// fmt.Printf is used for logging as this is called from artifact cli only
 	fmt.Printf("Checkout config repository from '%s' into '%s'\n", gitSvc.ConfigRepoURL, resourceRoot)
 	listFiles(resourceRoot)
-	repo, err := gitSvc.CloneDepth(context.Background(), artifactConfigRepoPath, 1)
+	repo, err := gitSvc.Clone(context.Background(), artifactConfigRepoPath)
 	if err != nil {
 		return "", errors.WithMessage(err, "clone config repo")
 	}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -28,7 +28,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		return "", err
 	}
 	defer close()
-	repo, err := s.Git.CloneDepth(ctx, sourceConfigRepoPath, 1)
+	repo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
 	if err != nil {
 		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
 	}

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -87,7 +87,7 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 	}
 
 	// copy current release artifacts into env
-	destinationRepo, err := s.Git.CloneDepth(ctx, destinationConfigRepoPath, 1)
+	destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
 	if err != nil {
 		return RollbackResult{}, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -89,7 +89,10 @@ func (s *Service) SyncMaster() error {
 	err = s.master.Fetch(&git.FetchOptions{
 		Auth: authSSH,
 	})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
+	if err != nil {
+		if err == git.NoErrAlreadyUpToDate {
+			return nil
+		}
 		return errors.WithMessage(err, "fetch changes")
 	}
 	w, err := s.master.Worktree()
@@ -100,6 +103,9 @@ func (s *Service) SyncMaster() error {
 		Auth: authSSH,
 	})
 	if err != nil {
+		if err == git.NoErrAlreadyUpToDate {
+			return nil
+		}
 		return errors.WithMessage(err, "pull latest")
 	}
 	return nil

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -59,7 +59,7 @@ func (s *Service) Get(ctx context.Context, svc string) (Policies, error) {
 		return Policies{}, err
 	}
 	defer close()
-	_, err = s.Git.CloneDepth(ctx, configRepoPath, 1)
+	_, err = s.Git.Clone(ctx, configRepoPath)
 	if err != nil {
 		return Policies{}, errors.WithMessage(err, fmt.Sprintf("clone to path '%s'", configRepoPath))
 	}
@@ -130,7 +130,7 @@ func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMs
 	// file flags used. This is to avoid opening and closing to file multiple
 	// times during the operation.
 	log.Debugf("internal/policy: clone config repository")
-	repo, err := s.Git.CloneDepth(ctx, configRepoPath, 1)
+	repo, err := s.Git.Clone(ctx, configRepoPath)
 	if err != nil {
 		return errors.WithMessage(err, fmt.Sprintf("clone to '%s'", configRepoPath))
 	}


### PR DESCRIPTION
Instead of cloning the config repo on every git command we keep a
"master"  repo up to date with GitHub webhooks and then copy that on
every git command.

This greatly reduces response times for the `hamctl` commands.

**The new behaviour is this**

Config repo is cloned into a "master" directory on startup.
On GitHub webhooks, we fetch and pull latest changes.

On Git operations, we copy the current "master" repo into a new destination and perform the git operations there.

There is a mutex guarding for updates from the sync and commands, so we should avoid races when a webhook is pulling changes and a copy is done in the middle of it.