### PR TITLE
Configurable logging with flags and environment variables

### DIFF
--- a/cmd/artifact/main.go
+++ b/cmd/artifact/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lunarway/release-manager/internal/log"
-
 	"github.com/lunarway/release-manager/cmd/artifact/command"
+	"github.com/lunarway/release-manager/internal/log"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -15,7 +15,12 @@ var (
 )
 
 func main() {
-	log.Init()
+	log.Init(&log.Configuration{
+		Level: log.Level{
+			Level: zapcore.DebugLevel,
+		},
+		Development: false,
+	})
 	c, err := command.NewCommand()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -16,10 +16,13 @@ import (
 
 func StartDaemon() *cobra.Command {
 	var authToken, releaseManagerUrl, environment string
+	var logConfiguration *log.Configuration
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "start the release-daemon",
 		RunE: func(c *cobra.Command, args []string) error {
+			logConfiguration.ParseFromEnvironmnet()
+			log.Init(logConfiguration)
 			kubectl, err := kubernetes.NewClient()
 			if err != nil {
 				return err
@@ -55,6 +58,7 @@ func StartDaemon() *cobra.Command {
 	command.Flags().StringVar(&authToken, "auth-token", os.Getenv("DAEMON_AUTH_TOKEN"), "token to be used to communicate with the release-manager")
 	command.Flags().StringVar(&environment, "environment", "", "environment where release-daemon is running")
 	command.MarkFlagRequired("environment")
+	logConfiguration = log.RegisterFlags(command)
 	return command
 }
 

--- a/cmd/daemon/kubernetes/kubernetes_test.go
+++ b/cmd/daemon/kubernetes/kubernetes_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +56,12 @@ func TestParseToJSONLogs(t *testing.T) {
 }
 
 func TestStatusNotifier(t *testing.T) {
-	log.Init()
+	log.Init(&log.Configuration{
+		Level: log.Level{
+			Level: zapcore.DebugLevel,
+		},
+		Development: true,
+	})
 	testCases := []struct {
 		desc          string
 		input         watch.Event

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/daemon/command"
-	"github.com/lunarway/release-manager/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +13,6 @@ var (
 )
 
 func main() {
-	log.Init()
 	c, err := command.DaemonCommand()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lunarway/release-manager/cmd/server/http"
+	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/spf13/cobra"
 )
@@ -18,6 +19,7 @@ func NewCommand() (*cobra.Command, error) {
 	var configRepoOpts configRepoOptions
 	var users []string
 	var userMappings map[string]string
+	var logConfiguration *log.Configuration
 
 	var command = &cobra.Command{
 		Use:   "server",
@@ -32,6 +34,8 @@ func NewCommand() (*cobra.Command, error) {
 			if err != nil {
 				return err
 			}
+			logConfiguration.ParseFromEnvironmnet()
+			log.Init(logConfiguration)
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {
@@ -55,6 +59,7 @@ func NewCommand() (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&grafanaOpts.StagingURL, "grafana-staging-url", os.Getenv("GRAFANA_STAGING_URL"), "grafana staging url")
 	command.PersistentFlags().StringVar(&grafanaOpts.ProdURL, "grafana-prod-url", os.Getenv("GRAFANA_PROD_URL"), "grafana prod url")
 	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
+	logConfiguration = log.RegisterFlags(command)
 
 	return command, nil
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/server/command"
-	"github.com/lunarway/release-manager/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +13,6 @@ var (
 )
 
 func main() {
-	log.Init()
 	c, err := command.NewCommand()
 	if err != nil {
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0

--- a/internal/log/configuration.go
+++ b/internal/log/configuration.go
@@ -1,0 +1,115 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Init initializes the global logger with proided level.
+//
+// Default level is zapcore.InfoLevel and non-development.
+func Init(c *Configuration) {
+	if c == nil {
+		c = &Configuration{}
+	}
+	fmt.Printf("Config: %+v\n", *c)
+	encoder := zapcore.EncoderConfig{
+		TimeKey:        "@timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "message",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+	config := zap.Config{
+		Level:            zap.NewAtomicLevelAt(c.Level.Level),
+		Development:      false,
+		Encoding:         "json",
+		EncoderConfig:    encoder,
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+	if c.Development {
+		config.Development = true
+		config.Encoding = "console"
+		config.EncoderConfig.TimeKey = ""
+	}
+	zapLogger, _ := config.Build(zap.AddCallerSkip(2))
+	logger = &Logger{sugar: zapLogger.Sugar()}
+}
+
+// Configuration represents a log configuration.
+type Configuration struct {
+	Level       Level
+	Development bool
+}
+
+// ParseFromEnvironmnet parses configuration from the environment and writes
+// found values to configuration struct c.
+func (c *Configuration) ParseFromEnvironmnet() {
+	if c == nil {
+		c = &Configuration{}
+	}
+	parseEnvLevel(c)
+	parseEnvDevelopment(c)
+}
+
+func parseEnvLevel(c *Configuration) {
+	l, ok := os.LookupEnv("LOG_LEVEL")
+	if !ok {
+		return
+	}
+	var level zapcore.Level
+	err := level.Set(l)
+	if err != nil {
+		fmt.Printf("internal/log: failed to parse LOG_LEVEL: %v\n", err)
+		return
+	}
+	c.Level = Level{
+		Level: level,
+	}
+}
+
+func parseEnvDevelopment(c *Configuration) {
+	d, ok := os.LookupEnv("LOG_DEVELOPMENT")
+	if !ok {
+		return
+	}
+	development, err := strconv.ParseBool(d)
+	if err != nil {
+		fmt.Printf("internal/log: failed to parse LOG_DEVELOPMENT '%s' as bool\n", d)
+		return
+	}
+	c.Development = development
+}
+
+// RegisterFlags registers logging configuration flags on command cmd and
+// returns pointers to the values.
+func RegisterFlags(cmd *cobra.Command) *Configuration {
+	var c Configuration
+	cmd.PersistentFlags().Var(&c.Level, "log.level", "configure log level. Available values are \"debug\", \"info\", \"error\" (fallback to LOG_LEVEL)")
+	cmd.PersistentFlags().BoolVar(&c.Development, "log.development", false, "configure log for development with human readable output (fallback to LOG_DEVELOPMENT)")
+	return &c
+}
+
+var _ pflag.Value = &Level{}
+
+// Level is a wrapped zapcore.Level that implements the pflag.Value interface.
+type Level struct {
+	zapcore.Level
+}
+
+func (*Level) Type() string {
+	return "string"
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var logger *Logger
@@ -10,22 +9,6 @@ var logger *Logger
 // Logger is a general structured logger.
 type Logger struct {
 	sugar *zap.SugaredLogger
-}
-
-func Init() {
-	config := zap.NewProductionConfig()
-	config.EncoderConfig.TimeKey = "@timestamp"
-	config.EncoderConfig.MessageKey = "message"
-	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	config.EncoderConfig.LevelKey = "level"
-	config.EncoderConfig.CallerKey = "caller"
-	config.EncoderConfig.StacktraceKey = "stacktrace"
-	config.EncoderConfig.LineEnding = zapcore.DefaultLineEnding
-	config.EncoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
-	config.EncoderConfig.EncodeDuration = zapcore.SecondsDurationEncoder
-	config.EncoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
-	zapLogger, _ := config.Build(zap.AddCallerSkip(2))
-	logger = &Logger{sugar: zapLogger.Sugar()}
 }
 
 // WithFields returns a logger with custom structured fields added to the 'fields' key in the log entries.


### PR DESCRIPTION
Flags `log.level` and `log.development` are read on start and fallback to `LOG_LEVEL` and `LOG_DEVELOPMENT` is implemented.