### PR TITLE
send reference to userMappings instead, and dereference in start instead

### DIFF
--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -42,7 +42,7 @@ func NewCommand() (*cobra.Command, error) {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewStart(&grafanaOpts, &slackAuthToken, &configRepoOpts, &httpOpts, userMappings))
+	command.AddCommand(NewStart(&grafanaOpts, &slackAuthToken, &configRepoOpts, &httpOpts, &userMappings))
 	command.PersistentFlags().IntVar(&httpOpts.Port, "http-port", 8080, "port of the http server")
 	command.PersistentFlags().DurationVar(&httpOpts.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
 	command.PersistentFlags().StringVar(&httpOpts.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -31,13 +31,13 @@ type configRepoOptions struct {
 	SSHPrivateKeyPath string
 }
 
-func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpts *configRepoOptions, httpOpts *http.Options, userMappings map[string]string) *cobra.Command {
+func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpts *configRepoOptions, httpOpts *http.Options, userMappings *map[string]string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "start",
 		Short: "start the release-manager",
 		RunE: func(c *cobra.Command, args []string) error {
 			done := make(chan error, 1)
-			slackClient, err := slack.NewClient(*slackAuthToken, userMappings)
+			slackClient, err := slack.NewClient(*slackAuthToken, *userMappings)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 			defer close()
 			flowSvc := flow.Service{
 				ArtifactFileName: configRepoOpts.ArtifactFileName,
-				UserMappings:     userMappings,
+				UserMappings:     *userMappings,
 				Slack:            slackClient,
 				Grafana:          &grafana,
 				Git:              &gitSvc,

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -23,7 +23,7 @@ var (
 )
 
 func NewClient(token string, emailMappings map[string]string) (*Client, error) {
-	log.Infof("slack; new client; initialized with emailMappings: %+v", emailMappings)
+	log.Infof("slack: new client: initialized with emailMappings: %+v", emailMappings)
 	slackClient := slack.New(token)
 	client := Client{
 		client:        slackClient,

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -23,6 +23,7 @@ var (
 )
 
 func NewClient(token string, emailMappings map[string]string) (*Client, error) {
+	log.Infof("slack; new client; initialized with emailMappings: %+v", emailMappings)
 	slackClient := slack.New(token)
 	client := Client{
 		client:        slackClient,


### PR DESCRIPTION
This PR fixes the problem of userMappings not being parsed down the chain to the Slack client. 

