### PR TITLE
Add a message that instructs the user to release manually with hamctl

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -337,7 +337,7 @@ func githubWebhook(flowSvc *flow.Service, policySvc *policyinternal.Service, git
 				if err != nil {
 					if errors.Cause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
-						err := slackClient.NotifySlackPolicyFailed(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s", serviceName, autoRelease.Environment, autoRelease.Branch))
+						err := slackClient.NotifySlackPolicyFailed(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service example --branch master --env dev", serviceName, autoRelease.Environment, autoRelease.Branch))
 						if err != nil {
 							log.Errorf("http: github webhook: auto-release failed: error notifying slack: %v", err)
 						}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -337,7 +337,7 @@ func githubWebhook(flowSvc *flow.Service, policySvc *policyinternal.Service, git
 				if err != nil {
 					if errors.Cause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
-						err := slackClient.NotifySlackPolicyFailed(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service example --branch master --env dev", serviceName, autoRelease.Environment, autoRelease.Branch))
+						err := slackClient.NotifySlackPolicyFailed(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
 						if err != nil {
 							log.Errorf("http: github webhook: auto-release failed: error notifying slack: %v", err)
 						}


### PR DESCRIPTION
This PR outputs a more clear message when an autorelease policy fails. We instruct the user to to a release manually