### PR TITLE
Add retries to all methods that commits

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -13,6 +13,9 @@ import (
 
 func pushCommand(options *Options) *cobra.Command {
 	var gitSvc git.Service
+	// retries for comitting changes into config repo
+	// can be required for racing writes
+	const maxRetries = 5
 	command := &cobra.Command{
 		Use:   "push",
 		Short: "push artifact to a configuration repository",
@@ -22,7 +25,7 @@ func pushCommand(options *Options) *cobra.Command {
 				return err
 			}
 			defer close()
-			artifactId, err := flow.PushArtifact(context.Background(), &gitSvc, options.FileName, options.RootPath)
+			artifactId, err := flow.PushArtifact(context.Background(), &gitSvc, options.FileName, options.RootPath, maxRetries)
 			if err != nil {
 				return err
 			}

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -72,9 +72,15 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, configRepoOpt
 				Slack:            slackClient,
 				Grafana:          &grafana,
 				Git:              &gitSvc,
+				// retries for comitting changes into config repo
+				// can be required for racing writes
+				MaxRetries: 3,
 			}
 			policySvc := policy.Service{
 				Git: &gitSvc,
+				// retries for comitting changes into config repo
+				// can be required for racing writes
+				MaxRetries: 3,
 			}
 			go func() {
 				err := http.NewServer(httpOpts, slackClient, &flowSvc, &policySvc, &gitSvc)

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/lunarway/release-manager/internal/grafana"
-
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/grafana"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/slack"
+	"github.com/lunarway/release-manager/internal/try"
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 )
@@ -29,6 +29,15 @@ type Service struct {
 	Slack            *slack.Client
 	Grafana          *grafana.Service
 	Git              *git.Service
+
+	MaxRetries int
+}
+
+// retry tries the function f until max attempts is reached
+// If f returns a true bool or a nil error retries are stopped and the error is
+// returned.
+func (s *Service) retry(f func(int) (bool, error)) error {
+	return try.Do(s.MaxRetries, f)
 }
 
 type Environment struct {
@@ -199,59 +208,67 @@ func releasePath(root, service, env, namespace string) string {
 //
 // The resourceRoot specifies the path to the artifact files. All files in this
 // path will be pushed.
-func PushArtifact(ctx context.Context, gitSvc *git.Service, artifactFileName, resourceRoot string) (string, error) {
-	artifactSpecPath := path.Join(resourceRoot, artifactFileName)
-	artifactSpec, err := artifact.Get(artifactSpecPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "path '%s'", artifactSpecPath)
-	}
-	artifactConfigRepoPath, close, err := git.TempDir("k8s-config-artifact")
+func PushArtifact(ctx context.Context, gitSvc *git.Service, artifactFileName, resourceRoot string, maxRetries int) (string, error) {
+	var result string
+	err := try.Do(maxRetries, func(int) (bool, error) {
+		artifactSpecPath := path.Join(resourceRoot, artifactFileName)
+		artifactSpec, err := artifact.Get(artifactSpecPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "path '%s'", artifactSpecPath)
+		}
+		artifactConfigRepoPath, close, err := git.TempDir("k8s-config-artifact")
+		if err != nil {
+			return true, err
+		}
+		defer close()
+		// fmt.Printf is used for logging as this is called from artifact cli only
+		fmt.Printf("Checkout config repository from '%s' into '%s'\n", gitSvc.ConfigRepoURL, resourceRoot)
+		listFiles(resourceRoot)
+		repo, err := gitSvc.Clone(context.Background(), artifactConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessage(err, "clone config repo")
+		}
+		destinationPath := artifactPath(artifactConfigRepoPath, artifactSpec.Service, artifactSpec.Application.Branch)
+		fmt.Printf("Artifacts destination '%s'\n", destinationPath)
+		listFiles(destinationPath)
+		fmt.Printf("Removing existing files\n")
+		err = os.RemoveAll(destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		}
+		err = os.MkdirAll(destinationPath, os.ModePerm)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		}
+		fmt.Printf("Copy configuration into destination\n")
+		err = copy.Copy(resourceRoot, destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", resourceRoot, destinationPath))
+		}
+		listFiles(destinationPath)
+		committerName, committerEmail, err := git.CommitterDetails()
+		if err != nil {
+			return true, errors.WithMessage(err, "get committer details")
+		}
+		artifactID := artifactSpec.ID
+		authorName := artifactSpec.Application.AuthorName
+		authorEmail := artifactSpec.Application.AuthorEmail
+		commitMsg := git.ArtifactCommitMessage(artifactSpec.Service, artifactID, authorName)
+		fmt.Printf("Committing changes\n")
+		err = gitSvc.Commit(context.Background(), repo, ".", authorName, authorEmail, committerName, committerEmail, commitMsg)
+		if err != nil {
+			if err == git.ErrNothingToCommit {
+				return true, nil
+			}
+			return false, errors.WithMessage(err, "commit files")
+		}
+		result = artifactSpec.ID
+		return true, nil
+	})
 	if err != nil {
 		return "", err
 	}
-	defer close()
-	// fmt.Printf is used for logging as this is called from artifact cli only
-	fmt.Printf("Checkout config repository from '%s' into '%s'\n", gitSvc.ConfigRepoURL, resourceRoot)
-	listFiles(resourceRoot)
-	repo, err := gitSvc.Clone(context.Background(), artifactConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessage(err, "clone config repo")
-	}
-	destinationPath := artifactPath(artifactConfigRepoPath, artifactSpec.Service, artifactSpec.Application.Branch)
-	fmt.Printf("Artifacts destination '%s'\n", destinationPath)
-	listFiles(destinationPath)
-	fmt.Printf("Removing existing files\n")
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
-	}
-	err = os.MkdirAll(destinationPath, os.ModePerm)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
-	}
-	fmt.Printf("Copy configuration into destination\n")
-	err = copy.Copy(resourceRoot, destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", resourceRoot, destinationPath))
-	}
-	listFiles(destinationPath)
-	committerName, committerEmail, err := git.CommitterDetails()
-	if err != nil {
-		return "", errors.WithMessage(err, "get committer details")
-	}
-	artifactID := artifactSpec.ID
-	authorName := artifactSpec.Application.AuthorName
-	authorEmail := artifactSpec.Application.AuthorEmail
-	commitMsg := git.ArtifactCommitMessage(artifactSpec.Service, artifactID, authorName)
-	fmt.Printf("Committing changes\n")
-	err = gitSvc.Commit(context.Background(), repo, ".", authorName, authorEmail, committerName, committerEmail, commitMsg)
-	if err != nil {
-		if err == git.ErrNothingToCommit {
-			return "", nil
-		}
-		return "", errors.WithMessage(err, "commit files")
-	}
-	return artifactSpec.ID, nil
+	return result, nil
 }
 
 func listFiles(path string) {

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -36,127 +36,134 @@ import (
 // Copy artifacts from the current release into the new environment and commit
 // the changes
 func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespace, service string) (PromoteResult, error) {
-	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-promote-source")
-	if err != nil {
-		return PromoteResult{}, err
-	}
-	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-promote-destination")
-	if err != nil {
-		return PromoteResult{}, err
-	}
-	defer closeDestination()
-	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
-	log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	// default to environment name for the namespace if none is specified
-	if namespace == "" {
-		namespace = environment
-	}
-	log.Infof("flow: Promote: using namespace '%s'", namespace)
-
-	sourceSpec, err := sourceSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
-	}
-
-	// if artifact has no namespace we only allow using the environment as
-	// namespace.
-	if sourceSpec.Namespace == "" && namespace != environment {
-		return PromoteResult{}, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
-	}
-
 	var result PromoteResult
-	// a developer can mistakenly specify the wrong namespace when promoting and
-	// we will not be able to detect it before this point.
-	// It only affects "dev" promotes as we read from the artifacts here where we
-	// can find the artifact without taking the namespace into account.
-	if sourceSpec.Namespace != "" && namespace != sourceSpec.Namespace {
-		log.Infof("flow: Promote: overwriting namespace '%s' to '%s'", namespace, sourceSpec.Namespace)
-		namespace = sourceSpec.Namespace
-		result.OverwritingNamespace = sourceSpec.Namespace
-	}
+	err := s.retry(func(int) (bool, error) {
+		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-promote-source")
+		if err != nil {
+			return true, err
+		}
+		defer closeSource()
+		destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-promote-destination")
+		if err != nil {
+			return true, err
+		}
+		defer closeDestination()
+		// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
+		log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+		sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		}
 
-	// find release identifier in artifact.json
-	result.ReleaseID = sourceSpec.ID
-	// ckechout commit of release
-	var hash plumbing.Hash
-	// when promoting to dev we use should look for the artifact instead of
-	// release as the artifact have never been released.
-	if environment == "dev" {
-		hash, err = s.Git.LocateArtifact(sourceRepo, result.ReleaseID)
-	} else {
-		hash, err = s.Git.LocateRelease(sourceRepo, result.ReleaseID)
-	}
-	if err != nil {
-		return PromoteResult{}, errors.WithMessagef(err, "locate release '%s'", result.ReleaseID)
-	}
-	log.Debugf("internal/flow: Promote: release hash '%v'", hash)
-	err = s.Git.Checkout(sourceRepo, hash)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
+		// default to environment name for the namespace if none is specified
+		if namespace == "" {
+			namespace = environment
+		}
+		log.Infof("flow: Promote: using namespace '%s'", namespace)
 
-	destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
-	}
+		sourceSpec, err := sourceSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+		}
 
-	// release service to env from original release
-	sourcePath := srcPath(sourceConfigRepoPath, service, "master", environment)
-	destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
-	log.Debugf("Copy resources from: %s to %s", sourcePath, destinationPath)
+		// if artifact has no namespace we only allow using the environment as
+		// namespace.
+		if sourceSpec.Namespace == "" && namespace != environment {
+			return true, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
+		}
 
-	// empty existing resources in destination
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
-	}
-	err = os.MkdirAll(destinationPath, os.ModePerm)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
-	}
-	// copy previous env. files into destination
-	err = copy.Copy(sourcePath, destinationPath)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
-	}
-	// copy artifact spec
-	artifactSourcePath := srcPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
-	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	log.Debugf("Copy artifact from: %s to %s", artifactSourcePath, artifactDestinationPath)
-	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
-	}
+		// a developer can mistakenly specify the wrong namespace when promoting and
+		// we will not be able to detect it before this point.
+		// It only affects "dev" promotes as we read from the artifacts here where we
+		// can find the artifact without taking the namespace into account.
+		if sourceSpec.Namespace != "" && namespace != sourceSpec.Namespace {
+			log.Infof("flow: Promote: overwriting namespace '%s' to '%s'", namespace, sourceSpec.Namespace)
+			namespace = sourceSpec.Namespace
+			result.OverwritingNamespace = sourceSpec.Namespace
+		}
 
-	authorName := sourceSpec.Application.AuthorName
-	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := git.ReleaseCommitMessage(environment, service, result.ReleaseID)
-	log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
-	err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
-	if err != nil {
-		return PromoteResult{}, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
-	}
-	err = s.notifyRelease(NotifyReleaseOptions{
-		Service:       service,
-		Environment:   environment,
-		Namespace:     namespace,
-		ArtifactID:    sourceSpec.ID,
-		CommitAuthor:  sourceSpec.Application.AuthorName,
-		CommitMessage: sourceSpec.Application.Message,
-		CommitSHA:     sourceSpec.Application.SHA,
-		CommitLink:    sourceSpec.Application.URL,
-		Releaser:      actor.Name,
+		// find release identifier in artifact.json
+		result.ReleaseID = sourceSpec.ID
+		// ckechout commit of release
+		var hash plumbing.Hash
+		// when promoting to dev we use should look for the artifact instead of
+		// release as the artifact have never been released.
+		if environment == "dev" {
+			hash, err = s.Git.LocateArtifact(sourceRepo, result.ReleaseID)
+		} else {
+			hash, err = s.Git.LocateRelease(sourceRepo, result.ReleaseID)
+		}
+		if err != nil {
+			return true, errors.WithMessagef(err, "locate release '%s'", result.ReleaseID)
+		}
+		log.Debugf("internal/flow: Promote: release hash '%v'", hash)
+		err = s.Git.Checkout(sourceRepo, hash)
+		if err != nil {
+			return true, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		}
+
+		destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
+		}
+
+		// release service to env from original release
+		sourcePath := srcPath(sourceConfigRepoPath, service, "master", environment)
+		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
+		log.Debugf("Copy resources from: %s to %s", sourcePath, destinationPath)
+
+		// empty existing resources in destination
+		err = os.RemoveAll(destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		}
+		err = os.MkdirAll(destinationPath, os.ModePerm)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		}
+		// copy previous env. files into destination
+		err = copy.Copy(sourcePath, destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
+		}
+		// copy artifact spec
+		artifactSourcePath := srcPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
+		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+		log.Debugf("Copy artifact from: %s to %s", artifactSourcePath, artifactDestinationPath)
+		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
+		}
+
+		authorName := sourceSpec.Application.AuthorName
+		authorEmail := sourceSpec.Application.AuthorEmail
+		releaseMessage := git.ReleaseCommitMessage(environment, service, result.ReleaseID)
+		log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
+		if err != nil {
+			// we can see races here where other changes are committed to the master repo
+			// after we cloned. Because of this we retry on any error.
+			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+		}
+		err = s.notifyRelease(NotifyReleaseOptions{
+			Service:       service,
+			Environment:   environment,
+			Namespace:     namespace,
+			ArtifactID:    sourceSpec.ID,
+			CommitAuthor:  sourceSpec.Application.AuthorName,
+			CommitMessage: sourceSpec.Application.Message,
+			CommitSHA:     sourceSpec.Application.SHA,
+			CommitLink:    sourceSpec.Application.URL,
+			Releaser:      actor.Name,
+		})
+		if err != nil {
+			log.Errorf("flow: Promote: error notifying release: %v", err)
+		}
+		return true, nil
 	})
 	if err != nil {
-		log.Errorf("flow: Promote: error notifying release: %v", err)
+		return PromoteResult{}, err
 	}
-
 	return result, nil
 }
 

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -23,83 +23,93 @@ import (
 //
 // Copy artifacts from the artifacts into the environment and commit the changes.
 func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, service, branch string) (string, error) {
-	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-release-branch")
+	var result string
+	err := s.retry(func(int) (bool, error) {
+		sourceConfigRepoPath, close, err := git.TempDir("k8s-config-release-branch")
+		if err != nil {
+			return true, err
+		}
+		defer close()
+		repo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		}
+		// repo/artifacts/{service}/{branch}/{artifactFileName}
+		artifactSpecPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
+		artifactSpec, err := artifact.Get(artifactSpecPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+		}
+		log.Infof("flow: ReleaseBranch: release branch: id '%s'", artifactSpec.ID)
+
+		// default to environment name for the namespace if none is specified
+		namespace := artifactSpec.Namespace
+		if namespace == "" {
+			namespace = environment
+		}
+
+		// release service to env from the artifact path
+		// repo/artifacts/{service}/{branch}/{env}
+		artifactPath := srcPath(sourceConfigRepoPath, service, branch, environment)
+		// repo/{env}/releases/{ns}/{service}
+		destinationPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
+		log.Infof("flow: ReleaseBranch: copy resources from %s to %s", artifactPath, destinationPath)
+
+		// empty existing resources in destination
+		err = os.RemoveAll(destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		}
+		err = os.MkdirAll(destinationPath, os.ModePerm)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		}
+		// copy artifact files into destination
+		err = copy.Copy(artifactPath, destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", artifactPath, destinationPath))
+		}
+		// copy artifact spec
+		// repo/{env}/releases/{ns}/{service}/{artifactFileName}
+		artifactDestinationPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+		log.Infof("flow: ReleaseBranch: copy artifact from %s to %s", artifactSpecPath, artifactDestinationPath)
+		err = copy.Copy(artifactSpecPath, artifactDestinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
+		}
+
+		authorName := artifactSpec.Application.AuthorName
+		authorEmail := artifactSpec.Application.AuthorEmail
+		artifactID := artifactSpec.ID
+		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
+		err = s.Git.Commit(ctx, repo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
+		if err != nil {
+			// we can see races here where other changes are committed to the master repo
+			// after we cloned. Because of this we retry on any error.
+			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+		}
+		err = s.notifyRelease(NotifyReleaseOptions{
+			Service:       service,
+			Environment:   environment,
+			Namespace:     namespace,
+			ArtifactID:    artifactSpec.ID,
+			CommitAuthor:  artifactSpec.Application.AuthorName,
+			CommitMessage: artifactSpec.Application.Message,
+			CommitSHA:     artifactSpec.Application.SHA,
+			CommitLink:    artifactSpec.Application.URL,
+			Releaser:      actor.Name,
+		})
+		if err != nil {
+			log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
+		}
+		result = artifactID
+		log.Infof("flow: ReleaseBranch: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		return true, nil
+	})
 	if err != nil {
 		return "", err
 	}
-	defer close()
-	repo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-	// repo/artifacts/{service}/{branch}/{artifactFileName}
-	artifactSpecPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
-	artifactSpec, err := artifact.Get(artifactSpecPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
-	}
-	log.Infof("flow: ReleaseBranch: release branch: id '%s'", artifactSpec.ID)
-
-	// default to environment name for the namespace if none is specified
-	namespace := artifactSpec.Namespace
-	if namespace == "" {
-		namespace = environment
-	}
-
-	// release service to env from the artifact path
-	// repo/artifacts/{service}/{branch}/{env}
-	artifactPath := srcPath(sourceConfigRepoPath, service, branch, environment)
-	// repo/{env}/releases/{ns}/{service}
-	destinationPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
-	log.Infof("flow: ReleaseBranch: copy resources from %s to %s", artifactPath, destinationPath)
-
-	// empty existing resources in destination
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
-	}
-	err = os.MkdirAll(destinationPath, os.ModePerm)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
-	}
-	// copy artifact files into destination
-	err = copy.Copy(artifactPath, destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", artifactPath, destinationPath))
-	}
-	// copy artifact spec
-	// repo/{env}/releases/{ns}/{service}/{artifactFileName}
-	artifactDestinationPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	log.Infof("flow: ReleaseBranch: copy artifact from %s to %s", artifactSpecPath, artifactDestinationPath)
-	err = copy.Copy(artifactSpecPath, artifactDestinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
-	}
-
-	authorName := artifactSpec.Application.AuthorName
-	authorEmail := artifactSpec.Application.AuthorEmail
-	artifactID := artifactSpec.ID
-	releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
-	err = s.Git.Commit(ctx, repo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
-	}
-	err = s.notifyRelease(NotifyReleaseOptions{
-		Service:       service,
-		Environment:   environment,
-		Namespace:     namespace,
-		ArtifactID:    artifactSpec.ID,
-		CommitAuthor:  artifactSpec.Application.AuthorName,
-		CommitMessage: artifactSpec.Application.Message,
-		CommitSHA:     artifactSpec.Application.SHA,
-		CommitLink:    artifactSpec.Application.URL,
-		Releaser:      actor.Name,
-	})
-	if err != nil {
-		log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
-	}
-	log.Infof("flow: ReleaseBranch: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
-	return artifactID, nil
+	return result, nil
 }
 
 // ReleaseArtifactID releases a specific artifact to environment env.
@@ -112,102 +122,111 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 // Copy resources from the artifact commit into the environment and commit
 // the changes
 func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environment, service, artifactID string) (string, error) {
-	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-release-artifact-source")
-	if err != nil {
-		return "", err
-	}
-	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-release-artifact-destination")
-	if err != nil {
-		return "", err
-	}
-	defer closeDestination()
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
+	var result string
+	err := s.retry(func(int) (bool, error) {
+		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-release-artifact-source")
+		if err != nil {
+			return true, err
+		}
+		defer closeSource()
+		destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-release-artifact-destination")
+		if err != nil {
+			return true, err
+		}
+		defer closeDestination()
+		sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		}
 
-	hash, err := s.Git.LocateArtifact(sourceRepo, artifactID)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate release '%s'", artifactID)
-	}
-	err = s.Git.Checkout(sourceRepo, hash)
-	if err != nil {
-		return "", errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
+		hash, err := s.Git.LocateArtifact(sourceRepo, artifactID)
+		if err != nil {
+			return true, errors.WithMessagef(err, "locate release '%s'", artifactID)
+		}
+		err = s.Git.Checkout(sourceRepo, hash)
+		if err != nil {
+			return true, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		}
 
-	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
-	}
-	sourceSpec, err := artifact.Get(srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName))
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
-	}
+		branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+		if err != nil {
+			return true, errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
+		}
+		sourceSpec, err := artifact.Get(srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName))
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+		}
 
-	log.Infof("flow: ReleaseArtifactID: hash '%s' id '%s'", hash, sourceSpec.ID)
+		log.Infof("flow: ReleaseArtifactID: hash '%s' id '%s'", hash, sourceSpec.ID)
 
-	// default to environment name for the namespace if none is specified
-	namespace := sourceSpec.Namespace
-	if namespace == "" {
-		namespace = environment
-	}
+		// default to environment name for the namespace if none is specified
+		namespace := sourceSpec.Namespace
+		if namespace == "" {
+			namespace = environment
+		}
 
-	destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
-	}
+		destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
+		}
 
-	// release service to env from original release
-	sourcePath := srcPath(sourceConfigRepoPath, service, branch, environment)
-	destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
-	log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
+		// release service to env from original release
+		sourcePath := srcPath(sourceConfigRepoPath, service, branch, environment)
+		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
+		log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
 
-	// empty existing resources in destination
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
-	}
-	err = os.MkdirAll(destinationPath, os.ModePerm)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
-	}
-	// copy previous env. files into destination
-	err = copy.Copy(sourcePath, destinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
-	}
-	// copy artifact spec
-	artifactSourcePath := srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
-	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
-	}
+		// empty existing resources in destination
+		err = os.RemoveAll(destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		}
+		err = os.MkdirAll(destinationPath, os.ModePerm)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		}
+		// copy previous env. files into destination
+		err = copy.Copy(sourcePath, destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
+		}
+		// copy artifact spec
+		artifactSourcePath := srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
+		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+		log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
+		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
+		}
 
-	authorName := sourceSpec.Application.AuthorName
-	authorEmail := sourceSpec.Application.AuthorEmail
-	releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
-	err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
-	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
-	}
-	err = s.notifyRelease(NotifyReleaseOptions{
-		Service:       service,
-		Environment:   environment,
-		Namespace:     namespace,
-		ArtifactID:    sourceSpec.ID,
-		CommitAuthor:  sourceSpec.Application.AuthorName,
-		CommitMessage: sourceSpec.Application.Message,
-		CommitSHA:     sourceSpec.Application.SHA,
-		CommitLink:    sourceSpec.Application.URL,
-		Releaser:      actor.Name,
+		authorName := sourceSpec.Application.AuthorName
+		authorEmail := sourceSpec.Application.AuthorEmail
+		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
+		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
+		if err != nil {
+			// we can see races here where other changes are committed to the master repo
+			// after we cloned. Because of this we retry on any error.
+			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+		}
+		err = s.notifyRelease(NotifyReleaseOptions{
+			Service:       service,
+			Environment:   environment,
+			Namespace:     namespace,
+			ArtifactID:    sourceSpec.ID,
+			CommitAuthor:  sourceSpec.Application.AuthorName,
+			CommitMessage: sourceSpec.Application.Message,
+			CommitSHA:     sourceSpec.Application.SHA,
+			CommitLink:    sourceSpec.Application.URL,
+			Releaser:      actor.Name,
+		})
+		if err != nil {
+			log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
+		}
+		result = artifactID
+		log.Infof("flow: ReleaseArtifactID: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		return true, nil
 	})
 	if err != nil {
-		log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
+		return "", err
 	}
-	log.Infof("flow: ReleaseArtifactID: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
-
-	return artifactID, nil
+	return result, nil
 }

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -19,130 +19,138 @@ type RollbackResult struct {
 }
 
 func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namespace, service string) (RollbackResult, error) {
-	sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-rollback-source")
-	if err != nil {
-		return RollbackResult{}, err
-	}
-	defer closeSource()
-	destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-rollback-destination")
-	if err != nil {
-		return RollbackResult{}, err
-	}
-	defer closeDestination()
-	r, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	// locate current release
-	currentHash, err := s.Git.LocateServiceRelease(r, environment, service)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "locate current release at '%s'", sourceConfigRepoPath)
-	}
-	log.Debugf("flow: Rollback: current release hash '%v'", currentHash)
-	err = s.Git.Checkout(r, currentHash)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "checkout current release hash '%v'", currentHash)
-	}
-	// default to environment name for the namespace if none is specified
-	if namespace == "" {
-		namespace = environment
-	}
-	log.Infof("flow: Rollback: using namespace '%s'", namespace)
-
-	currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "get spec of current release hash '%v'", currentHash)
-	}
-
-	// if artifact has no namespace we only allow using the environment as
-	// namespace.
-	if currentSpec.Namespace == "" && namespace != environment {
-		return RollbackResult{}, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
-	}
-
 	var result RollbackResult
-	// a developer can mistakenly specify the wrong namespace when promoting and
-	// we will not be able to detect it before this point.
-	// It only affects "dev" promotes as we read from the artifacts here where we
-	// can find the artifact without taking the namespace into account.
-	if currentSpec.Namespace != "" && namespace != currentSpec.Namespace {
-		log.Infof("flow: Rollback: overwriting namespace '%s' to '%s'", namespace, currentSpec.Namespace)
-		namespace = currentSpec.Namespace
-		result.OverwritingNamespace = currentSpec.Namespace
-	}
-	// locate new release (the previous released artifact for this service)
-	newHash, err := s.Git.LocateServiceReleaseRollbackSkip(r, environment, service, 1)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "locate previous release at '%s'", sourceConfigRepoPath)
-	}
-	log.Debugf("flow: Rollback: new release hash '%v'", newHash)
-	err = s.Git.Checkout(r, newHash)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "checkout previous release hash '%v'", newHash)
-	}
-	newSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "get spec of previous release hash '%v'", newHash)
-	}
+	err := s.retry(func(int) (bool, error) {
+		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-rollback-source")
+		if err != nil {
+			return true, err
+		}
+		defer closeSource()
+		destinationConfigRepoPath, closeDestination, err := git.TempDir("k8s-config-rollback-destination")
+		if err != nil {
+			return true, err
+		}
+		defer closeDestination()
+		r, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		}
 
-	// copy current release artifacts into env
-	destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
-	}
+		// locate current release
+		currentHash, err := s.Git.LocateServiceRelease(r, environment, service)
+		if err != nil {
+			return true, errors.WithMessagef(err, "locate current release at '%s'", sourceConfigRepoPath)
+		}
+		log.Debugf("flow: Rollback: current release hash '%v'", currentHash)
+		err = s.Git.Checkout(r, currentHash)
+		if err != nil {
+			return true, errors.WithMessagef(err, "checkout current release hash '%v'", currentHash)
+		}
+		// default to environment name for the namespace if none is specified
+		if namespace == "" {
+			namespace = environment
+		}
+		log.Infof("flow: Rollback: using namespace '%s'", namespace)
 
-	// release service to env from original release
-	sourcePath := releasePath(sourceConfigRepoPath, service, environment, namespace)
-	destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
-	log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
+		currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+		if err != nil {
+			return true, errors.WithMessagef(err, "get spec of current release hash '%v'", currentHash)
+		}
 
-	// empty existing resources in destination
-	err = os.RemoveAll(destinationPath)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
-	}
-	err = os.MkdirAll(destinationPath, os.ModePerm)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
-	}
-	// copy previous env. files into destination
-	err = copy.Copy(sourcePath, destinationPath)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
-	}
-	// copy artifact spec
-	artifactSourcePath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-	err = copy.Copy(artifactSourcePath, artifactDestinationPath)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
-	}
+		// if artifact has no namespace we only allow using the environment as
+		// namespace.
+		if currentSpec.Namespace == "" && namespace != environment {
+			return true, errors.WithMessagef(ErrNamespaceNotAllowedByArtifact, "namespace '%s'", namespace)
+		}
 
-	authorName := newSpec.Application.AuthorName
-	authorEmail := newSpec.Application.AuthorEmail
-	releaseMessage := git.RollbackCommitMessage(environment, service, currentSpec.ID, newSpec.ID)
-	err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
-	if err != nil {
-		return RollbackResult{}, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
-	}
-	err = s.notifyRelease(NotifyReleaseOptions{
-		Service:       service,
-		Environment:   environment,
-		Namespace:     namespace,
-		ArtifactID:    newSpec.ID,
-		CommitAuthor:  newSpec.Application.AuthorName,
-		CommitMessage: newSpec.Application.Message,
-		CommitSHA:     newSpec.Application.SHA,
-		CommitLink:    newSpec.Application.URL,
-		Releaser:      actor.Name,
+		// a developer can mistakenly specify the wrong namespace when promoting and
+		// we will not be able to detect it before this point.
+		// It only affects "dev" promotes as we read from the artifacts here where we
+		// can find the artifact without taking the namespace into account.
+		if currentSpec.Namespace != "" && namespace != currentSpec.Namespace {
+			log.Infof("flow: Rollback: overwriting namespace '%s' to '%s'", namespace, currentSpec.Namespace)
+			namespace = currentSpec.Namespace
+			result.OverwritingNamespace = currentSpec.Namespace
+		}
+		// locate new release (the previous released artifact for this service)
+		newHash, err := s.Git.LocateServiceReleaseRollbackSkip(r, environment, service, 1)
+		if err != nil {
+			return true, errors.WithMessagef(err, "locate previous release at '%s'", sourceConfigRepoPath)
+		}
+		log.Debugf("flow: Rollback: new release hash '%v'", newHash)
+		err = s.Git.Checkout(r, newHash)
+		if err != nil {
+			return true, errors.WithMessagef(err, "checkout previous release hash '%v'", newHash)
+		}
+		newSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+		if err != nil {
+			return true, errors.WithMessagef(err, "get spec of previous release hash '%v'", newHash)
+		}
+
+		// copy current release artifacts into env
+		destinationRepo, err := s.Git.Clone(ctx, destinationConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
+		}
+
+		// release service to env from original release
+		sourcePath := releasePath(sourceConfigRepoPath, service, environment, namespace)
+		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
+		log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
+
+		// empty existing resources in destination
+		err = os.RemoveAll(destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("remove destination path '%s'", destinationPath))
+		}
+		err = os.MkdirAll(destinationPath, os.ModePerm)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
+		}
+		// copy previous env. files into destination
+		err = copy.Copy(sourcePath, destinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", sourcePath, destinationPath))
+		}
+		// copy artifact spec
+		artifactSourcePath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+		log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
+		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		if err != nil {
+			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
+		}
+
+		authorName := newSpec.Application.AuthorName
+		authorEmail := newSpec.Application.AuthorEmail
+		releaseMessage := git.RollbackCommitMessage(environment, service, currentSpec.ID, newSpec.ID)
+		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
+		if err != nil {
+			// we can see races here where other changes are committed to the master repo
+			// after we cloned. Because of this we retry on any error.
+			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+		}
+		err = s.notifyRelease(NotifyReleaseOptions{
+			Service:       service,
+			Environment:   environment,
+			Namespace:     namespace,
+			ArtifactID:    newSpec.ID,
+			CommitAuthor:  newSpec.Application.AuthorName,
+			CommitMessage: newSpec.Application.Message,
+			CommitSHA:     newSpec.Application.SHA,
+			CommitLink:    newSpec.Application.URL,
+			Releaser:      actor.Name,
+		})
+		if err != nil {
+			log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
+		}
+		log.Infof("flow: Rollback: rollback committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		result.Previous = currentSpec.ID
+		result.New = newSpec.ID
+		return true, nil
 	})
 	if err != nil {
-		log.Errorf("flow: ReleaseBranch: error notifying release: %v", err)
+		return RollbackResult{}, err
 	}
-	log.Infof("flow: Rollback: rollback committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
-	result.Previous = currentSpec.ID
-	result.New = newSpec.ID
 	return result, nil
 }

--- a/internal/try/try.go
+++ b/internal/try/try.go
@@ -1,0 +1,36 @@
+package try
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+)
+
+var (
+	// ErrTooManyRetries indicates that an operation did not complete within
+	// configured retry count.
+	ErrTooManyRetries = fmt.Errorf("too many retries")
+)
+
+// Do tries the function f until max attempts is reached.
+// If f returns a true bool or a nil error retries are stopped and the error is
+// returned.
+func Do(max int, f func(int) (bool, error)) error {
+	var errs error
+	attempt := 1
+	for {
+		stop, err := f(attempt)
+		if err == nil {
+			return nil
+		}
+		if stop {
+			return multierr.Append(errs, err)
+		}
+		errs = multierr.Append(errs, errors.WithMessage(err, fmt.Sprintf("retry %d", attempt)))
+		attempt++
+		if attempt > max {
+			return multierr.Append(errs, ErrTooManyRetries)
+		}
+	}
+}

--- a/internal/try/try_test.go
+++ b/internal/try/try_test.go
@@ -1,0 +1,108 @@
+package try
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDo(t *testing.T) {
+	tt := []struct {
+		name string
+		//input
+		max int
+		f   func(int) (bool, error)
+		//output
+		err   error
+		tries int
+	}{
+		{
+			name: "stop without error",
+			max:  5,
+			f: func(a int) (bool, error) {
+				return true, nil
+			},
+			err:   nil,
+			tries: 1,
+		},
+		{
+			name: "stop with error",
+			max:  5,
+			f: func(a int) (bool, error) {
+				return true, errors.New("an error")
+			},
+			err:   errors.New("an error"),
+			tries: 1,
+		},
+		{
+			name: "success",
+			max:  5,
+			f: func(a int) (bool, error) {
+				return false, nil
+			},
+			err:   nil,
+			tries: 1,
+		},
+		{
+			name: "success on last attempt",
+			max:  5,
+			f: func(a int) (bool, error) {
+				if a == 5 {
+					return false, nil
+				}
+				return false, errors.New("an error")
+			},
+			err:   nil,
+			tries: 5,
+		},
+		{
+			name: "success on 3rd attempt",
+			max:  5,
+			f: func(a int) (bool, error) {
+				if a >= 3 {
+					return false, nil
+				}
+				return false, errors.New("an error")
+			},
+			err:   nil,
+			tries: 3,
+		},
+		{
+			name: "fail on all attempts",
+			max:  3,
+			f: func(a int) (bool, error) {
+				return false, errors.New("an error")
+			},
+			err:   errors.New("retry 1: an error; retry 2: an error; retry 3: an error; too many retries"),
+			tries: 3,
+		},
+		{
+			name: "fail on last attempt",
+			max:  3,
+			f: func(a int) (bool, error) {
+				if a <= 3 {
+					return false, errors.New("an error")
+				}
+				return false, nil
+			},
+			err:   errors.New("retry 1: an error; retry 2: an error; retry 3: an error; too many retries"),
+			tries: 3,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			c := 0
+			err := Do(tc.max, func(attempt int) (bool, error) {
+				c++
+				return tc.f(attempt)
+			})
+			if tc.err == nil {
+				assert.NoError(t, err, "unexpected error")
+			} else {
+				assert.EqualError(t, err, tc.err.Error(), "expected an error but got none")
+			}
+			assert.Equal(t, tc.tries, c, "actual retry count not as expected")
+		})
+	}
+}


### PR DESCRIPTION
This should limit commit errors when config repo have been updated during the command execution.

We have in particular seen a lot of `non-fast-forward` errors and `cannot lock ref 'refs/heads/master'`.

This changes adds a retry on the complete flows but are only actually triggered by errors in the `Commit()` call. This way we break out early if we for some reason cannot create temporary directories etc.