### PR TITLE
Unwrap pkg/errors and multierr errors

### DIFF
--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -7,6 +7,8 @@ import (
 
 	httpinternal "github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 )
 
 func Error(w http.ResponseWriter, message string, statusCode int) {
@@ -39,4 +41,16 @@ func requiredFieldError(w http.ResponseWriter, field string) {
 
 func requiredQueryError(w http.ResponseWriter, field string) {
 	Error(w, fmt.Sprintf("query param %s required but was empty", field), http.StatusBadRequest)
+}
+
+// errorCause unwraps err from pkg/errors messages and if err contains a
+// multierr, it will return the last err, again unwrapped if wrapped.
+func errorCause(err error) error {
+	// get cause before and after multierr unwrap to handle wrapped multierrs and
+	// multierrs with wrapped errors
+	errs := multierr.Errors(errors.Cause(err))
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Cause(errs[len(errs)-1])
 }

--- a/cmd/server/http/error_test.go
+++ b/cmd/server/http/error_test.go
@@ -1,0 +1,62 @@
+package http
+
+import (
+	stderrors "errors"
+	"testing"
+
+	pkgererors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+)
+
+func TestErrorCause(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  error
+		output error
+	}{
+		{
+			name:   "nil error",
+			input:  nil,
+			output: nil,
+		},
+		{
+			name:   "std lib",
+			input:  stderrors.New("std lib"),
+			output: stderrors.New("std lib"),
+		},
+		{
+			name:   "wrapped",
+			input:  pkgererors.Wrap(stderrors.New("std lib"), "message"),
+			output: stderrors.New("std lib"),
+		},
+		{
+			name:   "multierr",
+			input:  multierr.Combine(stderrors.New("std lib 1"), stderrors.New("std lib 2")),
+			output: stderrors.New("std lib 2"),
+		},
+		{
+			name: "multierr with wrapped errors",
+			input: multierr.Combine(
+				pkgererors.Wrap(stderrors.New("std lib 1"), "message"),
+				pkgererors.Wrap(stderrors.New("std lib 2"), "message"),
+			),
+			output: stderrors.New("std lib 2"),
+		},
+		{
+			name:   "wrapped with multierer",
+			input:  pkgererors.Wrap(multierr.Combine(stderrors.New("std lib 1"), stderrors.New("std lib 2")), "message"),
+			output: stderrors.New("std lib 2"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errorCause(tc.input)
+			if tc.output != nil {
+				assert.EqualError(t, err, tc.output.Error(), "error not as expected")
+				return
+			}
+			assert.NoError(t, err, "got an unexpected error")
+		})
+	}
+}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -200,7 +200,7 @@ func rollback(flowSvc *flow.Service) http.HandlerFunc {
 				cancelled(w)
 				return
 			}
-			switch errors.Cause(err) {
+			switch errorCause(err) {
 			case flow.ErrNamespaceNotAllowedByArtifact:
 				logger.Infof("http: rollback rejected: env '%s' service '%s': %v", req.Environment, req.Service, err)
 				Error(w, "namespace not allowed by artifact", http.StatusBadRequest)
@@ -335,7 +335,7 @@ func githubWebhook(flowSvc *flow.Service, policySvc *policyinternal.Service, git
 					Email: push.HeadCommit.Author.Email,
 				}, autoRelease.Environment, serviceName, autoRelease.Branch)
 				if err != nil {
-					if errors.Cause(err) != git.ErrNothingToCommit {
+					if errorCause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
 						err := slackClient.NotifySlackPolicyFailed(push.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
 						if err != nil {
@@ -399,7 +399,7 @@ func promote(flowSvc *flow.Service) http.HandlerFunc {
 				cancelled(w)
 				return
 			}
-			switch errors.Cause(err) {
+			switch errorCause(err) {
 			case git.ErrNothingToCommit:
 				statusString = "Environment is already up-to-date"
 				logger.Infof("http: promote: service '%s' environment '%s': promote skipped: environment up to date", req.Service, req.Environment)
@@ -502,8 +502,7 @@ func release(flowSvc *flow.Service) http.HandlerFunc {
 				cancelled(w)
 				return
 			}
-			cause := errors.Cause(err)
-			switch cause {
+			switch errorCause(err) {
 			case git.ErrNothingToCommit:
 				statusString = "Environment is already up-to-date"
 				logger.Infof("http: release: service '%s' environment '%s' branch '%s' artifact id '%s': release skipped: environment up to date", req.Service, req.Environment, req.Branch, req.ArtifactID)

--- a/cmd/server/http/policy.go
+++ b/cmd/server/http/policy.go
@@ -9,7 +9,6 @@ import (
 	httpinternal "github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	policyinternal "github.com/lunarway/release-manager/internal/policy"
-	"github.com/pkg/errors"
 )
 
 func policy(policySvc *policyinternal.Service) http.HandlerFunc {
@@ -108,7 +107,7 @@ func listPolicies(policySvc *policyinternal.Service) http.HandlerFunc {
 				cancelled(w)
 				return
 			}
-			if errors.Cause(err) == policyinternal.ErrNotFound {
+			if errorCause(err) == policyinternal.ErrNotFound {
 				Error(w, "no policies exist", http.StatusNotFound)
 				return
 			}
@@ -182,7 +181,7 @@ func deletePolicies(policySvc *policyinternal.Service) http.HandlerFunc {
 				cancelled(w)
 				return
 			}
-			if errors.Cause(err) == policyinternal.ErrNotFound {
+			if errorCause(err) == policyinternal.ErrNotFound {
 				Error(w, "no policies exist", http.StatusNotFound)
 				return
 			}


### PR DESCRIPTION
We cannot know if underlying functions have wrapped or aggregated errors, but we want to assert on them for better user messages.

This changes ensures to unwrap errors properly for assertions.