### PR TITLE
Remove service flag for version command

### DIFF
--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -29,6 +29,11 @@ func NewCommand(version *string) (*cobra.Command, error) {
 		Use:   "hamctl",
 		Short: "hamctl controls a release manager server",
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			// all commands but version requires the "service" flag
+			// if this is thee version command, skip the check
+			if c.Name() == "version" {
+				return nil
+			}
 			defaultShuttleString(shuttleSpecFromFile, &service, func(s *shuttleSpec) string {
 				return s.Vars.Service
 			})


### PR DESCRIPTION
The `service` flag is required for all sub-commands of `hamctl`.
This includes the `version` command, which makes little sense.

This change ignores the `service` flag check for the `version` command.