### PR TITLE
Add profiling endpoints to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ artifact-linux-amd64
 /cmd/artifact/artifact
 message.json
 artifact.json
+/profiles/

--- a/Makefile
+++ b/Makefile
@@ -156,3 +156,13 @@ daemon-webhook-configerror:
 	  ] \
 	}' \
 	localhost:8080/webhook/daemon
+
+server-profile-heap:
+	mkdir -p profiles
+	curl -o profiles/heap.pprof localhost:8080/debug/pprof/heap
+	go tool pprof -http=:8081 profiles/heap.pprof
+
+server-profile-cpu:
+	mkdir -p profiles
+	curl -o profiles/cpu.pprof localhost:8080/debug/pprof/profile?seconds=10
+	go tool pprof -http=:8081 profiles/cpu.pprof

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"regexp"
 	"strings"
 	"time"
@@ -39,6 +40,13 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	mux.HandleFunc("/policies", authenticate(opts.HamCtlAuthToken, policy(policySvc)))
 	mux.HandleFunc("/webhook/github", githubWebhook(flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
 	mux.HandleFunc("/webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(flowSvc)))
+
+	// profiling endpoints
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	s := http.Server{
 		Addr:              fmt.Sprintf(":%d", opts.Port),


### PR DESCRIPTION
This allows us to collect CPU, tracing and memory profiles on the server.

I've added two make targets to create heap allocation and cpu usage profiles on `localhost`.