### PR TITLE
Increase default timeout of hamctl

### DIFF
--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -54,7 +54,7 @@ func NewCommand(version *string) (*cobra.Command, error) {
 	command.AddCommand(NewRollback(&client, &service))
 	command.AddCommand(NewPolicy(&client, &service))
 	command.AddCommand(NewCompletion(command))
-	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 20*time.Second, "HTTP request timeout")
+	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 30*time.Second, "HTTP request timeout")
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
 	command.PersistentFlags().StringVar(&client.Metadata.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")


### PR DESCRIPTION
We see a lot of timeouts after adding retries on commit operations.
In general actions take around 10 seconds, so a single retry will hit the 20 second timeout.

This change increases the timeout to 30 seconds.