### PR TITLE
Add describe release and artifact commands

### DIFF
--- a/cmd/hamctl/command/describe.go
+++ b/cmd/hamctl/command/describe.go
@@ -1,0 +1,141 @@
+package command
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/lunarway/release-manager/cmd/hamctl/command/completion"
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func NewDescribe(client *httpinternal.Client, service *string) *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "describe",
+		Short: "Show details of resources controlled by the release manager.",
+		Example: `Get details about available artifacts for a service:
+
+	hamctl describe artifact --service product
+
+Get details about the current release of product in the dev environment:
+
+  hamctl describe release --service product --env dev`,
+	}
+	command.AddCommand(newDescribeRelease(client, service))
+	command.AddCommand(newDescribeArtifact(client, service))
+	return command
+}
+
+var describeReleaseDefaultTemplate = `Service: {{ .Artifact.Service }}
+{{ if ne (len .Artifact.Namespace) 0 -}}
+Namespace:  {{ .Artifact.Namespace }}
+{{ end -}}
+Environment: {{ .Environment }}
+Released at: {{ .ReleasedAt.Format "2006-01-02 15:04:03" }}
+Released by: {{ .ReleasedByName }} ({{ .ReleasedByEmail }})
+Commit: {{ .Artifact.Application.URL }}
+`
+
+func newDescribeRelease(client *httpinternal.Client, service *string) *cobra.Command {
+	var environment, namespace, template string
+	var command = &cobra.Command{
+		Use:   "release",
+		Short: "Show details about a release.",
+		Example: `Get details about the current release of product in the dev environment:
+
+	hamctl describe release --service product --env dev
+
+Format the output with a custom template:
+
+	hamctl describe release --service product --env dev --template '{{ .Service }}'`,
+		PreRun: func(c *cobra.Command, args []string) {
+			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
+				return s.Vars.K8S.Namespace
+			})
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			var resp httpinternal.DescribeReleaseResponse
+			params := url.Values{}
+			if namespace != "" {
+				params.Add("namespace", namespace)
+			}
+			path, err := client.URLWithQuery(fmt.Sprintf("describe/release/%s/%s", *service, environment), params)
+			if err != nil {
+				return err
+			}
+			err = client.Do(http.MethodGet, path, nil, &resp)
+			if err != nil {
+				return err
+			}
+			if len(template) == 0 {
+				template = describeReleaseDefaultTemplate
+			}
+			err = templateOutput(os.Stdout, "describeRelease", template, resp)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	command.Flags().StringVar(&environment, "env", "", "environment to promote to (required)")
+	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
+	command.MarkFlagRequired("env")
+	command.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace the service is deployed to (defaults to env)")
+	completion.FlagAnnotation(command, "namespace", "__hamctl_get_namespaces")
+	command.Flags().StringVarP(&template, "template", "", "", "template string to format the output. The format is Go templates (http://golang.org/pkg/text/template/#pkg-overview). Available data structure is an 'http.DescribeReleaseResponse' struct.")
+	return command
+}
+
+var describeArtifactDefaultTemplate = `Latest artifacts for service: {{ .Service }}
+
+{{ rightPad "Date" 21 }}{{ rightPad "Artifact" 30 }}Message
+{{ range $k, $v := .Artifacts -}}
+{{ rightPad (.CI.End.Format "2006-01-02 15:04:03") 21 }}{{ rightPad .ID 30 }}{{ .Application.Message }}
+{{ end -}}
+`
+
+func newDescribeArtifact(client *httpinternal.Client, service *string) *cobra.Command {
+	var count int
+	var template string
+	var command = &cobra.Command{
+		Use:   "artifact",
+		Short: "Show details about an artifact.",
+		Example: `Get details about available artifacts for a service:
+
+	hamctl describe artifact --service product
+
+Get details about the latest 5 artifacts for a service:
+
+	hamctl describe artifact --service product --count 5
+
+Format the output with a custom template:
+
+	hamctl describe artifact --service product --template '{{ .Service }}'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			var resp httpinternal.DescribeArtifactResponse
+			params := url.Values{}
+			params.Add("count", fmt.Sprintf("%d", count))
+			path, err := client.URLWithQuery(fmt.Sprintf("describe/artifact/%s", *service), params)
+			if err != nil {
+				return err
+			}
+			err = client.Do(http.MethodGet, path, nil, &resp)
+			if err != nil {
+				return err
+			}
+			if len(template) == 0 {
+				template = describeArtifactDefaultTemplate
+			}
+			err = templateOutput(os.Stdout, "describeArtifact", template, resp)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	command.Flags().IntVar(&count, "count", 1, "Number of artifacts to return sorted by latest")
+	command.Flags().StringVarP(&template, "template", "", "", "template string to format the output. The format is Go templates (http://golang.org/pkg/text/template/#pkg-overview). Available data structure is an 'http.DescribeArtifactResponse' struct.")
+	return command
+}

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -53,6 +53,7 @@ func NewCommand(version *string) (*cobra.Command, error) {
 	command.AddCommand(NewStatus(&client, &service))
 	command.AddCommand(NewRollback(&client, &service))
 	command.AddCommand(NewPolicy(&client, &service))
+	command.AddCommand(NewDescribe(&client, &service))
 	command.AddCommand(NewCompletion(command))
 	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 30*time.Second, "HTTP request timeout")
 	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")

--- a/cmd/hamctl/command/template.go
+++ b/cmd/hamctl/command/template.go
@@ -1,0 +1,28 @@
+package command
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+)
+
+// templateOutput parses the template text as a Go template. The empty interface
+// is available as the root object in the template.
+//
+// Some utility functions are available for data manipulation.
+func templateOutput(destination io.Writer, name, text string, data interface{}) error {
+	t := template.New(name)
+	t.Funcs(template.FuncMap{
+		"rightPad": tmplRightPad,
+	})
+	t, err := t.Parse(text)
+	if err != nil {
+		return fmt.Errorf("invalid template: %v", err)
+	}
+	return t.Execute(destination, data)
+}
+
+func tmplRightPad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}

--- a/cmd/server/http/describe.go
+++ b/cmd/server/http/describe.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/git"
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/lunarway/release-manager/internal/log"
+)
+
+func describe(flowSvc *flow.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			notFound(w)
+			return
+		}
+		p, ok := newDescribePath(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		switch p.Resource() {
+		case "release":
+			describeRelease(flowSvc, p.Namespace(), p.Environment(), p.Service())(w, r)
+		case "artifact":
+			describeArtifact(flowSvc, p.Service())(w, r)
+		default:
+			log.Errorf("describe path not found: %+v", p)
+			notFound(w)
+		}
+	}
+}
+
+type describePath struct {
+	r        *http.Request
+	segments []string
+}
+
+func newDescribePath(r *http.Request) (describePath, bool) {
+	p := describePath{
+		r:        r,
+		segments: strings.Split(r.URL.Path, "/"),
+	}
+	if len(p.segments) < 4 {
+		return describePath{}, false
+	}
+	return p, true
+}
+
+func (p *describePath) Resource() string {
+	return p.segments[2]
+}
+
+func (p *describePath) Service() string {
+	return p.segments[3]
+}
+
+func (p *describePath) Environment() string {
+	if len(p.segments) < 5 {
+		return ""
+	}
+	return p.segments[4]
+}
+
+func (p *describePath) Namespace() string {
+	values := p.r.URL.Query()
+	namespace := values.Get("namespace")
+	return namespace
+}
+
+func describeRelease(flowSvc *flow.Service, namespace, environment, service string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if emptyString(service) {
+			requiredFieldError(w, "service")
+			return
+		}
+		if emptyString(environment) {
+			requiredFieldError(w, "environment")
+			return
+		}
+		logger := log.WithFields("service", service, "environment", environment, "namespace", namespace)
+		ctx := r.Context()
+		resp, err := flowSvc.DescribeRelease(ctx, namespace, environment, service)
+		if err != nil {
+			if ctx.Err() == context.Canceled {
+				logger.Infof("http: describe release: service '%s' environment '%s': request cancelled", service, environment)
+				cancelled(w)
+				return
+			}
+			switch errorCause(err) {
+			case artifact.ErrFileNotFound:
+				Error(w, fmt.Sprintf("no release of service '%s' available in environment '%s'. Are you missing a namespace?", service, environment), http.StatusBadRequest)
+				return
+			default:
+				logger.Errorf("http: describe release: service '%s' environment '%s': failed: %v", service, environment, err)
+				unknownError(w)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(httpinternal.DescribeReleaseResponse{
+			Service:         service,
+			Environment:     environment,
+			Artifact:        resp.Artifact,
+			ReleasedAt:      resp.ReleasedAt,
+			ReleasedByEmail: resp.ReleasedByEmail,
+			ReleasedByName:  resp.ReleasedByName,
+		})
+		if err != nil {
+			logger.Errorf("http: describe release: service '%s' environment '%s': marshal response failed: %v", service, environment, err)
+		}
+	}
+}
+
+func describeArtifact(flowSvc *flow.Service, service string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if emptyString(service) {
+			requiredFieldError(w, "service")
+			return
+		}
+		values := r.URL.Query()
+		countParam := values.Get("count")
+		if emptyString(countParam) {
+			countParam = "1"
+		}
+		count, err := strconv.Atoi(countParam)
+		if err != nil || count <= 0 {
+			Error(w, fmt.Sprintf("invalid value '%s' of count. Must be a positive integer.", countParam), http.StatusBadRequest)
+			return
+		}
+		logger := log.WithFields("service", service, "count", count)
+		ctx := r.Context()
+		resp, err := flowSvc.DescribeArtifact(ctx, service, count)
+		if err != nil {
+			if ctx.Err() == context.Canceled {
+				logger.Infof("http: describe artifact: service '%s': request cancelled", service)
+				cancelled(w)
+				return
+			}
+			switch errorCause(err) {
+			case git.ErrArtifactNotFound:
+				Error(w, fmt.Sprintf("no artifacts available for service '%s'.", service), http.StatusBadRequest)
+				return
+			default:
+				logger.Errorf("http: describe artifact: service '%s': failed: %v", service, err)
+				unknownError(w)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(httpinternal.DescribeArtifactResponse{
+			Service:   service,
+			Artifacts: resp,
+		})
+		if err != nil {
+			logger.Errorf("http: describe artifact: service '%s': marshal response failed: %v", service, err)
+		}
+	}
+}

--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -43,6 +43,10 @@ func requiredQueryError(w http.ResponseWriter, field string) {
 	Error(w, fmt.Sprintf("query param %s required but was empty", field), http.StatusBadRequest)
 }
 
+func notFound(w http.ResponseWriter) {
+	Error(w, "not found", http.StatusNotFound)
+}
+
 // errorCause unwraps err from pkg/errors messages and if err contains a
 // multierr, it will return the last err, again unwrapped if wrapped.
 func errorCause(err error) error {

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -38,6 +38,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	mux.HandleFunc("/status", authenticate(opts.HamCtlAuthToken, status(flowSvc)))
 	mux.HandleFunc("/rollback", authenticate(opts.HamCtlAuthToken, rollback(flowSvc)))
 	mux.HandleFunc("/policies", authenticate(opts.HamCtlAuthToken, policy(policySvc)))
+	mux.HandleFunc("/describe/", authenticate(opts.HamCtlAuthToken, describe(flowSvc)))
 	mux.HandleFunc("/webhook/github", githubWebhook(flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
 	mux.HandleFunc("/webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(flowSvc)))
 

--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -1,0 +1,101 @@
+package flow
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/pkg/errors"
+)
+
+type DescribeReleaseResponse struct {
+	DefaultNamespaces bool
+	Artifact          artifact.Spec
+	ReleasedAt        time.Time
+	ReleasedByEmail   string
+	ReleasedByName    string
+}
+
+// DescribeRelease returns information about a specific release in an environment.
+func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, service string) (DescribeReleaseResponse, error) {
+	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-describe-release")
+	if err != nil {
+		return DescribeReleaseResponse{}, err
+	}
+	defer close()
+
+	log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return DescribeReleaseResponse{}, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	defaultNamespaces := namespace == ""
+	if defaultNamespaces {
+		namespace = environment
+	}
+
+	spec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+	if err != nil {
+		return DescribeReleaseResponse{}, errors.WithMessagef(err, "namespace '%s'", namespace)
+	}
+
+	hash, err := s.Git.LocateServiceReleaseRollbackSkip(sourceRepo, environment, service, 0)
+	if err != nil {
+		return DescribeReleaseResponse{}, errors.WithMessagef(err, "namespace '%s': locate latest release", namespace)
+	}
+	c, err := sourceRepo.CommitObject(hash)
+	if err != nil {
+		return DescribeReleaseResponse{}, errors.WithMessagef(err, "namespace '%s': get commit at hash '%s'", namespace, hash)
+	}
+	return DescribeReleaseResponse{
+		DefaultNamespaces: defaultNamespaces,
+		Artifact:          spec,
+		ReleasedAt:        c.Committer.When,
+		ReleasedByEmail:   c.Committer.Email,
+		ReleasedByName:    c.Committer.Name,
+	}, nil
+}
+
+// DescribeArtifact returns n artifacts for a service.
+func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) ([]artifact.Spec, error) {
+	sourceConfigRepoPath, close, err := git.TempDir("k8s-config-describe-artifact")
+	if err != nil {
+		return nil, err
+	}
+	defer close()
+
+	log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	hashes, err := s.Git.LocateArtifacts(sourceRepo, service, n)
+	if err != nil {
+		return nil, errors.WithMessage(err, "locate artifacts")
+	}
+	var artifacts []artifact.Spec
+	log.Debugf("flow/describe: hashes %+v", hashes)
+	for _, hash := range hashes {
+		err = s.Git.Checkout(sourceRepo, hash)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		}
+		branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+		if err != nil {
+			log.Errorf("flow/describe: get branch from head failed at hash '%s': skipping hash: %v", hash, err)
+			continue
+		}
+		artifactPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
+		spec, err := artifact.Get(artifactPath)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "get artifact at path '%s' at hash '%s'", artifactPath, hash)
+		}
+		artifacts = append(artifacts, spec)
+	}
+	return artifacts, nil
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -442,3 +442,55 @@ func TestLocateEnvReleaseCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestLocateArtifactServiceCondition(t *testing.T) {
+	tt := []struct {
+		name    string
+		service string
+		message string
+		output  bool
+	}{
+		{
+			name:    "empty service",
+			service: "",
+			message: "[service-name] artifact master-1234567890-1234567890",
+			output:  false,
+		},
+		{
+			name:    "regexp like service",
+			service: `(\`,
+			message: "[service-name] artifact master-1234567890-1234567890",
+			output:  false,
+		},
+		{
+			name:    "partial service",
+			service: "service",
+			message: "[service-name] artifact master-1234567890-1234567890",
+			output:  false,
+		},
+		{
+			name:    "exact service",
+			service: "service-name",
+			message: "[service-name] artifact master-1234567890-1234567890",
+			output:  true,
+		},
+		{
+			name:    "wrong cased service",
+			service: "SERVICE-NAME",
+			message: "[service-name] artifact master-1234567890-1234567890",
+			output:  true,
+		},
+		{
+			name:    "release of exact service",
+			service: "service-name",
+			message: "[env/service-name] release master-1234567890-1234567890",
+			output:  false,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := locateArtifactServiceCondition(tc.service)(tc.message)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -1,5 +1,11 @@
 package http
 
+import (
+	"time"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+)
+
 type StatusRequest struct {
 	Service string `json:"service,omitempty"`
 }
@@ -140,4 +146,18 @@ type RollbackResponse struct {
 	Environment        string `json:"environment,omitempty"`
 	PreviousArtifactID string `json:"previousArtifactId,omitempty"`
 	NewArtifactID      string `json:"newArtifactId,omitempty"`
+}
+
+type DescribeReleaseResponse struct {
+	Service         string        `json:"service,omitempty"`
+	Environment     string        `json:"environment,omitempty"`
+	Artifact        artifact.Spec `json:"artifact,omitempty"`
+	ReleasedAt      time.Time     `json:"releasedAt,omitempty"`
+	ReleasedByEmail string        `json:"releasedByEmail,omitempty"`
+	ReleasedByName  string        `json:"releasedByName,omitempty"`
+}
+
+type DescribeArtifactResponse struct {
+	Service   string          `json:"service,omitempty"`
+	Artifacts []artifact.Spec `json:"artifacts,omitempty"`
 }


### PR DESCRIPTION
These commands will show details about releases and artifacts respectively.

An example of a `describe artifact` command:

```
$ hamctl describe artifact --service prometheus --count 4
Latest artifacts for service: prometheus

Date                 Artifact                      Message
2019-06-12 23:40:11  dummy-51c51153ef-12eefab971   Dummy-build
2019-04-29 11:12:11  master-c2512fcef3-5b25bbbc0f  add-annotations-and-label-to-podTemplate-as-well
2019-04-29 10:58:10  master-08f6655ee1-5b25bbbc0f  let-origin-image-be-an-annotation-instead-of-a-label
2019-04-29 10:54:10  master-669bbadfc3-5b25bbbc0f  add-origin-version-and-image-to-deployment
```

An example of `describe release`:

```
$ hamctl describe release --service prometheus --env dev --namespace monitoring
Service: prometheus
Namespace:  monitoring
Environment: dev
Released at: 2019-04-29 09:13:09
Released by: Kasper Nissen (kni@lunarway.com)
Commit: https://github.com/lunarway/lunar-way-prometheus/commit/c2512fcef3598360492ee82c277fbff882bc3be8
```

The outputs are templated and can be customized with the `template` flag.