### PR TITLE
Handle ErrTooManyRetres in errorCause

### DIFF
--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -7,6 +7,7 @@ import (
 
 	httpinternal "github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/try"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
@@ -52,5 +53,11 @@ func errorCause(err error) error {
 	if len(errs) == 0 {
 		return nil
 	}
-	return errors.Cause(errs[len(errs)-1])
+	for i := len(errs) - 1; i >= 0; i-- {
+		err := errs[i]
+		if err != try.ErrTooManyRetries {
+			return errors.Cause(err)
+		}
+	}
+	return err
 }

--- a/cmd/server/http/error_test.go
+++ b/cmd/server/http/error_test.go
@@ -4,6 +4,7 @@ import (
 	stderrors "errors"
 	"testing"
 
+	"github.com/lunarway/release-manager/internal/try"
 	pkgererors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
@@ -47,6 +48,20 @@ func TestErrorCause(t *testing.T) {
 			name:   "wrapped with multierer",
 			input:  pkgererors.Wrap(multierr.Combine(stderrors.New("std lib 1"), stderrors.New("std lib 2")), "message"),
 			output: stderrors.New("std lib 2"),
+		},
+		{
+			name: "last error is too many retries",
+			input: multierr.Combine(
+				pkgererors.Wrap(stderrors.New("std lib 1"), "message"),
+				pkgererors.Wrap(stderrors.New("std lib 2"), "message"),
+				try.ErrTooManyRetries,
+			),
+			output: stderrors.New("std lib 2"),
+		},
+		{
+			name:   "last error is too many retries",
+			input:  try.ErrTooManyRetries,
+			output: try.ErrTooManyRetries,
 		},
 	}
 	for _, tc := range tt {

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -141,6 +141,9 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 		log.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
 		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
+			if err == git.ErrNothingToCommit {
+				return true, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+			}
 			// we can see races here where other changes are committed to the master repo
 			// after we cloned. Because of this we retry on any error.
 			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -84,6 +84,9 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
 		err = s.Git.Commit(ctx, repo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
+			if err == git.ErrNothingToCommit {
+				return true, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+			}
 			// we can see races here where other changes are committed to the master repo
 			// after we cloned. Because of this we retry on any error.
 			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
@@ -203,6 +206,9 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
 		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
+			if err == git.ErrNothingToCommit {
+				return true, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+			}
 			// we can see races here where other changes are committed to the master repo
 			// after we cloned. Because of this we retry on any error.
 			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -126,6 +126,9 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 		releaseMessage := git.RollbackCommitMessage(environment, service, currentSpec.ID, newSpec.ID)
 		err = s.Git.Commit(ctx, destinationRepo, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
+			if err == git.ErrNothingToCommit {
+				return true, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))
+			}
 			// we can see races here where other changes are committed to the master repo
 			// after we cloned. Because of this we retry on any error.
 			return false, errors.WithMessage(err, fmt.Sprintf("commit changes from path '%s'", destinationPath))


### PR DESCRIPTION
The `errorCause` function did not detect the original cause when hitting maximum retries.

Further more did we retry on `git.ErrNothingToCommit` which made little sense as the condition will never change during the request.

This change fixes the detection of the cause and further more drops the retries.