### PR TITLE
Respect context cancelation in try.Do

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -22,7 +22,7 @@ func pushCommand(options *Options) *cobra.Command {
 		Short: "push artifact to a configuration repository",
 		RunE: func(c *cobra.Command, args []string) error {
 			var artifactID string
-			err := try.Do(maxRetries, func(int) (bool, error) {
+			err := try.Do(context.Background(), maxRetries, func(int) (bool, error) {
 				close, err := gitSvc.InitMasterRepo()
 				if err != nil {
 					return false, err

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -36,8 +36,8 @@ type Service struct {
 // retry tries the function f until max attempts is reached
 // If f returns a true bool or a nil error retries are stopped and the error is
 // returned.
-func (s *Service) retry(f func(int) (bool, error)) error {
-	return try.Do(s.MaxRetries, f)
+func (s *Service) retry(ctx context.Context, f func(int) (bool, error)) error {
+	return try.Do(ctx, s.MaxRetries, f)
 }
 
 type Environment struct {

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -37,7 +37,7 @@ import (
 // the changes
 func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespace, service string) (PromoteResult, error) {
 	var result PromoteResult
-	err := s.retry(func(int) (bool, error) {
+	err := s.retry(ctx, func(int) (bool, error) {
 		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-promote-source")
 		if err != nil {
 			return true, err

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -24,7 +24,7 @@ import (
 // Copy artifacts from the artifacts into the environment and commit the changes.
 func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, service, branch string) (string, error) {
 	var result string
-	err := s.retry(func(int) (bool, error) {
+	err := s.retry(ctx, func(int) (bool, error) {
 		sourceConfigRepoPath, close, err := git.TempDir("k8s-config-release-branch")
 		if err != nil {
 			return true, err
@@ -126,7 +126,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 // the changes
 func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environment, service, artifactID string) (string, error) {
 	var result string
-	err := s.retry(func(int) (bool, error) {
+	err := s.retry(ctx, func(int) (bool, error) {
 		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-release-artifact-source")
 		if err != nil {
 			return true, err

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -20,7 +20,7 @@ type RollbackResult struct {
 
 func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namespace, service string) (RollbackResult, error) {
 	var result RollbackResult
-	err := s.retry(func(int) (bool, error) {
+	err := s.retry(ctx, func(int) (bool, error) {
 		sourceConfigRepoPath, closeSource, err := git.TempDir("k8s-config-rollback-source")
 		if err != nil {
 			return true, err

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -124,7 +124,7 @@ func (s *Service) Delete(ctx context.Context, actor Actor, svc string, ids []str
 }
 
 func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMsg string, f func(p *Policies)) error {
-	return try.Do(s.MaxRetries, func(int) (bool, error) {
+	return try.Do(ctx, s.MaxRetries, func(int) (bool, error) {
 		configRepoPath, close, err := git.TempDir("k8s-config-notify")
 		if err != nil {
 			return true, err

--- a/internal/try/try.go
+++ b/internal/try/try.go
@@ -1,6 +1,7 @@
 package try
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -16,21 +17,28 @@ var (
 // Do tries the function f until max attempts is reached.
 // If f returns a true bool or a nil error retries are stopped and the error is
 // returned.
-func Do(max int, f func(int) (bool, error)) error {
+//
+// Context cancellation is respected in between attempts.
+func Do(ctx context.Context, max int, f func(int) (bool, error)) error {
 	var errs error
 	attempt := 1
 	for {
-		stop, err := f(attempt)
-		if err == nil {
-			return nil
-		}
-		if stop {
-			return multierr.Append(errs, err)
-		}
-		errs = multierr.Append(errs, errors.WithMessage(err, fmt.Sprintf("retry %d", attempt)))
-		attempt++
-		if attempt > max {
-			return multierr.Append(errs, ErrTooManyRetries)
+		select {
+		case <-ctx.Done():
+			return multierr.Append(errs, ctx.Err())
+		default:
+			stop, err := f(attempt)
+			if err == nil {
+				return nil
+			}
+			if stop {
+				return multierr.Append(errs, err)
+			}
+			errs = multierr.Append(errs, errors.WithMessage(err, fmt.Sprintf("retry %d", attempt)))
+			attempt++
+			if attempt > max {
+				return multierr.Append(errs, ErrTooManyRetries)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently retries are done even when the request is cancelled.

Instead of implementing this into each caller, this change makes `try.Do` context aware. This means it will skip retries if the context is cancelled.