### PR TITLE
Initial tracing support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ github-webhook:
 		} \
 	}' \
 	localhost:8080/webhook/github
-	
+
 hamctl-status:
 	curl -X GET \
 	-H 'Content-Type: application/json' \
@@ -166,3 +166,6 @@ server-profile-cpu:
 	mkdir -p profiles
 	curl -o profiles/cpu.pprof localhost:8080/debug/pprof/profile?seconds=10
 	go tool pprof -http=:8081 profiles/cpu.pprof
+
+jaeger:
+	docker run --rm -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 9411:9411 -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 jaegertracing/all-in-one:1.7

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ This is an example of applying an auto-release policy for the product service fo
 $ hamctl policy --service example apply auto-release --branch master --env dev
 ```
 
+### Tracing support
+
+The server collects [Jaeger](https://www.jaegertracing.io/) spans. This is enabled by default and reported as service `release-manager`.
+The jaeger configuration can be customized with available [environment variables](https://github.com/jaegertracing/jaeger-client-go#environment-variables).
+
+For local development a jaeger all-in-one instance can be created with Docker running `make jaeger`.
+The Jaeger UI will be available on [`localhost:16686`](http://localhost:16686).
+
+To disable collection set `JAEGER_DISABLED=true`.
+
 ## hamctl
 
 `hamctl` is a thin CLI for interacting with the release-manager server. The different commands implemented in `hamctl` is visible in the previous section.

--- a/cmd/server/command/tracing.go
+++ b/cmd/server/command/tracing.go
@@ -23,6 +23,7 @@ func initTracing() (opentracing.Tracer, io.Closer, error) {
 		Param: 1,
 	}
 	cfg.Reporter.LogSpans = true
+	log.WithFields("config", cfg).Infof("Tracing spans reported to '%s'", cfg.Reporter.LocalAgentHostPort)
 
 	tracer, closer, err := cfg.NewTracer(
 		config.Logger(&jaegerLogger{

--- a/cmd/server/command/tracing.go
+++ b/cmd/server/command/tracing.go
@@ -16,7 +16,7 @@ func initTracing() (opentracing.Tracer, io.Closer, error) {
 		return nil, nil, err
 	}
 	if cfg.ServiceName == "" {
-		cfg.ServiceName = "default-service-name"
+		cfg.ServiceName = "release-manager"
 	}
 	cfg.Sampler = &config.SamplerConfig{
 		Type:  jaeger.SamplerTypeConst,

--- a/cmd/server/command/tracing.go
+++ b/cmd/server/command/tracing.go
@@ -1,0 +1,53 @@
+package command
+
+import (
+	"io"
+
+	"github.com/lunarway/release-manager/internal/log"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+func initTracing() (opentracing.Tracer, io.Closer, error) {
+	cfg := config.Configuration{
+		ServiceName: "release-manager",
+		Sampler: &config.SamplerConfig{
+			Type:  jaeger.SamplerTypeConst,
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+
+	// Example metrics factory. Use github.com/uber/jaeger-lib/metrics to bind to
+	// real metrics frameworks.
+	jMetricsFactory := metrics.NullFactory
+
+	// Initialize tracer with a logger and a metrics factory
+	tracer, closer, err := cfg.NewTracer(
+		config.Logger(&jaegerLogger{
+			l: log.With("system", "jaeger"),
+		}),
+		config.Metrics(jMetricsFactory),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tracer, closer, nil
+}
+
+type jaegerLogger struct {
+	l *log.Logger
+}
+
+func (j *jaegerLogger) Error(msg string) {
+	j.l.Error(msg)
+}
+
+func (j *jaegerLogger) Infof(msg string, args ...interface{}) {
+	j.l.Infof(msg, args...)
+}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -35,14 +35,14 @@ type Options struct {
 func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, policySvc *policyinternal.Service, gitSvc *git.Service, tracer opentracing.Tracer) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", ping)
-	mux.HandleFunc("/promote", authenticate(opts.HamCtlAuthToken, promote(flowSvc)))
-	mux.HandleFunc("/release", authenticate(opts.HamCtlAuthToken, release(flowSvc)))
+	mux.HandleFunc("/promote", trace(tracer, authenticate(opts.HamCtlAuthToken, promote(flowSvc))))
+	mux.HandleFunc("/release", trace(tracer, authenticate(opts.HamCtlAuthToken, release(flowSvc))))
 	mux.HandleFunc("/status", trace(tracer, authenticate(opts.HamCtlAuthToken, status(tracer, flowSvc))))
-	mux.HandleFunc("/rollback", authenticate(opts.HamCtlAuthToken, rollback(flowSvc)))
+	mux.HandleFunc("/rollback", trace(tracer, authenticate(opts.HamCtlAuthToken, rollback(flowSvc))))
 	mux.HandleFunc("/policies", trace(tracer, authenticate(opts.HamCtlAuthToken, policy(policySvc))))
-	mux.HandleFunc("/describe/", authenticate(opts.HamCtlAuthToken, describe(flowSvc)))
-	mux.HandleFunc("/webhook/github", githubWebhook(flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
-	mux.HandleFunc("/webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(flowSvc)))
+	mux.HandleFunc("/describe/", trace(tracer, authenticate(opts.HamCtlAuthToken, describe(flowSvc))))
+	mux.HandleFunc("/webhook/github", trace(tracer, githubWebhook(flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret)))
+	mux.HandleFunc("/webhook/daemon", trace(tracer, authenticate(opts.DaemonAuthToken, daemonWebhook(flowSvc))))
 
 	// profiling endpoints
 	mux.HandleFunc("/debug/pprof/", pprof.Index)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/lunarway/release-manager
 
 require (
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
@@ -14,6 +15,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/nlopes/slack v0.5.0
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -22,6 +24,9 @@ require (
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
+	github.com/uber-go/atomic v1.4.0 // indirect
+	github.com/uber/jaeger-client-go v2.16.0+incompatible
+	github.com/uber/jaeger-lib v2.0.0+incompatible
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -93,6 +95,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nlopes/slack v0.5.0 h1:NbIae8Kd0NpqaEI3iUrsuS0KbcEDhzhc939jLW5fNm0=
 github.com/nlopes/slack v0.5.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
@@ -140,6 +144,12 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
+github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
+github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQGFt7E53bPYqEgug/AoBtY=
+github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
+github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xanzy/ssh-agent v0.2.0 h1:Adglfbi5p9Z0BmK2oKU9nTG+zKfniSfnaMYB+ULd+Ro=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=


### PR DESCRIPTION
This change adds Jaeger trace reporting to the server application.

An HTTP middleware is added to all endpoints and some service methods as well.

A `make` target `jaeger` will spin up an all-in-one deployment of Jaeger in Docker making traces available to local development.

Reporting can be disabled with `JAEGER_DISABLED=true`.
