### PR TITLE
Handle unknown environments on release

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -477,6 +477,10 @@ func promote(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 				logger.Infof("http: promote: service '%s' environment '%s': promote rejected: artifact not found", req.Service, req.Environment)
 				Error(w, fmt.Sprintf("artifact not found for service '%s'. Are you missing a namespace?", req.Service), http.StatusBadRequest)
 				return
+			case flow.ErrUnknownConfiguration:
+				logger.Infof("http: promote: service '%s' environment '%s': promote rejected: source configuration not found", req.Service, req.Environment)
+				Error(w, fmt.Sprintf("configuration for environment '%s' not found for service '%s'. Is the environment specified in 'shuttle.yaml'?", req.Environment, req.Service), http.StatusBadRequest)
+				return
 			default:
 				logger.Errorf("http: promote: service '%s' environment '%s': promote failed: %v", req.Service, req.Environment, err)
 				unknownError(w)
@@ -577,6 +581,10 @@ func release(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 				} else {
 					Error(w, fmt.Sprintf("artifact '%s' not found for service '%s'", req.ArtifactID, req.Service), http.StatusBadRequest)
 				}
+				return
+			case flow.ErrUnknownConfiguration:
+				logger.Infof("http: release: service '%s' environment '%s' branch '%s' artifact id '%s': release rejected: source configuration not found", req.Service, req.Environment, req.Branch, req.ArtifactID)
+				Error(w, fmt.Sprintf("configuration for environment '%s' not found for service '%s'. Is the environment specified in 'shuttle.yaml'?", req.Environment, req.Service), http.StatusBadRequest)
 				return
 			default:
 				logger.Errorf("http: release: service '%s' environment '%s' branch '%s' artifact id '%s': release failed: %v", req.Service, req.Environment, req.Branch, req.ArtifactID, err)

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -22,6 +22,7 @@ import (
 var (
 	ErrUnknownEnvironment            = errors.New("unknown environment")
 	ErrNamespaceNotAllowedByArtifact = errors.New("namespace not allowed by artifact")
+	ErrUnknownConfiguration          = errors.New("unknown configuration")
 )
 
 type Service struct {
@@ -377,6 +378,9 @@ func (s *Service) cleanCopy(ctx context.Context, src, dest string) error {
 	span.Finish()
 	err = copy.Copy(src, dest)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrUnknownConfiguration
+		}
 		return errors.WithMessage(err, "copy files")
 	}
 	return nil


### PR DESCRIPTION
If a release/promote request targets an environment where no configuration exists return a 400 Bad Request instead of 500.
This helps clients to understand that they either targeted the wrong environment or forgot to specify it in their build.