### PR TITLE
Disable logging of tracing spans

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -40,7 +40,7 @@ func NewJaeger() (Tracer, error) {
 		Type:  jaeger.SamplerTypeConst,
 		Param: 1,
 	}
-	cfg.Reporter.LogSpans = true
+	cfg.Reporter.LogSpans = false
 	log.WithFields("config", cfg).Infof("Tracing spans reported to '%s'", cfg.Reporter.LocalAgentHostPort)
 
 	tracer, closer, err := cfg.NewTracer(


### PR DESCRIPTION
The logs do not provide any value as is so we might as well drop them.

The logs look like below.

```
Reporting span 4df233c828bf58d7:dd179f36a4179a6:4df233c828bf58d7:1
```