### PR TITLE
Add alias to branch and env flags

### DIFF
--- a/cmd/hamctl/command/describe.go
+++ b/cmd/hamctl/command/describe.go
@@ -79,7 +79,7 @@ Format the output with a custom template:
 			return nil
 		},
 	}
-	command.Flags().StringVar(&environment, "env", "", "environment to promote to (required)")
+	command.Flags().StringVarP(&environment, "env", "e", "", "environment to promote to (required)")
 	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
 	command.MarkFlagRequired("env")
 	command.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace the service is deployed to (defaults to env)")

--- a/cmd/hamctl/command/policy/apply.go
+++ b/cmd/hamctl/command/policy/apply.go
@@ -67,10 +67,10 @@ func autoRelease(client *httpinternal.Client, service *string) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&branch, "branch", "", "Branch to auto-release artifacts from")
+	command.Flags().StringVarP(&branch, "branch", "b", "", "Branch to auto-release artifacts from")
 	command.MarkFlagRequired("branch")
 	completion.FlagAnnotation(command, "branch", "__hamctl_get_branches")
-	command.Flags().StringVar(&env, "env", "", "Environment to release artifacts to")
+	command.Flags().StringVarP(&env, "env", "e", "", "Environment to release artifacts to")
 	command.MarkFlagRequired("env")
 	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
 	return command

--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -51,7 +51,7 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&environment, "env", "", "Environment to promote to (required)")
+	command.Flags().StringVarP(&environment, "env", "e", "", "Environment to promote to (required)")
 	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
 	command.MarkFlagRequired("env")
 	command.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace the service is deployed to (defaults to env)")

--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -60,10 +60,10 @@ Release latest artifact from branch 'master' of service 'product' into environme
 			return nil
 		},
 	}
-	command.Flags().StringVar(&environment, "env", "", "environment to release to (required)")
+	command.Flags().StringVarP(&environment, "env", "e", "", "environment to release to (required)")
 	command.MarkFlagRequired("env")
 	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
-	command.Flags().StringVar(&branch, "branch", "", "release latest artifact from this branch (mutually exclusive with --artifact)")
+	command.Flags().StringVarP(&branch, "branch", "b", "", "release latest artifact from this branch (mutually exclusive with --artifact)")
 	completion.FlagAnnotation(command, "branch", "__hamctl_get_branches")
 	command.Flags().StringVar(&artifact, "artifact", "", "release this artifact id (mutually exclusive with --branch)")
 	return command

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -61,7 +61,7 @@ has no effect.`,
 			return nil
 		},
 	}
-	command.Flags().StringVar(&environment, "env", "", "environment to release to (required)")
+	command.Flags().StringVarP(&environment, "env", "e", "", "environment to release to (required)")
 	command.MarkFlagRequired("env")
 	completion.FlagAnnotation(command, "env", "__hamctl_get_environments")
 	command.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace the service is deployed to (defaults to env)")


### PR DESCRIPTION
Spare some key strokes by adding a command line alias for `branch` and `env` flags, `b` and `e` respectively.