### PR TITLE
Ignore .git and what is in .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/dist
+artifact-linux-amd64
+.tmp/
+.idea/
+/.vscode/
+/cmd/artifact/examples
+/cmd/artifact/artifact
+message.json
+artifact.json
+/profiles/
+/.git
+/main


### PR DESCRIPTION
This reduces build times as we do not have to copy the .git directory
into Docker context.

As of now this reduces the copied data from 159MB to 18MB.