### PR TITLE
Remove fmt.Printf from log.Init

### DIFF
--- a/internal/log/configuration.go
+++ b/internal/log/configuration.go
@@ -18,7 +18,6 @@ func Init(c *Configuration) {
 	if c == nil {
 		c = &Configuration{}
 	}
-	fmt.Printf("Config: %+v\n", *c)
 	encoder := zapcore.EncoderConfig{
 		TimeKey:        "@timestamp",
 		LevelKey:       "level",


### PR DESCRIPTION
Left over from debugging at some point.