### PR TITLE
Remove temp files synchronously in artifact

### DIFF
--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -23,7 +23,7 @@ type DescribeReleaseResponse struct {
 func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, service string) (DescribeReleaseResponse, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.DescribeRelease")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-describe-release")
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-release")
 	if err != nil {
 		return DescribeReleaseResponse{}, err
 	}
@@ -66,7 +66,7 @@ func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, s
 func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) ([]artifact.Spec, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.DescribeArtifact")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-describe-artifact")
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -92,7 +92,7 @@ type Actor struct {
 func (s *Service) Status(ctx context.Context, namespace, service string) (StatusResponse, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.Status")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-status")
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-status")
 	if err != nil {
 		return StatusResponse{}, err
 	}

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -15,7 +15,7 @@ import (
 func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequest) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.NotifyCommitter")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-notify")
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-notify")
 	if err != nil {
 		return err
 	}

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -39,12 +39,12 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 	defer span.Finish()
 	var result PromoteResult
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
-		sourceConfigRepoPath, closeSource, err := git.TempDir(ctx, s.Tracer, "k8s-config-promote-source")
+		sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
 		if err != nil {
 			return true, err
 		}
 		defer closeSource(ctx)
-		destinationConfigRepoPath, closeDestination, err := git.TempDir(ctx, s.Tracer, "k8s-config-promote-destination")
+		destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-destination")
 		if err != nil {
 			return true, err
 		}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -26,7 +26,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 	defer span.Finish()
 	var result string
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
-		sourceConfigRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-release-branch")
+		sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-branch")
 		if err != nil {
 			return true, err
 		}
@@ -114,12 +114,12 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 	defer span.Finish()
 	var result string
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
-		sourceConfigRepoPath, closeSource, err := git.TempDir(ctx, s.Tracer, "k8s-config-release-artifact-source")
+		sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-source")
 		if err != nil {
 			return true, err
 		}
 		defer closeSource(ctx)
-		destinationConfigRepoPath, closeDestination, err := git.TempDir(ctx, s.Tracer, "k8s-config-release-artifact-destination")
+		destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
 		if err != nil {
 			return true, err
 		}

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -22,12 +22,12 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 	defer span.Finish()
 	var result RollbackResult
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
-		sourceConfigRepoPath, closeSource, err := git.TempDir(ctx, s.Tracer, "k8s-config-rollback-source")
+		sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-rollback-source")
 		if err != nil {
 			return true, err
 		}
 		defer closeSource(ctx)
-		destinationConfigRepoPath, closeDestination, err := git.TempDir(ctx, s.Tracer, "k8s-config-rollback-destination")
+		destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-rollback-destination")
 		if err != nil {
 			return true, err
 		}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -63,7 +63,7 @@ func (s *Service) GetAutoReleases(ctx context.Context, svc, branch string) ([]Au
 func (s *Service) Get(ctx context.Context, svc string) (Policies, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "policy.Get")
 	defer span.Finish()
-	configRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-notify")
+	configRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-notify")
 	if err != nil {
 		return Policies{}, err
 	}
@@ -137,7 +137,7 @@ func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMs
 	span, ctx := s.Tracer.FromCtx(ctx, "policy.updatePolicies")
 	defer span.Finish()
 	return try.Do(ctx, s.Tracer, s.MaxRetries, func(ctx context.Context, attempt int) (bool, error) {
-		configRepoPath, close, err := git.TempDir(ctx, s.Tracer, "k8s-config-notify")
+		configRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-notify")
 		if err != nil {
 			return true, err
 		}


### PR DESCRIPTION
Currently we see k8s-master-clone* and k8s-config-artifact* directories
leaked on CI due to artifact trying to clean up asynchronously.
All Go routines are shut down when the process exits so there is no way of
knowing when the operation completed.

This change adds a git.TempDirAsync function that acts like existing the
git.TempDir, ie. removes the temp dir asynchronously.
git.TempDir is updated to remve the directory synchronously.

This should ensure that the artifact CLI will clean up temporary files
before exiting while keeping the HTTP server fast.

Not that this diff explicitly does not touch the two places where we now get
synchronous clean up, ie. [`InitMasterRepo`](https://github.com/lunarway/release-manager/blob/e493a6481a724087ba9e4ae4b054d9dbff3c1c16/internal/git/git.go#L46-L65) and [`PushArtifact`](https://github.com/lunarway/release-manager/blob/e493a6481a724087ba9e4ae4b054d9dbff3c1c16/internal/flow/flow.go#L250-L254).