### PR TITLE
Improve policy delete help text

### DIFF
--- a/cmd/hamctl/command/policy/delete.go
+++ b/cmd/hamctl/command/policy/delete.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -12,8 +13,34 @@ import (
 func NewDelete(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete one or more policies",
-		Args:  cobra.MinimumNArgs(1),
+		Short: "Delete one or more policies by their id.",
+		Args: func(c *cobra.Command, args []string) error {
+			err := cobra.MinimumNArgs(1)(c, args)
+			if err != nil {
+				return errors.New("at least one policy id must be specified.")
+			}
+			return nil
+		},
+		Example: `List available policies:
+
+	$ hamctl --service product policy list
+
+	Policies for service product
+
+	Auto-releases:
+
+	BRANCH     ENV      ID
+	master     dev      auto-release-master-dev
+	master     prod     auto-release-master-prod
+
+Delete a single policy:
+
+	$ hamctl --service product policy delete auto-release-master-dev
+
+Delete multiple policies:
+
+	$ hamctl --service product policy delete auto-release-master-dev auto-release-master-prod
+`,
 		RunE: func(c *cobra.Command, args []string) error {
 			committerName, committerEmail, err := git.CommitterDetails()
 			if err != nil {
@@ -38,5 +65,31 @@ func NewDelete(client *httpinternal.Client, service *string) *cobra.Command {
 			return nil
 		},
 	}
+	// copied from cobra's default usage template with the addition of policy id arguments
+	// https://github.com/spf13/cobra/blob/77e4d5aecc4d34e58f72e5a1c4a5a13ef55e6f44/command.go#L464-L487
+	command.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}} [policy-id]{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
 	return command
 }


### PR DESCRIPTION
The current default help text has no information about the positional arguments
for policy ids.

This change adds examples of usage along with a more precise usage string
including.

    $ hamctl policy delete
    Error: at least one policy id must be specified.
    Usage:
      hamctl policy delete [flags] [policy-id]

    Examples:
    List available policies:

      $ hamctl --service product policy list

      Policies for service product

      Auto-releases:

      BRANCH     ENV      ID
      master     dev      auto-release-master-dev
      master     prod     auto-release-master-prod

    Delete a single policy:

      $ hamctl --service product policy delete auto-release-master-dev

    Delete multiple policies:

      $ hamctl --service product policy delete auto-release-master-dev auto-release-master-prod

    Flags:
      -h, --help   help for delete

    Global Flags:
          --http-auth-token string   auth token for the http service (default "RrZa8JGgLJW87rZfegyKkCE8cgJ8Vc9t")
          --http-base-url string     address of the http release manager server (default "https://release-manager.dev.lunarway.com")
          --http-timeout duration    HTTP request timeout (default 30s)
          --service string           service name to execute commands for

    exit status 1