### PR TITLE
Better tracing

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -40,14 +40,14 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", ping)
-	mux.HandleFunc("/promote", trace(tracer, "promote", authenticate(opts.HamCtlAuthToken, promote(&payloader, flowSvc))))
-	mux.HandleFunc("/release", trace(tracer, "release", authenticate(opts.HamCtlAuthToken, release(&payloader, flowSvc))))
-	mux.HandleFunc("/status", trace(tracer, "status", authenticate(opts.HamCtlAuthToken, status(&payloader, flowSvc))))
-	mux.HandleFunc("/rollback", trace(tracer, "rollback", authenticate(opts.HamCtlAuthToken, rollback(&payloader, flowSvc))))
-	mux.HandleFunc("/policies", trace(tracer, "policies", authenticate(opts.HamCtlAuthToken, policy(&payloader, policySvc))))
-	mux.HandleFunc("/describe/", trace(tracer, "describe", authenticate(opts.HamCtlAuthToken, describe(&payloader, flowSvc))))
-	mux.HandleFunc("/webhook/github", trace(tracer, "webhook/github", githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret)))
-	mux.HandleFunc("/webhook/daemon", trace(tracer, "webhook/daemon", authenticate(opts.DaemonAuthToken, daemonWebhook(&payloader, flowSvc))))
+	mux.HandleFunc("/promote", trace(tracer, authenticate(opts.HamCtlAuthToken, promote(&payloader, flowSvc))))
+	mux.HandleFunc("/release", trace(tracer, authenticate(opts.HamCtlAuthToken, release(&payloader, flowSvc))))
+	mux.HandleFunc("/status", trace(tracer, authenticate(opts.HamCtlAuthToken, status(&payloader, flowSvc))))
+	mux.HandleFunc("/rollback", trace(tracer, authenticate(opts.HamCtlAuthToken, rollback(&payloader, flowSvc))))
+	mux.HandleFunc("/policies", trace(tracer, authenticate(opts.HamCtlAuthToken, policy(&payloader, policySvc))))
+	mux.HandleFunc("/describe/", trace(tracer, authenticate(opts.HamCtlAuthToken, describe(&payloader, flowSvc))))
+	mux.HandleFunc("/webhook/github", trace(tracer, githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret)))
+	mux.HandleFunc("/webhook/daemon", trace(tracer, authenticate(opts.DaemonAuthToken, daemonWebhook(&payloader, flowSvc))))
 
 	// profiling endpoints
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
@@ -75,10 +75,10 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 }
 
 // trace adds an OpenTracing span to the request context.
-func trace(tracer tracing.Tracer, op string, h http.HandlerFunc) http.HandlerFunc {
+func trace(tracer tracing.Tracer, h http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		span, ctx := tracer.FromCtxf(ctx, fmt.Sprintf("http %s %s", r.Method, r.URL.Path))
+		span, ctx := tracer.FromCtxf(ctx, "http %s %s", r.Method, r.URL.Path)
 		defer span.Finish()
 		*r = *r.WithContext(ctx)
 		lrw := &statusCodeResponseWriter{w, http.StatusOK}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -81,12 +81,12 @@ func trace(tracer tracing.Tracer, h http.HandlerFunc) http.HandlerFunc {
 		span, ctx := tracer.FromCtxf(ctx, "http %s %s", r.Method, r.URL.Path)
 		defer span.Finish()
 		*r = *r.WithContext(ctx)
-		lrw := &statusCodeResponseWriter{w, http.StatusOK}
-		h(lrw, r)
-		span.SetTag("http.status_code", lrw.statusCode)
+		statusWriter := &statusCodeResponseWriter{w, http.StatusOK}
+		h(statusWriter, r)
+		span.SetTag("http.status_code", statusWriter.statusCode)
 		span.SetTag("http.url", r.URL.RequestURI())
 		span.SetTag("http.method", r.Method)
-		if lrw.statusCode >= http.StatusInternalServerError {
+		if statusWriter.statusCode >= http.StatusInternalServerError {
 			span.SetTag("error", true)
 		}
 	})

--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -13,24 +13,24 @@ type statusCodeResponseWriter struct {
 	statusCode int
 }
 
-func (lrw *statusCodeResponseWriter) WriteHeader(code int) {
-	lrw.statusCode = code
-	lrw.ResponseWriter.WriteHeader(code)
+func (w *statusCodeResponseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
 }
 
 // reqrespLogger returns an http.Handler that logs request and response
 // details.
 func reqrespLogger(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lrw := &statusCodeResponseWriter{w, http.StatusOK}
+		statusWriter := &statusCodeResponseWriter{w, http.StatusOK}
 		start := time.Now()
-		h.ServeHTTP(lrw, r)
+		h.ServeHTTP(statusWriter, r)
 		if r.URL.Path == "/ping" {
 			return
 		}
 		// request duration in miliseconds
 		duration := time.Since(start).Nanoseconds() / 1e6
-		statusCode := lrw.statusCode
+		statusCode := statusWriter.statusCode
 		logger := log.With(
 			"req", struct {
 				URL     string            `json:"url,omitempty"`

--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -8,12 +8,12 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 )
 
-type loggingResponseWriter struct {
+type statusCodeResponseWriter struct {
 	http.ResponseWriter
 	statusCode int
 }
 
-func (lrw *loggingResponseWriter) WriteHeader(code int) {
+func (lrw *statusCodeResponseWriter) WriteHeader(code int) {
 	lrw.statusCode = code
 	lrw.ResponseWriter.WriteHeader(code)
 }
@@ -22,7 +22,7 @@ func (lrw *loggingResponseWriter) WriteHeader(code int) {
 // details.
 func reqrespLogger(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lrw := &loggingResponseWriter{w, http.StatusOK}
+		lrw := &statusCodeResponseWriter{w, http.StatusOK}
 		start := time.Now()
 		h.ServeHTTP(lrw, r)
 		if r.URL.Path == "/ping" {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -111,7 +111,8 @@ func (s *Service) Status(ctx context.Context, namespace, service string) (Status
 		}
 		return namespace
 	}
-	span, _ = s.Tracer.FromCtx(ctx, "envSpec dev")
+	span, _ = s.Tracer.FromCtx(ctx, "artifact spec for environment")
+	span.SetTag("env", "dev")
 	devSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "dev", defaultNamespace("dev"))
 	if err != nil {
 		cause := errors.Cause(err)
@@ -121,7 +122,8 @@ func (s *Service) Status(ctx context.Context, namespace, service string) (Status
 	}
 	defer span.Finish()
 
-	span, _ = s.Tracer.FromCtx(ctx, "envSpec staging")
+	span, _ = s.Tracer.FromCtx(ctx, "artifact spec for environment")
+	span.SetTag("env", "staging")
 	stagingSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "staging", defaultNamespace("staging"))
 	if err != nil {
 		cause := errors.Cause(err)
@@ -131,7 +133,8 @@ func (s *Service) Status(ctx context.Context, namespace, service string) (Status
 	}
 	defer span.Finish()
 
-	span, _ = s.Tracer.FromCtx(ctx, "envSpec prod")
+	span, _ = s.Tracer.FromCtx(ctx, "artifact spec for environment")
+	span.SetTag("env", "prod")
 	prodSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, "prod", defaultNamespace("prod"))
 	if err != nil {
 		cause := errors.Cause(err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -351,6 +351,7 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, authorName,
 	span, ctx := s.Tracer.FromCtx(ctx, "git.Commit")
 	defer span.Finish()
 
+	span, _ = s.Tracer.FromCtx(ctx, "add changes")
 	err := execCommand(ctx, rootPath, "git", "add", ".")
 	span.Finish()
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -71,15 +71,20 @@ func (s *Service) clone(ctx context.Context, destination string) (*git.Repositor
 	if err != nil {
 		return nil, errors.WithMessage(err, "public keys from file")
 	}
+	span, _ = s.Tracer.FromCtx(ctx, "remove destination")
+	span.SetTag("path", destination)
 	err = os.RemoveAll(destination)
+	span.Finish()
 	if err != nil {
 		return nil, errors.WithMessage(err, "remove existing destination")
 	}
 
+	span, _ = s.Tracer.FromCtx(ctx, "plain clone")
 	r, err := git.PlainCloneContext(ctx, destination, false, &git.CloneOptions{
 		URL:  s.ConfigRepoURL,
 		Auth: authSSH,
 	})
+	span.Finish()
 	if err != nil {
 		return nil, errors.WithMessage(err, "clone repo")
 	}

--- a/internal/git/temp_dir.go
+++ b/internal/git/temp_dir.go
@@ -13,7 +13,8 @@ import (
 // The first return argument is the path. The second is a close function to
 // remove the path.
 func TempDir(ctx context.Context, tracer tracing.Tracer, prefix string) (string, func(context.Context), error) {
-	span, _ := tracer.FromCtxf(ctx, "create temp dir for '%s'", prefix)
+	span, _ := tracer.FromCtxf(ctx, "create temp dir")
+	span.SetTag("path_prefix", prefix)
 	defer span.Finish()
 	path, err := ioutil.TempDir("", prefix)
 	if err != nil {

--- a/internal/git/temp_dir.go
+++ b/internal/git/temp_dir.go
@@ -21,7 +21,8 @@ func TempDir(ctx context.Context, tracer tracing.Tracer, prefix string) (string,
 		return "", func(context.Context) {}, err
 	}
 	return path, func(ctx context.Context) {
-		span, _ := tracer.FromCtxf(ctx, "clean temp dir for '%s'", prefix)
+		span, _ := tracer.FromCtxf(ctx, "clean temp dir")
+		span.SetTag("path_prefix", prefix)
 		defer span.Finish()
 		err := os.RemoveAll(path)
 		if err != nil {

--- a/internal/try/try.go
+++ b/internal/try/try.go
@@ -28,8 +28,9 @@ func Do(ctx context.Context, tracer tracing.Tracer, max int, f func(context.Cont
 		case <-ctx.Done():
 			return multierr.Append(errs, ctx.Err())
 		default:
-			span, ctx := tracer.FromCtxf(ctx, "attempt %d", attempt)
+			span, ctx := tracer.FromCtxf(ctx, "retry attempt")
 			defer span.Finish()
+			span.SetTag("attempt_number", fmt.Sprintf("%d", attempt))
 			stop, err := f(ctx, attempt)
 			if err == nil {
 				return nil


### PR DESCRIPTION
This change set reduces the difference of traces covering the same operations
along with fixing some bugs in the current traces.

Each span now represents the operation they cover and not the parameters of the
operation, ie. "retry attempt" instead of "attempt 1", as the operations are
what we generally want to understand.

The HTTP root spans now contains tags for their method, path (including query
params) and in case of errors the `error=true` tag. This is picked up by Jaeger
UI and highlighted so it becomes easier to see what went wrong.