### PR TITLE
Mark context errors in logs and traces

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -89,6 +89,11 @@ func trace(tracer tracing.Tracer, h http.HandlerFunc) http.HandlerFunc {
 		if statusWriter.statusCode >= http.StatusInternalServerError {
 			span.SetTag("error", true)
 		}
+		err := ctx.Err()
+		if err != nil {
+			span.SetTag("error", true)
+			span.SetTag("error_message", err.Error())
+		}
 	})
 }
 

--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -31,7 +31,7 @@ func reqrespLogger(h http.Handler) http.Handler {
 		// request duration in miliseconds
 		duration := time.Since(start).Nanoseconds() / 1e6
 		statusCode := statusWriter.statusCode
-		logger := log.With(
+		fields := []interface{}{
 			"req", struct {
 				URL     string            `json:"url,omitempty"`
 				Method  string            `json:"method,omitempty"`
@@ -49,7 +49,12 @@ func reqrespLogger(h http.Handler) http.Handler {
 				StatusCode: statusCode,
 			},
 			"responseTime", duration,
-		)
+		}
+		err := r.Context().Err()
+		if err != nil {
+			fields = append(fields, "error", err)
+		}
+		logger := log.With(fields...)
 		if statusCode >= http.StatusInternalServerError {
 			logger.Errorf("[%d] %s %s", statusCode, r.Method, r.URL.Path)
 			return


### PR DESCRIPTION
This will make request cancellations visible in both logs and traces to help
with understanding partial flows.