### PR TITLE
Add request IDs to traces and logs

### DIFF
--- a/cmd/hamctl/main.go
+++ b/cmd/hamctl/main.go
@@ -28,7 +28,6 @@ func main() {
 	c.AddCommand(versionCmd)
 	err = c.Execute()
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -33,11 +33,13 @@ func reqrespLogger(h http.Handler) http.Handler {
 		statusCode := statusWriter.statusCode
 		fields := []interface{}{
 			"req", struct {
+				ID      string            `json:"id,omitempty"`
 				URL     string            `json:"url,omitempty"`
 				Method  string            `json:"method,omitempty"`
 				Path    string            `json:"path,omitempty"`
 				Headers map[string]string `json:"headers,omitempty"`
 			}{
+				ID:      getRequestID(r),
 				URL:     r.URL.RequestURI(),
 				Method:  r.Method,
 				Path:    r.URL.Path,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/lunarway/color v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
@@ -48,12 +49,13 @@ type PromoteResponse struct {
 type ErrorResponse struct {
 	Status  int    `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
+	ID      string `json:"-"`
 }
 
 var _ error = &ErrorResponse{}
 
 func (e *ErrorResponse) Error() string {
-	return e.Message
+	return fmt.Sprintf("%s\nReference: %s", e.Message, e.ID)
 }
 
 type ReleaseRequest struct {


### PR DESCRIPTION
Request IDs are generated by hamctl and passed in an HTTP header to the server.
The server will tag request logs and traces with the request ID.

If no request ID is set in the incoming request the server generates one.