### PR TITLE
Native copy command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,6 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/nlopes/slack v0.6.0
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/otiai10/copy v1.0.2
-	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
-bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -161,15 +159,6 @@ github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuB
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
-github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 h1:o59bHXu8Ejas8Kq6pjoVJQ9/neN66SM8AKh6wI42BBs=
-github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZeFXocWuvtcS0XSFLcf2XUSDHkq9t1jU4=
-github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGBkR3M=
-github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -1,7 +1,6 @@
 package copy
 
 import (
-	"context"
 	"io/ioutil"
 	"os/exec"
 	"strings"
@@ -11,12 +10,12 @@ import (
 )
 
 func Copy(src, dest string) error {
-	return execCommand(context.Background(), ".", "cp", "-a", src, dest)
+	return execCommand(".", "cp", "-a", src, dest)
 }
 
-func execCommand(ctx context.Context, rootPath string, cmdName string, args ...string) error {
+func execCommand(rootPath string, cmdName string, args ...string) error {
 	log.WithFields("root", rootPath).Infof("copy/execCommand: running: %s %s", cmdName, strings.Join(args, " "))
-	cmd := exec.CommandContext(ctx, cmdName, args...)
+	cmd := exec.Command(cmdName, args...)
 	cmd.Dir = rootPath
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -1,0 +1,50 @@
+package copy
+
+import (
+	"context"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/pkg/errors"
+)
+
+func Copy(src, dest string) error {
+	return execCommand(context.Background(), ".", "cp", "-a", src, dest)
+}
+
+func execCommand(ctx context.Context, rootPath string, cmdName string, args ...string) error {
+	log.WithFields("root", rootPath).Infof("copy/execCommand: running: %s %s", cmdName, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+	cmd.Dir = rootPath
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return errors.WithMessage(err, "get stdout pipe for command")
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return errors.WithMessage(err, "get stderr pipe for command")
+	}
+	err = cmd.Start()
+	if err != nil {
+		return errors.WithMessage(err, "start command")
+	}
+
+	stdoutData, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		return errors.WithMessage(err, "read stdout data of command")
+	}
+	stderrData, err := ioutil.ReadAll(stderr)
+	if err != nil {
+		return errors.WithMessage(err, "read stderr data of command")
+	}
+
+	err = cmd.Wait()
+	log.Infof("copy/execCommand: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
+	log.Infof("copy/execCommand: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
+	if err != nil {
+		return errors.WithMessage(err, "execute command failed")
+	}
+	return nil
+}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/lunarway/release-manager/internal/try"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 )
 

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"path"
 
-	"gopkg.in/src-d/go-git.v4/plumbing"
-
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 // Promote promotes a specific service to environment env.

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -6,9 +6,9 @@ import (
 	"path"
 
 	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 )
 

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 )
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/tracing"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"


### PR DESCRIPTION
As an attempt to optimize copy performance this change uses Linux cp command
instead of github.com/otiai10/copy to copy the master repository.

The module is responsible for most CPU work and allocations naturaly as this is
one of the main operations of the release-manager. Hopefully by using a native
implementation the time spend on these operations is optimized.