### PR TITLE
Upgrade Go and Alpine to latest

### DIFF
--- a/Dockerfile-daemon
+++ b/Dockerfile-daemon
@@ -1,4 +1,4 @@
-FROM golang:1.13.0 as builder
+FROM golang:1.13.5 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-daemon-goreleaser
+++ b/Dockerfile-daemon-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.10.2 as builder
+FROM alpine:3.10.3 as builder
 
 RUN apk update
 RUN apk add ca-certificates

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.13.0 as builder
+FROM golang:1.13.5 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -13,7 +13,7 @@ COPY cmd/server/ ./cmd/server/
 
 RUN go build -o server cmd/server/main.go
 
-FROM alpine:3.10.2
+FROM alpine:3.10.3
 RUN   apk update && \
       apk add --no-cache \
       openssh-keygen bash openssh-client git ca-certificates

--- a/Dockerfile-server-goreleaser
+++ b/Dockerfile-server-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.10.2
+FROM alpine:3.10.3
 RUN   apk update && \
       apk add --no-cache \
       openssh-keygen bash openssh-client git ca-certificates


### PR DESCRIPTION
Awaits the Go 1.13.5 Docker image is available on [Docker hub](https://hub.docker.com/_/golang/).