### PR TITLE
Fix directory copies

### DIFF
--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -1,7 +1,9 @@
 package copy
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -9,7 +11,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Copy(src, dest string) error {
+func CopyDir(src, dest string) error {
+	if !strings.HasSuffix(src, string(os.PathSeparator)) {
+		src = fmt.Sprintf("%s/", src)
+	}
+	return execCommand(".", "cp", "-a", src, dest)
+}
+
+func CopyFile(src, dest string) error {
 	return execCommand(".", "cp", "-a", src, dest)
 }
 

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -275,7 +275,7 @@ func PushArtifact(ctx context.Context, gitSvc *git.Service, artifactFileName, re
 		return "", errors.WithMessage(err, fmt.Sprintf("create destination dir '%s'", destinationPath))
 	}
 	fmt.Printf("Copy configuration into destination\n")
-	err = copy.Copy(resourceRoot, destinationPath)
+	err = copy.CopyDir(resourceRoot, destinationPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("copy resources from '%s' to '%s'", resourceRoot, destinationPath))
 	}
@@ -350,7 +350,7 @@ func (s *Service) cleanCopy(ctx context.Context, src, dest string) error {
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "copy files")
 	span.Finish()
-	err = copy.Copy(src, dest)
+	err = copy.CopyDir(src, dest)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return ErrUnknownConfiguration

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -121,7 +121,7 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 		artifactSourcePath := srcPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		log.Debugf("Copy artifact from: %s to %s", artifactSourcePath, artifactDestinationPath)
-		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		err = copy.CopyFile(artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -65,7 +65,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		// repo/{env}/releases/{ns}/{service}/{artifactFileName}
 		artifactDestinationPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		log.Infof("flow: ReleaseBranch: copy artifact from %s to %s", artifactSpecPath, artifactDestinationPath)
-		err = copy.Copy(artifactSpecPath, artifactDestinationPath)
+		err = copy.CopyFile(artifactSpecPath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
 		}
@@ -173,7 +173,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		artifactSourcePath := srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		err = copy.CopyFile(artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -107,7 +107,7 @@ func (s *Service) Rollback(ctx context.Context, actor Actor, environment, namesp
 		artifactSourcePath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-		err = copy.Copy(artifactSourcePath, artifactDestinationPath)
+		err = copy.CopyFile(artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -136,7 +136,7 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 	defer s.masterMutex.RUnlock()
 	span.Finish()
 	span, _ = s.Tracer.FromCtx(ctx, "copy to destination")
-	err = copy.Copy(s.masterPath, destination)
+	err = copy.CopyDir(s.masterPath, destination)
 	span.Finish()
 	if err != nil {
 		return nil, errors.WithMessagef(err, "copy master from '%s'", s.masterPath)


### PR DESCRIPTION
Migrating to using native cp command changed the contract og copy.Copy.

Directories are moved instead of their contents copied which leads to wrong
directories being created.