### PR TITLE
Fix directory copy on linux

### DIFF
--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -13,7 +13,7 @@ import (
 
 func CopyDir(src, dest string) error {
 	if !strings.HasSuffix(src, string(os.PathSeparator)) {
-		src = fmt.Sprintf("%s/", src)
+		src = fmt.Sprintf("%s/.", src)
 	}
 	return execCommand(".", "cp", "-a", src, dest)
 }


### PR DESCRIPTION
Linux cp command treats directories differently.
This ensures equal behaviour between macOS and Linux.