### PR TITLE
Handle unknown configuration

### DIFF
--- a/internal/copy/copy_test.go
+++ b/internal/copy/copy_test.go
@@ -1,0 +1,58 @@
+package copy_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/lunarway/release-manager/internal/copy"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestCopyDir(t *testing.T) {
+	tt := []struct {
+		name string
+		src  string
+		dest string
+		err  error
+	}{
+		{
+			name: "existing directory",
+			src:  "testdata/dir-a",
+			dest: "testdata/new-dir-a",
+			err:  nil,
+		},
+		{
+			name: "unknown source directory",
+			src:  "testdata/dir-unknown",
+			dest: "testdata/new-dir-a",
+			err:  copy.ErrUnknownSource,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			log.Init(&log.Configuration{
+				Level: log.Level{
+					Level: zapcore.DebugLevel,
+				},
+				Development: true,
+			})
+			pwd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("unexpeted error getting pwd: %v", err)
+			}
+			t.Logf("Using pwd: %s", pwd)
+			absSrc := path.Join(pwd, tc.src)
+			absDest := path.Join(pwd, tc.dest)
+			err = copy.CopyDir(absSrc, absDest)
+			defer os.RemoveAll(absDest)
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error(), "wrong error")
+			} else {
+				assert.NoError(t, err, "unepxected error")
+			}
+		})
+	}
+}

--- a/internal/copy/testdata/dir-a/conf.yaml
+++ b/internal/copy/testdata/dir-a/conf.yaml
@@ -1,0 +1,1 @@
+some: conf

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -352,7 +352,7 @@ func (s *Service) cleanCopy(ctx context.Context, src, dest string) error {
 	span.Finish()
 	err = copy.CopyDir(src, dest)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Cause(err) == copy.ErrUnknownSource {
 			return ErrUnknownConfiguration
 		}
 		return errors.WithMessage(err, "copy files")


### PR DESCRIPTION
If a client mistypes an environment, service or branch name we currently fail
with a 500 internal error. This is a bug introduced with commits 62439e7,
7abe09f and 738f3ce when we switched to copy mechanism from Go std lib to native
cp execs.

This change makes package copy expose an `ErrUnknownSource` error if the source
path is not found which error handling is updated to detect.