### PR TITLE
Log errors in daemon

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -85,7 +85,7 @@ func notifyReleaseManager(event *kubernetes.PodEvent, logs, releaseManagerUrl, a
 	})
 
 	if err != nil {
-		log.Errorf("error encoding StatusNotifyRequest: %v", err)
+		log.Errorf("error encoding StatusNotifyRequest: %+v", err)
 		return
 	}
 

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -107,7 +107,7 @@ func notifyReleaseManager(event *kubernetes.PodEvent, logs, releaseManagerUrl, a
 		if err != nil {
 			log.Errorf("failed to read response body: %+v", err)
 		}
-		log.Errorf("release-manager returned %d status-code in notify webhook: %s", resp.Status, body)
+		log.Errorf("release-manager returned %s status-code in notify webhook: %s", resp.Status, body)
 		return
 	}
 }


### PR DESCRIPTION
Currently the daemon logs that it got an error but not what it was. This makes
it hard to understand from the logs alone.

This change logs the actual errors along with the context message.