### PR TITLE
Detect request EOF errors

### DIFF
--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -55,7 +55,10 @@ type ErrorResponse struct {
 var _ error = &ErrorResponse{}
 
 func (e *ErrorResponse) Error() string {
-	return fmt.Sprintf("%s\nReference: %s", e.Message, e.ID)
+	if e.ID != "" {
+		return fmt.Sprintf("%s\nReference: %s", e.Message, e.ID)
+	}
+	return e.Message
 }
 
 type ReleaseRequest struct {


### PR DESCRIPTION
If a client is not connected to the internet or Lunar VPN they receive two
implementation detail errors.

    Error: Post https://release-manager.dev.lunarway.com/release: dial tcp: lookup release-manager.dev.lunarway.com: no such host
    Error: Post https://release-manager.dev.lunarway.com/release: EOF

One indicates no DNS lookup is possible. The other that we cannot connect to the
found IP (if it is inside our VPN).

This change detects these two error cases in the hamctl CLI and will instead
give a more descriptive error.

    Error: could not connect to the release-manager server. Are you connected to the internet and, if required, a VPN?

The `Reference` id output printed together with errors on the client is also
removed if it is empty. These client side errors never reach the server so the
reference ID is only known locally.