### PR TITLE
Remove Git operations when notifying comitter

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -73,15 +73,17 @@ func notifyReleaseManager(event *kubernetes.PodEvent, logs, releaseManagerUrl, a
 
 	b := &bytes.Buffer{}
 	err := json.NewEncoder(b).Encode(httpinternal.PodNotifyRequest{
-		Name:        event.Name,
-		Namespace:   event.Namespace,
-		Message:     event.Message,
-		Reason:      event.Reason,
-		State:       event.State,
-		Containers:  mapContainers(event.Containers),
-		ArtifactID:  event.ArtifactID,
-		Logs:        logs,
-		Environment: environment,
+		Name:           event.Name,
+		Namespace:      event.Namespace,
+		Message:        event.Message,
+		Reason:         event.Reason,
+		State:          event.State,
+		Containers:     mapContainers(event.Containers),
+		ArtifactID:     event.ArtifactID,
+		Logs:           logs,
+		Environment:    environment,
+		AuthorEmail:    event.AuthorEmail,
+		CommitterEmail: event.CommitterEmail,
 	})
 
 	if err != nil {

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -128,6 +128,8 @@ func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {
 	}
 
 	artifactId := pod.Annotations["lunarway.com/artifact-id"]
+	authorEmail := pod.Annotations["lunarway.com/author"]
+	committerEmail := pod.Annotations["lunarway.com/committer"]
 
 	switch e.Type {
 	case watch.Modified:
@@ -181,13 +183,15 @@ func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {
 
 			if containsState(containers, "CrashLoopBackOff") {
 				event := PodEvent{
-					Namespace:  pod.Namespace,
-					Name:       pod.Name,
-					ArtifactID: artifactId,
-					State:      "CrashLoopBackOff",
-					Containers: containers,
-					Reason:     "CrashLoopBackOff",
-					Message:    message,
+					Namespace:      pod.Namespace,
+					Name:           pod.Name,
+					ArtifactID:     artifactId,
+					State:          "CrashLoopBackOff",
+					Containers:     containers,
+					Reason:         "CrashLoopBackOff",
+					Message:        message,
+					AuthorEmail:    authorEmail,
+					CommitterEmail: committerEmail,
 				}
 				err := failed(&event)
 				if err != nil {
@@ -196,13 +200,15 @@ func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {
 				return
 			} else if allContainersReady(containers) {
 				event := PodEvent{
-					Namespace:  pod.Namespace,
-					Name:       pod.Name,
-					ArtifactID: artifactId,
-					State:      "Ready",
-					Containers: containers,
-					Reason:     "",
-					Message:    message,
+					Namespace:      pod.Namespace,
+					Name:           pod.Name,
+					ArtifactID:     artifactId,
+					State:          "Ready",
+					Containers:     containers,
+					Reason:         "",
+					Message:        message,
+					AuthorEmail:    authorEmail,
+					CommitterEmail: committerEmail,
 				}
 				err := succeeded(&event)
 				if err != nil {
@@ -216,12 +222,14 @@ func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {
 			// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
 		case v1.PodFailed:
 			event := PodEvent{
-				Namespace:  pod.Namespace,
-				Name:       pod.Name,
-				ArtifactID: artifactId,
-				State:      string(v1.PodFailed),
-				Reason:     pod.Status.Reason,
-				Message:    pod.Status.Message,
+				Namespace:      pod.Namespace,
+				Name:           pod.Name,
+				ArtifactID:     artifactId,
+				State:          string(v1.PodFailed),
+				Reason:         pod.Status.Reason,
+				Message:        pod.Status.Message,
+				AuthorEmail:    authorEmail,
+				CommitterEmail: committerEmail,
 			}
 			err := failed(&event)
 			if err != nil {
@@ -267,13 +275,15 @@ func statusNotifier(e watch.Event, succeeded, failed NotifyFunc) {
 
 			if containsState(containers, "CreateContainerConfigError") {
 				event := PodEvent{
-					Namespace:  pod.Namespace,
-					Name:       pod.Name,
-					ArtifactID: artifactId,
-					State:      "CreateContainerConfigError",
-					Containers: containers,
-					Reason:     "CreateContainerConfigError",
-					Message:    message,
+					Namespace:      pod.Namespace,
+					Name:           pod.Name,
+					ArtifactID:     artifactId,
+					State:          "CreateContainerConfigError",
+					Containers:     containers,
+					Reason:         "CreateContainerConfigError",
+					Message:        message,
+					AuthorEmail:    authorEmail,
+					CommitterEmail: committerEmail,
 				}
 				err := failed(&event)
 				if err != nil {

--- a/cmd/daemon/kubernetes/types.go
+++ b/cmd/daemon/kubernetes/types.go
@@ -2,13 +2,15 @@ package kubernetes
 
 // PodEvent represents Pod termination event
 type PodEvent struct {
-	Namespace  string      `json:"namespace"`
-	Name       string      `json:"name"`
-	State      string      `json:"state"`
-	Reason     string      `json:"reason"`
-	Message    string      `json:"message"`
-	Containers []Container `json:"containers"`
-	ArtifactID string      `json:"artifactId"`
+	Namespace      string      `json:"namespace"`
+	Name           string      `json:"name"`
+	State          string      `json:"state"`
+	Reason         string      `json:"reason"`
+	Message        string      `json:"message"`
+	Containers     []Container `json:"containers"`
+	ArtifactID     string      `json:"artifactId"`
+	CommitterEmail string      `json:"committerEmail"`
+	AuthorEmail    string      `json:"authorEmail"`
 }
 
 type Container struct {

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -2,11 +2,9 @@ package flow
 
 import (
 	"context"
-	"regexp"
 
 	"strings"
 
-	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
@@ -15,52 +13,9 @@ import (
 func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequest) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.NotifyCommitter")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-notify")
-	if err != nil {
-		return err
-	}
-	defer close(ctx)
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	hash, err := s.Git.LocateEnvRelease(ctx, sourceRepo, event.Environment, event.ArtifactID)
-	if err != nil {
-		return errors.WithMessagef(err, "locate release '%s'", event.ArtifactID)
-	}
-	log.Infof("internal/flow: NotifyCommitter: located release of '%s' on hash '%s'", event.ArtifactID, hash)
-
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		return errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
-
-	commit, err := sourceRepo.CommitObject(hash)
-	if err != nil {
-		return errors.WithMessage(err, "locate commit object")
-	}
-
-	rgx := regexp.MustCompile(`\[(.*?)\/(.*?)\]`)
-	matches := rgx.FindStringSubmatch(commit.Message)
-	if len(matches) < 2 {
-		return errors.WithMessagef(err, "locate service from commit message: '%s'", commit.Message)
-	}
-	// Use environment received from release-daemon
-	env := event.Environment
-	service := matches[2]
-	namespace := event.Namespace
-
-	log.Infof("internal/flow: NotifyCommitter: read spec from: env '%s' namespace '%s' service '%s'", env, namespace, service)
-	sourceSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, env, namespace)
-	if err != nil {
-		return errors.WithMessage(err, "locate source spec")
-	}
-
-	log.Infof("Commit: %+v", commit)
-	email := commit.Committer.Email
+	email := event.CommitterEmail
 	if email == "" {
-		email = commit.Author.Email
+		email = event.AuthorEmail
 	}
 	if !strings.Contains(email, "@lunarway.com") {
 		//check UserMappings
@@ -72,7 +27,7 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 		email = lwEmail
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "post private slack message")
-	err = s.Slack.PostPrivateMessage(email, env, service, sourceSpec, event)
+	err := s.Slack.PostPrivateMessage(email, event)
 	span.Finish()
 	if err != nil {
 		return errors.WithMessage(err, "post private message")

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -79,15 +79,17 @@ type ReleaseResponse struct {
 }
 
 type PodNotifyRequest struct {
-	Namespace   string      `json:"namespace"`
-	Name        string      `json:"name"`
-	State       string      `json:"state"`
-	Reason      string      `json:"reason"`
-	Message     string      `json:"message"`
-	Containers  []Container `json:"containers"`
-	ArtifactID  string      `json:"artifactId"`
-	Logs        string      `json:"logs"`
-	Environment string      `json:"environment"`
+	Namespace      string      `json:"namespace"`
+	Name           string      `json:"name"`
+	State          string      `json:"state"`
+	Reason         string      `json:"reason"`
+	Message        string      `json:"message"`
+	Containers     []Container `json:"containers"`
+	ArtifactID     string      `json:"artifactId"`
+	Logs           string      `json:"logs"`
+	Environment    string      `json:"environment"`
+	CommitterEmail string      `json:"committerEmail"`
+	AuthorEmail    string      `json:"authorEmail"`
 }
 
 type Container struct {


### PR DESCRIPTION
This change removes the need for locating the artifact spec when handling daemon
webhooks. We can derive all the necessary information from the pod annotations
and pod event instead.

This reduces heavy load on the server if multiple pods are in CrashLoopBackoff
as we no longer do any git operations nor expensive cp operations for every pod
start/fail event.