### PR TITLE
Always use author email for notifications

### DIFF
--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -13,10 +13,7 @@ import (
 func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequest) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.NotifyCommitter")
 	defer span.Finish()
-	email := event.CommitterEmail
-	if email == "" {
-		email = event.AuthorEmail
-	}
+	email := event.AuthorEmail
 	if !strings.Contains(email, "@lunarway.com") {
 		//check UserMappings
 		lwEmail, ok := s.UserMappings[email]


### PR DESCRIPTION
As merged/rebase GitHub PRs uses noreply@github.com as committer the field makes
little sense to use for slack notifications.