### PR TITLE
Change private release messages

### DIFF
--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -115,7 +115,7 @@ func (c *Client) PostPrivateMessage(email string, podNotify *http.PodNotifyReque
 
 func successMessage(podNotify *http.PodNotifyRequest) slack.MsgOption {
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf("[%s] :white_check_mark: %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
+		Title:      fmt.Sprintf(":white_check_mark: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
 		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
 		Color:      "#73bf69",
 		MarkdownIn: []string{"text", "fields"},
@@ -129,7 +129,7 @@ func createConfigErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOption 
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf("[%s] :no_entry: %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
+		Title:      fmt.Sprintf(":no_entry: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
 		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
@@ -144,7 +144,7 @@ func crashLoopBackOffErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOpt
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf("[%s] :no_entry: %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
+		Title:      fmt.Sprintf(":no_entry: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
 		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},


### PR DESCRIPTION
This change moves the emoji to the beginning of the slack messages.
This reads a bit more clear than having the environment first.

Before it was:

> [prod] :white_check_mark: subscription-67f9bf7d67-blr7f (Ready)

With this change it becomes
> :white_check_mark: [prod] subscription-67f9bf7d67-blr7f (Ready)