### PR TITLE
Add context logging

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -93,7 +93,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, githubAPIToke
 				NotifyReleaseHook: func(ctx context.Context, opts flow.NotifyReleaseOptions) {
 					span, ctx := tracer.FromCtx(ctx, "flow.NotifyReleaseHook")
 					defer span.Finish()
-					logger := log.WithFields("service", opts.Service,
+					logger := log.WithContext(ctx).WithFields("service", opts.Service,
 						"environment", opts.Environment,
 						"namespace", opts.Namespace,
 						"artifact-id", opts.Spec.ID,
@@ -108,7 +108,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, githubAPIToke
 						"type", "release")
 
 					span, _ = tracer.FromCtx(ctx, "notify release channel")
-					err := slackClient.NotifySlackReleasesChannel(slack.ReleaseOptions{
+					err := slackClient.NotifySlackReleasesChannel(ctx, slack.ReleaseOptions{
 						Service:       opts.Service,
 						Environment:   opts.Environment,
 						ArtifactID:    opts.Spec.ID,
@@ -124,7 +124,7 @@ func NewStart(grafanaOpts *grafanaOptions, slackAuthToken *string, githubAPIToke
 					}
 
 					span, _ = tracer.FromCtx(ctx, "annotate grafana")
-					err = grafanaSvc.Annotate(opts.Environment, grafana.AnnotateRequest{
+					err = grafanaSvc.Annotate(ctx, opts.Environment, grafana.AnnotateRequest{
 						What: fmt.Sprintf("Deployment: %s", opts.Service),
 						Data: fmt.Sprintf("Author: %s\nMessage: %s\nArtifactID: %s", opts.Spec.Application.AuthorName, opts.Spec.Application.Message, opts.Spec.ID),
 						Tags: []string{"deployment", opts.Service},

--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -31,7 +31,9 @@ func reqrespLogger(h http.Handler) http.Handler {
 		// request duration in miliseconds
 		duration := time.Since(start).Nanoseconds() / 1e6
 		statusCode := statusWriter.statusCode
+		requestID := getRequestID(r)
 		fields := []interface{}{
+			"requestId", requestID,
 			"req", struct {
 				ID      string            `json:"id,omitempty"`
 				URL     string            `json:"url,omitempty"`
@@ -39,7 +41,7 @@ func reqrespLogger(h http.Handler) http.Handler {
 				Path    string            `json:"path,omitempty"`
 				Headers map[string]string `json:"headers,omitempty"`
 			}{
-				ID:      getRequestID(r),
+				ID:      requestID,
 				URL:     r.URL.RequestURI(),
 				Method:  r.Method,
 				Path:    r.URL.Path,

--- a/cmd/server/http/policy.go
+++ b/cmd/server/http/policy.go
@@ -31,10 +31,11 @@ func policy(payload *payload, policySvc *policyinternal.Service) http.HandlerFun
 func applyAutoReleasePolicy(payload *payload, policySvc *policyinternal.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := log.WithContext(ctx)
 		var req httpinternal.ApplyAutoReleasePolicyRequest
 		err := payload.decodeResponse(ctx, r.Body, &req)
 		if err != nil {
-			log.Errorf("http: policy: apply: decode request body failed: %v", err)
+			logger.Errorf("http: policy: apply: decode request body failed: %v", err)
 			invalidBodyError(w)
 			return
 		}
@@ -58,7 +59,7 @@ func applyAutoReleasePolicy(payload *payload, policySvc *policyinternal.Service)
 			requiredFieldError(w, "committerEmail")
 			return
 		}
-		logger := log.WithFields("service", req.Service, "req", req)
+		logger = logger.WithFields("service", req.Service, "req", req)
 		logger.Infof("http: policy: apply: service '%s' branch '%s' environment '%s': apply auto-release policy started", req.Service, req.Branch, req.Environment)
 		id, err := policySvc.ApplyAutoRelease(ctx, policyinternal.Actor{
 			Name:  req.CommitterName,
@@ -105,8 +106,8 @@ func listPolicies(payload *payload, policySvc *policyinternal.Service) http.Hand
 			return
 		}
 
-		logger := log.WithFields("service", service)
 		ctx := r.Context()
+		logger := log.WithContext(ctx).WithFields("service", service)
 		policies, err := policySvc.Get(ctx, service)
 		if err != nil {
 			if ctx.Err() == context.Canceled {
@@ -150,10 +151,11 @@ func mapAutoReleasePolicies(policies []policyinternal.AutoReleasePolicy) []httpi
 func deletePolicies(payload *payload, policySvc *policyinternal.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := log.WithContext(ctx)
 		var req httpinternal.DeletePolicyRequest
 		err := payload.decodeResponse(ctx, r.Body, &req)
 		if err != nil {
-			log.Errorf("http: policy: delete: decode request body failed: %v", err)
+			logger.Errorf("http: policy: delete: decode request body failed: %v", err)
 			invalidBodyError(w)
 			return
 		}
@@ -175,7 +177,7 @@ func deletePolicies(payload *payload, policySvc *policyinternal.Service) http.Ha
 			return
 		}
 
-		logger := log.WithFields("service", req.Service, "req", req)
+		logger = logger.WithFields("service", req.Service, "req", req)
 
 		deleted, err := policySvc.Delete(ctx, policyinternal.Actor{
 			Name:  req.CommitterName,
@@ -209,7 +211,7 @@ func deletePolicies(payload *payload, policySvc *policyinternal.Service) http.Ha
 			Count:   deleted,
 		})
 		if err != nil {
-			log.Errorf("http: policy: delete: service '%s' ids %v: marshal response failed: %v", req.Service, ids, err)
+			logger.Errorf("http: policy: delete: service '%s' ids %v: marshal response failed: %v", req.Service, ids, err)
 		}
 	}
 }

--- a/internal/copy/copy_test.go
+++ b/internal/copy/copy_test.go
@@ -1,6 +1,7 @@
 package copy_test
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
@@ -46,7 +47,7 @@ func TestCopyDir(t *testing.T) {
 			t.Logf("Using pwd: %s", pwd)
 			absSrc := path.Join(pwd, tc.src)
 			absDest := path.Join(pwd, tc.dest)
-			err = copy.CopyDir(absSrc, absDest)
+			err = copy.CopyDir(context.Background(), absSrc, absDest)
 			defer os.RemoveAll(absDest)
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error(), "wrong error")

--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -29,7 +29,7 @@ func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, s
 	}
 	defer close(ctx)
 
-	log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	log.WithContext(ctx).Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
 	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
 	if err != nil {
 		return DescribeReleaseResponse{}, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
@@ -72,7 +72,8 @@ func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) (
 	}
 	defer close(ctx)
 
-	log.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	logger := log.WithContext(ctx)
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
 	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
@@ -83,7 +84,7 @@ func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) (
 		return nil, errors.WithMessage(err, "locate artifacts")
 	}
 	var artifacts []artifact.Spec
-	log.Debugf("flow/describe: hashes %+v", hashes)
+	logger.Debugf("flow/describe: hashes %+v", hashes)
 	for _, hash := range hashes {
 		err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
 		if err != nil {
@@ -91,7 +92,7 @@ func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) (
 		}
 		branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
 		if err != nil {
-			log.Errorf("flow/describe: get branch from head failed at hash '%s': skipping hash: %v", hash, err)
+			logger.Errorf("flow/describe: get branch from head failed at hash '%s': skipping hash: %v", hash, err)
 			continue
 		}
 		artifactPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -18,13 +18,13 @@ func (s *Service) NotifyCommitter(ctx context.Context, event *http.PodNotifyRequ
 		//check UserMappings
 		lwEmail, ok := s.UserMappings[email]
 		if !ok {
-			log.Errorf("%s is not a Lunar Way email and no mapping exist", email)
+			log.WithContext(ctx).Errorf("%s is not a Lunar Way email and no mapping exist", email)
 			return errors.Errorf("%s is not a Lunar Way email and no mapping exist", email)
 		}
 		email = lwEmail
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "post private slack message")
-	err := s.Slack.PostPrivateMessage(email, event)
+	err := s.Slack.PostPrivateMessage(ctx, email, event)
 	span.Finish()
 	if err != nil {
 		return errors.WithMessage(err, "post private message")

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -41,7 +41,8 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 		}
-		log.Infof("flow: ReleaseBranch: release branch: id '%s'", artifactSpec.ID)
+		logger := log.WithContext(ctx)
+		logger.Infof("flow: ReleaseBranch: release branch: id '%s'", artifactSpec.ID)
 
 		// default to environment name for the namespace if none is specified
 		namespace := artifactSpec.Namespace
@@ -54,7 +55,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		artifactPath := srcPath(sourceConfigRepoPath, service, branch, environment)
 		// repo/{env}/releases/{ns}/{service}
 		destinationPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
-		log.Infof("flow: ReleaseBranch: copy resources from %s to %s", artifactPath, destinationPath)
+		logger.Infof("flow: ReleaseBranch: copy resources from %s to %s", artifactPath, destinationPath)
 
 		err = s.cleanCopy(ctx, artifactPath, destinationPath)
 		if err != nil {
@@ -64,8 +65,8 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		// copy artifact spec
 		// repo/{env}/releases/{ns}/{service}/{artifactFileName}
 		artifactDestinationPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-		log.Infof("flow: ReleaseBranch: copy artifact from %s to %s", artifactSpecPath, artifactDestinationPath)
-		err = copy.CopyFile(artifactSpecPath, artifactDestinationPath)
+		logger.Infof("flow: ReleaseBranch: copy artifact from %s to %s", artifactSpecPath, artifactDestinationPath)
+		err = copy.CopyFile(ctx, artifactSpecPath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
 		}
@@ -91,7 +92,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 			Releaser:    actor.Name,
 		})
 		result = artifactID
-		log.Infof("flow: ReleaseBranch: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		logger.Infof("flow: ReleaseBranch: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
 		return true, nil
 	})
 	if err != nil {
@@ -146,8 +147,8 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 		}
-
-		log.Infof("flow: ReleaseArtifactID: hash '%s' id '%s'", hash, sourceSpec.ID)
+		logger := log.WithContext(ctx)
+		logger.Infof("flow: ReleaseArtifactID: hash '%s' id '%s'", hash, sourceSpec.ID)
 
 		// default to environment name for the namespace if none is specified
 		namespace := sourceSpec.Namespace
@@ -163,7 +164,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		// release service to env from original release
 		sourcePath := srcPath(sourceConfigRepoPath, service, branch, environment)
 		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
-		log.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
+		logger.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
 
 		err = s.cleanCopy(ctx, sourcePath, destinationPath)
 		if err != nil {
@@ -172,8 +173,8 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		// copy artifact spec
 		artifactSourcePath := srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-		log.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-		err = copy.CopyFile(artifactSourcePath, artifactDestinationPath)
+		logger.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
+		err = copy.CopyFile(ctx, artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}
@@ -198,7 +199,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 			Releaser:    actor.Name,
 		})
 		result = artifactID
-		log.Infof("flow: ReleaseArtifactID: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
+		logger.Infof("flow: ReleaseArtifactID: release committed: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
 		return true, nil
 	})
 	if err != nil {

--- a/internal/git/temp_dir.go
+++ b/internal/git/temp_dir.go
@@ -26,7 +26,7 @@ func TempDir(ctx context.Context, tracer tracing.Tracer, prefix string) (string,
 		defer span.Finish()
 		err := os.RemoveAll(path)
 		if err != nil {
-			log.Errorf("Removing temporary directory failed: path '%s': %v", path, err)
+			log.WithContext(ctx).Errorf("Removing temporary directory failed: path '%s': %v", path, err)
 		}
 	}, nil
 }

--- a/internal/grafana/grafana.go
+++ b/internal/grafana/grafana.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -31,7 +32,7 @@ type AnnotateResponse struct {
 	Id      int64  `json:"id,omitempty"`
 }
 
-func (s *Service) Annotate(env string, body AnnotateRequest) error {
+func (s *Service) Annotate(ctx context.Context, env string, body AnnotateRequest) error {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -58,9 +59,10 @@ func (s *Service) Annotate(env string, body AnnotateRequest) error {
 		return err
 	}
 
+	logger := log.WithContext(ctx)
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		log.Infof("grafana: response body: %s", body)
+		logger.Infof("grafana: response body: %s", body)
 		return errors.New("grafana: status code not ok")
 	}
 	var responseBody AnnotateResponse
@@ -69,6 +71,6 @@ func (s *Service) Annotate(env string, body AnnotateRequest) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("grafana: AnnotateResponse: message: %s, id: %d", responseBody.Message, responseBody.Id)
+	logger.Infof("grafana: AnnotateResponse: message: %s, id: %d", responseBody.Message, responseBody.Id)
 	return nil
 }

--- a/internal/log/context.go
+++ b/internal/log/context.go
@@ -1,0 +1,22 @@
+package log
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+// WithContext returns a Logger instance. Every logged line with the returned
+// logger will contain the extracted fields (if any) from the context.
+func WithContext(ctx context.Context) *Logger {
+	fields, ok := ctx.Value(contextKey{}).([]interface{})
+	if !ok {
+		return With()
+	}
+	return With(fields...)
+}
+
+// AddContext adds fields to the context that can be used in WithContext.
+func AddContext(ctx context.Context, fields ...interface{}) context.Context {
+	return context.WithValue(ctx, contextKey{}, fields)
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -109,3 +109,28 @@ func (l *Logger) Debug(args ...interface{}) {
 func (l *Logger) Debugf(template string, args ...interface{}) {
 	l.sugar.Debugf(template, args...)
 }
+
+// WithFields returns a logger with custom structured fields added to the 'fields' key in the log entries.
+// The arguments are passed to the underlying sugared zap logger. See the zap documentation for details.
+// If an argument is a zap.Field it is logged accordingly, otherwise the arguments are treated as key value pairs.
+//
+// For example,
+//   log.WithFields("hello", "world").WithFields(zap.String("zapKey", "zapValue")).Info("msg")
+// logs the following fields (some fields omitted)
+//   { "message": "msg", "fields": { "hello": "world", "zapKey": "zapValue" }}
+func (l *Logger) WithFields(args ...interface{}) *Logger {
+	args = append([]interface{}{zap.Namespace("fields")}, args...)
+	return l.With(args...)
+}
+
+// With returns a logger with custom structured fields added to the root of the log entries.
+// The arguments are passed to the underlying sugared zap logger. See the zap documentation for details.
+// If an argument is a zap.Field it is logged accordingly, otherwise the arguments are treated as key value pairs.
+//
+// For example,
+//   log.With("hello", "world").With(zap.String("zapKey", "zapValue")).Info("msg")
+// logs the following fields (some fields omitted)
+//   { "message": "msg", "hello": "world", "zapKey": "zapValue"}
+func (l *Logger) With(args ...interface{}) *Logger {
+	return &Logger{sugar: l.sugar.With(args...)}
+}


### PR DESCRIPTION
This change adds two context logging helpers. `AddContext` will enrich a context
instance with fields that can later be extracted with `WithContext`. The logging
instance returned by the latter will log the extracted fields with any logged
line.

The `trace` middleware enriches the context with the request id and all other
functions and methods are updated to always log with a context logger so that
the request id can be used as a reference for all related lines.