### PR TITLE
Align slack messages a bit

### DIFF
--- a/cmd/artifact/command/failure.go
+++ b/cmd/artifact/command/failure.go
@@ -23,7 +23,7 @@ func failureCommand(options *Options) *cobra.Command {
 			err = client.UpdateMessage(path.Join(options.RootPath, options.MessageFileName), func(m slack.Message) slack.Message {
 				m.Color = slack.MsgColorRed
 				m.Text += fmt.Sprintf(":no_entry: *%s*", errorMessage)
-				m.Title = m.Service + " :no_entry:"
+				m.Title = ":jenkins: Jenkins :no_entry:"
 				return m
 			})
 			if err != nil {

--- a/cmd/artifact/command/init.go
+++ b/cmd/artifact/command/init.go
@@ -78,9 +78,9 @@ func initCommand(options *Options) *cobra.Command {
 				}
 
 				// create and post the initial slack message
-				title := s.Application.Name + " :mario_luigi_dance:"
+				title := ":jenkins: Jenkins :sonic-running:"
 				titleLink := s.CI.JobURL
-				text := fmt.Sprintf("Build for branch: <%s|*%s*>\n", s.Application.URL, s.Application.Branch)
+				text := fmt.Sprintf("Build for: %s\nBranch: <%s|*%s*>\n", s.Application.Name, s.Application.URL, s.Application.Branch)
 				color := slack.MsgColorYellow
 				respChan, timestamp, err := client.PostSlackBuildStarted(s.Application.AuthorEmail, title, titleLink, text, color)
 				if err != nil {

--- a/cmd/artifact/command/successful.go
+++ b/cmd/artifact/command/successful.go
@@ -21,7 +21,7 @@ func successfulCommand(options *Options) *cobra.Command {
 			}
 			err = client.UpdateMessage(path.Join(options.RootPath, options.MessageFileName), func(m slack.Message) slack.Message {
 				m.Color = slack.MsgColorGreen
-				m.Title = m.Service + " :white_check_mark:"
+				m.Title = ":jenkins: Jenkins :white_check_mark:"
 				return m
 			})
 			if err != nil {

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -435,7 +435,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 				if err != nil {
 					if errorCause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
-						err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
+						err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager", fmt.Sprintf(":no_entry: Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
 						if err != nil {
 							logger.Errorf("http: github webhook: auto-release failed: error notifying slack: %v", err)
 						}
@@ -444,7 +444,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 					logger.Infof("http: github webhook: service '%s': auto-release from policy '%s' to '%s': nothing to commit", serviceName, autoRelease.ID, autoRelease.Environment)
 					continue
 				}
-				err = slackClient.NotifySlackPolicySucceeded(ctx, payload.HeadCommit.Author.Email, "Auto release policy detected", fmt.Sprintf("Service *%s* was auto released to *%s*", serviceName, autoRelease.Environment))
+				err = slackClient.NotifySlackPolicySucceeded(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager", fmt.Sprintf("Service *%s* will be auto released to *%s*\nArtifact: <%s|*%s*>", serviceName, autoRelease.Environment, payload.HeadCommit.URL, releaseID))
 				if err != nil {
 					if errors.Cause(err) != slack.ErrUnknownEmail {
 						logger.Errorf("http: github webhook: auto-release succeeded: error notifying slack: %v", err)

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -116,8 +116,8 @@ func (c *Client) PostPrivateMessage(ctx context.Context, email string, podNotify
 
 func successMessage(podNotify *http.PodNotifyRequest) slack.MsgOption {
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":white_check_mark: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
-		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
+		Text:       fmt.Sprintf(":white_check_mark: %s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#73bf69",
 		MarkdownIn: []string{"text", "fields"},
 	})
@@ -130,8 +130,8 @@ func createConfigErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOption 
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":no_entry: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
-		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
+		Text:       fmt.Sprintf(":no_entry: %s (%s)\nArtifact%s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{messageField},
@@ -145,8 +145,8 @@ func crashLoopBackOffErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOpt
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":no_entry: [%s] %s (%s)", podNotify.Environment, podNotify.Name, podNotify.State),
-		Text:       fmt.Sprintf("Artifact id %s", podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
+		Text:       fmt.Sprintf(":no_entry: %s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{logField},
@@ -256,10 +256,9 @@ func (c *Client) NotifyAuthorEventProcessed(ctx context.Context, options Release
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":rocket: Release Manager: Release for %s processed", options.Service),
-		TitleLink:  options.CommitLink,
+		Title:      fmt.Sprintf(":rocket: Release Manager"),
 		Color:      MsgColorGreen,
-		Text:       fmt.Sprintf("Artifact ID: %s", options.ArtifactID),
+		Text:       fmt.Sprintf("Release for %s processed\nArtifact: <%s|*%s*>", options.Service, options.CommitLink, options.ArtifactID),
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)


### PR DESCRIPTION
This PR updates the Slack messages a bit. The most important improvement is that all the important messages has been moved from title to the first line of text, as it looks like this is what is being displayed in the notification.

Further some logos etc has been added to make it clear from which part of the pipeline the message is regarding.