### PR TITLE
Allow more than 2 message in reconnect test

### DIFF
--- a/internal/broker/amqp/amqp_test.go
+++ b/internal/broker/amqp/amqp_test.go
@@ -239,5 +239,8 @@ func TestWorker_reconnection(t *testing.T) {
 	logger.Infof("TEST: worker error: %v", err)
 	assert.EqualError(t, err, broker.ErrBrokerClosed.Error(), "consumer returned unexpected error")
 	wg.Wait()
-	assert.Equal(t, int32(2), consumedCount, "did not receive two messages as exected")
+	// we might see more than two consumed messages. In case of acknowledgement
+	// fails due to the channel being killed, we receive the same message multiple
+	// times
+	assert.GreaterOrEqual(t, int32(2), consumedCount, "did not receive at least two messages as expected")
 }


### PR DESCRIPTION
If we fail to acknowledge an AMQP message in the test, due to the connection
being killed (part of the test), we will receive the message multiple times.
This change accepts this condition and eases the assertion to at least two
messages received.