### PR TITLE
Add authorEmail to commit message

### DIFF
--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -212,7 +212,7 @@ func (s *Service) ExecPromote(ctx context.Context, p PromoteEvent) error {
 		}
 		authorName := sourceSpec.Application.AuthorName
 		authorEmail := sourceSpec.Application.AuthorEmail
-		releaseMessage := git.ReleaseCommitMessage(environment, service, result.ReleaseID)
+		releaseMessage := git.ReleaseCommitMessage(environment, service, result.ReleaseID, authorEmail)
 		logger.Debugf("Committing release: %s, Author: %s <%s>, Committer: %s <%s>", releaseMessage, authorName, authorEmail, actor.Name, actor.Email)
 		err = s.Git.Commit(ctx, destinationConfigRepoPath, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -135,7 +135,7 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 		authorName := artifactSpec.Application.AuthorName
 		authorEmail := artifactSpec.Application.AuthorEmail
 		artifactID := artifactSpec.ID
-		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
+		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID, authorEmail)
 		err = s.Git.Commit(ctx, sourceConfigRepoPath, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
 			if errors.Cause(err) == git.ErrNothingToCommit {
@@ -308,7 +308,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		}
 		authorName := sourceSpec.Application.AuthorName
 		authorEmail := sourceSpec.Application.AuthorEmail
-		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID)
+		releaseMessage := git.ReleaseCommitMessage(environment, service, artifactID, authorEmail)
 		err = s.Git.Commit(ctx, destinationConfigRepoPath, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
 			if errors.Cause(err) == git.ErrNothingToCommit {

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -190,7 +190,7 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 
 		authorName := newSpec.Application.AuthorName
 		authorEmail := newSpec.Application.AuthorEmail
-		releaseMessage := git.RollbackCommitMessage(environment, service, currentSpecID, newSpec.ID)
+		releaseMessage := git.RollbackCommitMessage(environment, service, currentSpecID, newSpec.ID, authorEmail)
 		err = s.Git.Commit(ctx, destinationConfigRepoPath, releasePath(".", service, environment, namespace), authorName, authorEmail, actor.Name, actor.Email, releaseMessage)
 		if err != nil {
 			if errors.Cause(err) == git.ErrNothingToCommit {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -172,7 +172,7 @@ func (s *Service) LocateRelease(ctx context.Context, r *git.Repository, artifact
 }
 
 func locateReleaseCondition(artifactID string) conditionFunc {
-	r := regexp.MustCompile(fmt.Sprintf(`(?i)release %s($|\r\n|\r|\n)`, regexp.QuoteMeta(artifactID)))
+	r := regexp.MustCompile(fmt.Sprintf(`(?i)release %s($|\r\n|\r|\n|\sby\s\S+)`, regexp.QuoteMeta(artifactID)))
 	return func(commitMsg string) bool {
 		if artifactID == "" {
 			return false
@@ -218,7 +218,7 @@ func (s *Service) LocateEnvRelease(ctx context.Context, r *git.Repository, env, 
 }
 
 func locateEnvReleaseCondition(env, artifactId string) conditionFunc {
-	r := regexp.MustCompile(fmt.Sprintf(`(?i)\[%s/.*] release %s($|\r\n|\r|\n)`, regexp.QuoteMeta(env), regexp.QuoteMeta(artifactId)))
+	r := regexp.MustCompile(fmt.Sprintf(`(?i)\[%s/.*] release %s($|\r\n|\r|\n|\sby\s\S+)`, regexp.QuoteMeta(env), regexp.QuoteMeta(artifactId)))
 	return func(commitMsg string) bool {
 		if env == "" {
 			return false

--- a/internal/git/messages.go
+++ b/internal/git/messages.go
@@ -8,13 +8,13 @@ func ArtifactCommitMessage(service, artifactID, author string) string {
 }
 
 // ReleaseCommitMessage returns an artifact release commit message.
-func ReleaseCommitMessage(env, service, artifactID string) string {
-	return fmt.Sprintf("[%s/%s] release %s", env, service, artifactID)
+func ReleaseCommitMessage(env, service, artifactID, authorEmail string) string {
+	return fmt.Sprintf("[%s/%s] release %s by %s", env, service, artifactID, authorEmail)
 }
 
 // RollbackCommitMessage returns an artifact rollback commit message.
-func RollbackCommitMessage(env, service, oldArtifactID, newArtifactID string) string {
-	return fmt.Sprintf("[%s/%s] rollback %s to %s", env, service, oldArtifactID, newArtifactID)
+func RollbackCommitMessage(env, service, oldArtifactID, newArtifactID, authorEmail string) string {
+	return fmt.Sprintf("[%s/%s] rollback %s to %s by %s", env, service, oldArtifactID, newArtifactID, authorEmail)
 }
 
 // PolicyUpdateApplyCommitMessage returns an apply policy commit message.


### PR DESCRIPTION
This PR adds the e-mail of the git author to the commit message. 
This makes it easier to parse and determine the recipient when reporting flux events in Slack later on.