### PR TITLE
Fail fast on nothing to release

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -503,7 +503,7 @@ func promote(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 				return
 			}
 			switch errorCause(err) {
-			case git.ErrNothingToCommit:
+			case flow.ErrNothingToRelease:
 				statusString = "Environment is already up-to-date"
 				logger.Infof("http: promote: service '%s' environment '%s': promote skipped: environment up to date", req.Service, req.Environment)
 			case git.ErrBranchBehindOrigin:
@@ -613,7 +613,7 @@ func release(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 				return
 			}
 			switch errorCause(err) {
-			case git.ErrNothingToCommit:
+			case flow.ErrNothingToRelease:
 				statusString = "Environment is already up-to-date"
 				logger.Infof("http: release: service '%s' environment '%s' branch '%s' artifact id '%s': release skipped: environment up to date", req.Service, req.Environment, req.Branch, req.ArtifactID)
 			case git.ErrArtifactNotFound:

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -22,6 +22,7 @@ var (
 	ErrUnknownEnvironment            = errors.New("unknown environment")
 	ErrNamespaceNotAllowedByArtifact = errors.New("namespace not allowed by artifact")
 	ErrUnknownConfiguration          = errors.New("unknown configuration")
+	ErrNothingToRelease              = errors.New("nothing to release")
 )
 
 type Service struct {

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -77,9 +77,15 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 			return true, errors.WithMessagef(err, "locate release '%s'", result.ReleaseID)
 		}
 
-		// TODO: we don't know if there is any changes to commit at this point, but
-		// it might be nice to be able to answer that directly. we could check the
-		// current artifact ID in the environment right away?
+		// check that the artifact to be released is not already released in the
+		// environment
+		currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+		if err != nil {
+			return true, errors.WithMessage(err, "get current released spec")
+		}
+		if currentSpec.ID == sourceSpec.ID {
+			return true, ErrNothingToRelease
+		}
 
 		err = s.PublishPromote(ctx, PromoteEvent{
 			Hash:        hash.String(),

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -49,6 +49,16 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		namespace = environment
 	}
 
+	// check that the artifact to be released is not already released in the
+	// environment
+	currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+	if err != nil {
+		return "", errors.WithMessage(err, "get current released spec")
+	}
+	if currentSpec.ID == artifactSpec.ID {
+		return "", ErrNothingToRelease
+	}
+
 	err = s.PublishReleaseBranch(ctx, ReleaseBranchEvent{
 		Branch:      branch,
 		Actor:       actor,


### PR DESCRIPTION
If a release command specifies what is already running, e.g. two releases from
the same branch without new artifacts, no feedback is given to the client. A log
message in the asynchronous flow is the only indication what there was nothing
to do.

This change set adds a validation of the artifact ids as to detect this up front
and return a message to the client as fast as possible.