### PR TITLE
Reformat the k8s slack messages for better notifications

### DIFF
--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -116,8 +116,8 @@ func (c *Client) PostPrivateMessage(ctx context.Context, email string, podNotify
 
 func successMessage(podNotify *http.PodNotifyRequest) slack.MsgOption {
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
-		Text:       fmt.Sprintf(":white_check_mark: %s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :white_check_mark:", podNotify.Environment),
+		Text:       fmt.Sprintf("%s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#73bf69",
 		MarkdownIn: []string{"text", "fields"},
 	})
@@ -130,8 +130,8 @@ func createConfigErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOption 
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
-		Text:       fmt.Sprintf(":no_entry: %s (%s)\nArtifact%s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :no_entry:", podNotify.Environment),
+		Text:       fmt.Sprintf("%s (%s)\nArtifact%s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{messageField},
@@ -145,8 +145,8 @@ func crashLoopBackOffErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOpt
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (%s)", podNotify.Environment),
-		Text:       fmt.Sprintf(":no_entry: %s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :no_entry:", podNotify.Environment),
+		Text:       fmt.Sprintf("%s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{logField},


### PR DESCRIPTION
This PR makes the k8s Slack notifications better and aligned with the rest of the messages.

The first thing in the Text field should be the most important. 
