### PR TITLE
Refactor flux event parsing into server

### DIFF
--- a/cmd/daemon/flux/exporter.go
+++ b/cmd/daemon/flux/exporter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/weaveworks/flux/event"
-	"github.com/weaveworks/flux/update"
 )
 
 type Message struct {
@@ -34,68 +33,11 @@ func (f *ReleaseManagerExporter) Send(_ context.Context, event event.Event) erro
 		return err
 	}
 	err = f.Client.Do(http.MethodPost, url, httpinternal.FluxNotifyRequest{
-		Environment:        f.Environment,
-		EventID:            event.ID,
-		EventServiceIDs:    event.ServiceIDs,
-		EventChangedImages: getChangedImages(event.Metadata),
-		EventResult:        getResult(event.Metadata),
-		EventType:          event.Type,
-		EventStartedAt:     event.StartedAt,
-		EventEndedAt:       event.EndedAt,
-		EventLogLevel:      event.LogLevel,
-		EventMessage:       event.Message,
-		EventString:        event.String(),
-		Commits:            getCommits(event.Metadata),
-		Errors:             getErrors(event.Metadata),
+		Environment: f.Environment,
+		FluxEvent:   event,
 	}, &resp)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func getCommits(meta event.EventMetadata) []event.Commit {
-	switch v := meta.(type) {
-	case *event.CommitEventMetadata:
-		return []event.Commit{
-			event.Commit{
-				Revision: v.Revision,
-			},
-		}
-	case *event.SyncEventMetadata:
-		return v.Commits
-	default:
-		return []event.Commit{}
-	}
-}
-
-func getResult(meta event.EventMetadata) update.Result {
-	switch v := meta.(type) {
-	case *event.AutoReleaseEventMetadata:
-		return v.Result
-	case *event.ReleaseEventMetadata:
-		return v.Result
-	default:
-		return update.Result{}
-	}
-}
-
-func getChangedImages(meta event.EventMetadata) []string {
-	switch v := meta.(type) {
-	case *event.AutoReleaseEventMetadata:
-		return v.Result.ChangedImages()
-	case *event.ReleaseEventMetadata:
-		return v.Result.ChangedImages()
-	default:
-		return []string{}
-	}
-}
-
-func getErrors(meta event.EventMetadata) []event.ResourceError {
-	switch v := meta.(type) {
-	case *event.SyncEventMetadata:
-		return v.Errors
-	default:
-		return []event.ResourceError{}
-	}
 }

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -388,7 +388,7 @@ func daemonFluxWebhook(payload *payload, flowSvc *flow.Service) http.HandlerFunc
 		}
 		logger = logger.WithFields(
 			"environment", fluxNotifyEvent.Environment,
-			"event", fluxNotifyEvent)
+			"event", fluxNotifyEvent.FluxEvent)
 
 		err = flowSvc.NotifyFluxEvent(ctx, &fluxNotifyEvent)
 		if err != nil && errors.Cause(err) != slack.ErrUnknownEmail {

--- a/internal/flux/flux.go
+++ b/internal/flux/flux.go
@@ -1,0 +1,52 @@
+package flux
+
+import (
+	"github.com/weaveworks/flux/event"
+	"github.com/weaveworks/flux/update"
+)
+
+func GetCommits(meta event.EventMetadata) []event.Commit {
+	switch v := meta.(type) {
+	case *event.CommitEventMetadata:
+		return []event.Commit{
+			event.Commit{
+				Revision: v.Revision,
+			},
+		}
+	case *event.SyncEventMetadata:
+		return v.Commits
+	default:
+		return []event.Commit{}
+	}
+}
+
+func GetResult(meta event.EventMetadata) update.Result {
+	switch v := meta.(type) {
+	case *event.AutoReleaseEventMetadata:
+		return v.Result
+	case *event.ReleaseEventMetadata:
+		return v.Result
+	default:
+		return update.Result{}
+	}
+}
+
+func GetChangedImages(meta event.EventMetadata) []string {
+	switch v := meta.(type) {
+	case *event.AutoReleaseEventMetadata:
+		return v.Result.ChangedImages()
+	case *event.ReleaseEventMetadata:
+		return v.Result.ChangedImages()
+	default:
+		return []string{}
+	}
+}
+
+func GetErrors(meta event.EventMetadata) []event.ResourceError {
+	switch v := meta.(type) {
+	case *event.SyncEventMetadata:
+		return v.Errors
+	default:
+		return []event.ResourceError{}
+	}
+}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -5,9 +5,7 @@ import (
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
-	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/event"
-	"github.com/weaveworks/flux/update"
 )
 
 type StatusRequest struct {
@@ -85,19 +83,8 @@ type FluxNotifyResponse struct {
 }
 
 type FluxNotifyRequest struct {
-	Environment        string `json:"environment,omitempty"`
-	EventID            event.EventID
-	EventServiceIDs    []flux.ResourceID
-	EventChangedImages []string
-	EventResult        update.Result
-	EventType          string
-	EventStartedAt     time.Time
-	EventEndedAt       time.Time
-	EventLogLevel      string
-	EventMessage       string
-	EventString        string
-	Commits            []event.Commit
-	Errors             []event.ResourceError
+	Environment string `json:"environment,omitempty"`
+	FluxEvent   event.Event
 }
 
 type PodNotifyResponse struct {


### PR DESCRIPTION
This PR moves the flux event handling to the release-manager server instead of the daemons