### PR TITLE
Align Slack messages

### DIFF
--- a/cmd/artifact/command/add.go
+++ b/cmd/artifact/command/add.go
@@ -87,7 +87,7 @@ func appendBuildSubCommand(options *Options) *cobra.Command {
 			if err != nil {
 				return nil
 			}
-			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Build* (<%s:image>)", fmt.Sprintf("%s:%s", buildData.Image, buildData.Tag)), slack.MsgColorYellow)
+			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Build* (<%s:%s:image>)", buildData.Image, buildData.Tag), slack.MsgColorYellow)
 			if err != nil {
 				fmt.Printf("Error notifying slack")
 			}

--- a/cmd/artifact/command/add.go
+++ b/cmd/artifact/command/add.go
@@ -87,7 +87,7 @@ func appendBuildSubCommand(options *Options) *cobra.Command {
 			if err != nil {
 				return nil
 			}
-			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Build* (%s:%s)", buildData.Image, buildData.Tag), slack.MsgColorYellow)
+			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Build* (<%s:image>)", fmt.Sprintf("%s:%s", buildData.Image, buildData.Tag)), slack.MsgColorYellow)
 			if err != nil {
 				fmt.Printf("Error notifying slack")
 			}
@@ -196,7 +196,7 @@ func appendPushSubCommand(options *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Push* (%s:%s)", pushData.Image, pushData.Tag), slack.MsgColorYellow)
+			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Push* (<%s:image>)", fmt.Sprintf("%s:%s", pushData.Image, pushData.Tag)), slack.MsgColorYellow)
 			if err != nil {
 				fmt.Printf("Error notifying slack")
 			}

--- a/cmd/artifact/command/add.go
+++ b/cmd/artifact/command/add.go
@@ -196,7 +196,7 @@ func appendPushSubCommand(options *Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Push* (<%s:image>)", fmt.Sprintf("%s:%s", pushData.Image, pushData.Tag)), slack.MsgColorYellow)
+			err = notifySlack(options, fmt.Sprintf(":white_check_mark: *Push* (<%s:%s:image>)", pushData.Image, pushData.Tag), slack.MsgColorYellow)
 			if err != nil {
 				fmt.Printf("Error notifying slack")
 			}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -450,7 +450,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 			autoReleases, err := policySvc.GetAutoReleases(ctx, serviceName, branch)
 			if err != nil {
 				logger.Errorf("http: github webhook: service '%s' branch '%s': get auto release policies failed: %v", serviceName, branch, err)
-				err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, "Auto release policy failed", fmt.Sprintf("failed for branch: %s, env: %s", serviceName, branch))
+				err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Auto release policy failed for service %s and %s", serviceName, branch))
 				if err != nil {
 					logger.Errorf("http: github webhook: get auto-release policies: error notifying slack: %v", err)
 				}
@@ -467,7 +467,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 				if err != nil {
 					if errorCause(err) != git.ErrNothingToCommit {
 						errs = multierr.Append(errs, err)
-						err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager", fmt.Sprintf(":no_entry: Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
+						err := slackClient.NotifySlackPolicyFailed(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", serviceName, autoRelease.Environment, autoRelease.Branch))
 						if err != nil {
 							logger.Errorf("http: github webhook: auto-release failed: error notifying slack: %v", err)
 						}
@@ -476,7 +476,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 					logger.Infof("http: github webhook: service '%s': auto-release from policy '%s' to '%s': nothing to commit", serviceName, autoRelease.ID, autoRelease.Environment)
 					continue
 				}
-				err = slackClient.NotifySlackPolicySucceeded(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager", fmt.Sprintf("Service *%s* will be auto released to *%s*\nArtifact: <%s|*%s*>", serviceName, autoRelease.Environment, payload.HeadCommit.URL, releaseID))
+				err = slackClient.NotifySlackPolicySucceeded(ctx, payload.HeadCommit.Author.Email, ":rocket: Release Manager :white_check_mark:", fmt.Sprintf("Service *%s* will be auto released to *%s*\nArtifact: <%s|*%s*>", serviceName, autoRelease.Environment, payload.HeadCommit.URL, releaseID))
 				if err != nil {
 					if errors.Cause(err) != slack.ErrUnknownEmail {
 						logger.Errorf("http: github webhook: auto-release succeeded: error notifying slack: %v", err)

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -116,8 +116,8 @@ func (c *Client) PostPrivateMessage(ctx context.Context, email string, podNotify
 
 func successMessage(podNotify *http.PodNotifyRequest) slack.MsgOption {
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :white_check_mark:", podNotify.Environment),
-		Text:       fmt.Sprintf("%s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (*%s*) :white_check_mark:", podNotify.Environment),
+		Text:       fmt.Sprintf("%s (%s)\nArtifact: *%s*", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#73bf69",
 		MarkdownIn: []string{"text", "fields"},
 	})
@@ -131,7 +131,7 @@ func createConfigErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOption 
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
 		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :no_entry:", podNotify.Environment),
-		Text:       fmt.Sprintf("%s (%s)\nArtifact%s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Text:       fmt.Sprintf("%s (*%s*)\nArtifact: *%s*", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{messageField},
@@ -145,8 +145,8 @@ func crashLoopBackOffErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOpt
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :no_entry:", podNotify.Environment),
-		Text:       fmt.Sprintf("%s (%s)\nArtifact: %s", podNotify.Name, podNotify.State, podNotify.ArtifactID),
+		Title:      fmt.Sprintf(":kubernetes: k8s (*%s*) :no_entry:", podNotify.Environment),
+		Text:       fmt.Sprintf("%s (%s)\nArtifact: *%s*", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     []slack.AttachmentField{logField},
@@ -256,9 +256,9 @@ func (c *Client) NotifyAuthorEventProcessed(ctx context.Context, options Release
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":rocket: Release Manager"),
+		Title:      fmt.Sprintf(":rocket: Release Manager :white_check_mark:"),
 		Color:      MsgColorGreen,
-		Text:       fmt.Sprintf("Release for %s processed\nArtifact: <%s|*%s*>", options.Service, options.CommitLink, options.ArtifactID),
+		Text:       fmt.Sprintf("Release for *%s* in %s processed\nArtifact: <%s|*%s*>", options.Service, options.Environment, options.CommitLink, options.ArtifactID),
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
@@ -275,7 +275,7 @@ func (c *Client) NotifyFluxEventProcessed(ctx context.Context, artifactID, env, 
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":flux: Flux (%s)", env),
+		Title:      fmt.Sprintf(":flux: Flux (%s) :white_check_mark:", env),
 		Color:      MsgColorGreen,
 		Text:       fmt.Sprintf("Rollout initiated for *%s*\nArtifact: %s", service, artifactID),
 		MarkdownIn: []string{"text", "fields"},
@@ -294,7 +294,7 @@ func (c *Client) NotifyFluxErrorEvent(ctx context.Context, artifactID, env, emai
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":flux: Flux (%s)", env),
+		Title:      fmt.Sprintf(":flux: Flux (%s) :no_entry:", env),
 		Color:      MsgColorRed,
 		Text:       fmt.Sprintf("Error detected for *%s*\nArtifact: %s\nPath: `%s`\n```%s```", service, artifactID, errorPath, errorMessage),
 		MarkdownIn: []string{"text", "fields"},


### PR DESCRIPTION
This PR realigns the Slack messages produced. 

It also shrinks the long docker image tags into a link instead. 