### PR TITLE
Slack Title's do not render bold font

### DIFF
--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -116,7 +116,7 @@ func (c *Client) PostPrivateMessage(ctx context.Context, email string, podNotify
 
 func successMessage(podNotify *http.PodNotifyRequest) slack.MsgOption {
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (*%s*) :white_check_mark:", podNotify.Environment),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :white_check_mark:", podNotify.Environment),
 		Text:       fmt.Sprintf("%s (%s)\nArtifact: *%s*", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#73bf69",
 		MarkdownIn: []string{"text", "fields"},
@@ -145,7 +145,7 @@ func crashLoopBackOffErrorMessage(podNotify *http.PodNotifyRequest) slack.MsgOpt
 		Short: false,
 	}
 	return slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":kubernetes: k8s (*%s*) :no_entry:", podNotify.Environment),
+		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :no_entry:", podNotify.Environment),
 		Text:       fmt.Sprintf("%s (%s)\nArtifact: *%s*", podNotify.Name, podNotify.State, podNotify.ArtifactID),
 		Color:      "#e24d42",
 		MarkdownIn: []string{"text", "fields"},


### PR DESCRIPTION
This reverts the previous addition where bold font was used in the title. 