### PR TITLE
Inspect added files in GitHub webhooks

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -439,8 +439,10 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 			}
 			serviceName := matches[1]
 
-			// locate branch of commit
-			branch, ok := git.BranchName(payload.HeadCommit.Modified, flowSvc.ArtifactFileName, serviceName)
+			// locate branch of commit. Look at both modified and added commits to
+			// cover both updated artifacts and added ones (new versions vs first
+			// version)
+			branch, ok := git.BranchName(append(payload.HeadCommit.Added, payload.HeadCommit.Modified...), flowSvc.ArtifactFileName, serviceName)
 			if !ok {
 				logger.Infof("http: github webhook: service '%s': branch name not found", serviceName)
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
If a GitHub webhook is based of the first artifact for a service or branch it
will only contain added files. Currently we only inspect modified files and thus
we will fail to auto-release the very first artifact from a branch matching the
policy.

This change merged added and modified files to a single slice and detects the
branch name from these. This will ensure that we find a branch name also for the
very first artifacts on a branch.