### PR TITLE
Ignore missing artifacts from existing release

### DIFF
--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
@@ -86,9 +87,11 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 		}
 
 		// check that the artifact to be released is not already released in the
-		// environment
+		// environment. If there is no artifact released to the target environment an
+		// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
+		// will then be the default value and this its ID will be the empty string.
 		currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-		if err != nil {
+		if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
 			return true, errors.WithMessage(err, "get current released spec")
 		}
 		if currentSpec.ID == sourceSpec.ID {


### PR DESCRIPTION
When testing if the current released artifact is the same as a new release we
might hit an `artifact.ErrFileNotFound` error if there has never been a release to
the target environment.

This change set ensures that this error is ignored in these checks to avoid
effectively blocking releases to new environments.

It also adds a check to the release artifact flow that was missed in
aff012fd6a433664956876a5adfa640cfcb0a9ac (#150).