### PR TITLE
Fix branch restriction for same env as auto release

### DIFF
--- a/internal/policy/branch_restriction.go
+++ b/internal/policy/branch_restriction.go
@@ -34,8 +34,8 @@ func (s *Service) ApplyBranchRestriction(ctx context.Context, actor Actor, svc, 
 		return "", err
 	}
 	for _, policy := range policies.AutoReleases {
-		if re.MatchString(policy.Branch) {
-			return "", ErrConflict
+		if policy.Environment == env && re.MatchString(policy.Branch) {
+			return "", errors.WithMessagef(ErrConflict, "conflict with %s", policy.ID)
 		}
 	}
 


### PR DESCRIPTION
If we try to apply a branch restriction policy to a branch that matches an auto
release policy but for another environment the apply fails as if they conflict.

This is due to a missing environment comparision when checking against the auto
release policies. This comparison is added in this change set.