### PR TITLE
Watch DaemonSets and StatefulSets for new revisions

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -77,6 +77,16 @@ func StartDaemon() *cobra.Command {
 
 			go func() {
 				for {
+					err = kubectl.HandleNewDaemonSets(context.Background())
+					if err != nil && err != kubernetes.ErrWatcherClosed {
+						done <- errors.WithMessage(err, "kubectl handle new daemonsets: watcher closed")
+						return
+					}
+				}
+			}()
+
+			go func() {
+				for {
 					err = kubectl.HandlePodErrors(context.Background())
 					if err != nil && err != kubernetes.ErrWatcherClosed {
 						done <- errors.WithMessage(err, "kubectl handle pod errors: watcher closed")

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -24,7 +24,6 @@ func StartDaemon() *cobra.Command {
 	var environment, kubeConfigPath, fluxApiBinding string
 	var moduloCrashReportNotif float64
 	var logConfiguration *log.Configuration
-	var replicaSetTimeDiff time.Duration
 
 	client := httpinternal.Client{}
 	var command = &cobra.Command{
@@ -36,7 +35,7 @@ func StartDaemon() *cobra.Command {
 			logConfiguration.ParseFromEnvironmnet()
 			log.Init(logConfiguration)
 
-			kubectl, err := kubernetes.NewClient(kubeConfigPath, moduloCrashReportNotif, replicaSetTimeDiff, &kubernetes.ReleaseManagerExporter{
+			kubectl, err := kubernetes.NewClient(kubeConfigPath, moduloCrashReportNotif, &kubernetes.ReleaseManagerExporter{
 				Log:         log.With("type", "k8s-exporter"),
 				Client:      client,
 				Environment: environment,
@@ -129,7 +128,6 @@ func StartDaemon() *cobra.Command {
 	command.Flags().StringVar(&kubeConfigPath, "kubeconfig", "", "path to kubeconfig file. If not specified, then daemon is expected to run inside kubernetes")
 	command.Flags().StringVar(&fluxApiBinding, "flux-api-binding", ":8080", "binding of the daemon flux api server")
 	command.Flags().Float64Var(&moduloCrashReportNotif, "modulo-crash-report-notif", 5, "modulo for how often to report CrashLoopBackOff events")
-	command.Flags().DurationVar(&replicaSetTimeDiff, "replicaset-creation-time-diff", 10*time.Second, "the duration from creation of replicaset to when its not considered new")
 	// errors are skipped here as the only case they can occour are if thee flag
 	// does not exist on the command.
 	//nolint:errcheck

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -87,6 +87,16 @@ func StartDaemon() *cobra.Command {
 
 			go func() {
 				for {
+					err = kubectl.HandleNewStatefulSets(context.Background())
+					if err != nil && err != kubernetes.ErrWatcherClosed {
+						done <- errors.WithMessage(err, "kubectl handle new statefulsets: watcher closed")
+						return
+					}
+				}
+			}()
+
+			go func() {
+				for {
 					err = kubectl.HandlePodErrors(context.Background())
 					if err != nil && err != kubernetes.ErrWatcherClosed {
 						done <- errors.WithMessage(err, "kubectl handle pod errors: watcher closed")

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -100,15 +100,9 @@ func isDaemonSetSuccessful(ds *appsv1.DaemonSet) bool {
 }
 
 func isDaemonSetCorrectlyAnnotated(ds *appsv1.DaemonSet) bool {
-	if !(ds.Annotations["lunarway.com/controlled-by-release-manager"] == "true") {
-		return false
-	}
-	if ds.Annotations["lunarway.com/artifact-id"] == "" {
-		log.Errorf("artifact-id missing in deployment: namespace '%s' name '%s'", ds.Namespace, ds.Name)
-		return false
-	}
-	if ds.Annotations["lunarway.com/author"] == "" {
-		log.Errorf("author missing in deployment: namespace '%s' name '%s'", ds.Namespace, ds.Name)
+	if !(ds.Annotations["lunarway.com/controlled-by-release-manager"] == "true") &&
+		ds.Annotations["lunarway.com/artifact-id"] == "" &&
+		ds.Annotations["lunarway.com/author"] == "" {
 		return false
 	}
 	return true
@@ -119,6 +113,7 @@ func isDaemonSetMarkedForTermination(ds *appsv1.DaemonSet) bool {
 	return ds.DeletionTimestamp != nil
 }
 
+// Annotates the DaemonSet with the observed-artifact-id. This is used to differentiate new releases from pod deletion events.
 func annotateDaemonSet(ctx context.Context, c *kubernetes.Clientset, ds *appsv1.DaemonSet) error {
 	ds.Annotations["lunarway.com/observed-artifact-id"] = ds.Annotations["lunarway.com/artifact-id"]
 	_, err := c.AppsV1().DaemonSets(ds.Namespace).Update(ctx, ds, metav1.UpdateOptions{})

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -49,13 +49,14 @@ func (c *Client) HandleNewDaemonSets(ctx context.Context) error {
 			}
 
 			// Notify the release-manager with the successful deployment event.
-			err = c.exporter.SendSuccessfulDeploymentEvent(ctx, http.DeploymentEvent{
+			err = c.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
 				Name:          ds.Name,
 				Namespace:     ds.Namespace,
+				ResourceType:  "DaemonSet",
 				ArtifactID:    ds.Annotations["lunarway.com/artifact-id"],
 				AuthorEmail:   ds.Annotations["lunarway.com/author"],
 				AvailablePods: ds.Status.NumberAvailable,
-				Replicas:      ds.Status.DesiredNumberScheduled,
+				DesiredPods:   ds.Status.DesiredNumberScheduled,
 			})
 			if err != nil {
 				log.Errorf("Failed to send successful deployment event: %v", err)

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -1,0 +1,94 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/lunarway/release-manager/internal/http"
+	"github.com/lunarway/release-manager/internal/log"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func (c *Client) HandleNewDaemonSets(ctx context.Context) error {
+	watcher, err := c.clientset.AppsV1().DaemonSets("").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			watcher.Stop()
+		case e, ok := <-watcher.ResultChan():
+			if !ok {
+				return ErrWatcherClosed
+			}
+			if e.Object == nil {
+				continue
+			}
+			if e.Type == watch.Deleted {
+				continue
+			}
+			ds, ok := e.Object.(*appsv1.DaemonSet)
+			if !ok {
+				continue
+			}
+
+			if !isDaemonSetCorrectlyAnnotated(ds) {
+				continue
+			}
+
+			// Avoid reporting on pods that has been marked for termination
+			if isDaemonSetMarkedForTermination(ds) {
+				continue
+			}
+
+			ok = isDaemonSetSuccessful(ds)
+			if !ok {
+				continue
+			}
+
+			// Notify the release-manager with the successful deployment event.
+			err = c.exporter.SendSuccessfulDeploymentEvent(ctx, http.DeploymentEvent{
+				Name:          ds.Name,
+				Namespace:     ds.Namespace,
+				ArtifactID:    ds.Annotations["lunarway.com/artifact-id"],
+				AuthorEmail:   ds.Annotations["lunarway.com/author"],
+				AvailablePods: ds.Status.NumberAvailable,
+				Replicas:      ds.Status.DesiredNumberScheduled,
+			})
+			if err != nil {
+				log.Errorf("Failed to send successful deployment event: %v", err)
+				continue
+			}
+		}
+	}
+}
+
+func isDaemonSetSuccessful(ds *appsv1.DaemonSet) bool {
+	return ds.Status.DesiredNumberScheduled != 0 && ds.Status.DesiredNumberScheduled == ds.Status.CurrentNumberScheduled && ds.Status.NumberReady == ds.Status.UpdatedNumberScheduled && ds.Status.UpdatedNumberScheduled == ds.Status.NumberAvailable && ds.Status.NumberUnavailable == 0 && ds.Status.NumberMisscheduled == 0
+}
+
+func isDaemonSetCorrectlyAnnotated(ds *appsv1.DaemonSet) bool {
+	// Just continue if this pod is not controlled by the release manager
+	if !(ds.Annotations["lunarway.com/controlled-by-release-manager"] == "true") {
+		return false
+	}
+
+	// Just discard the event if there's no artifact id
+	if ds.Annotations["lunarway.com/artifact-id"] == "" {
+		log.Errorf("artifact-id missing in deployment: namespace '%s' name '%s'", ds.Namespace, ds.Name)
+		return false
+	}
+
+	if ds.Annotations["lunarway.com/author"] == "" {
+		log.Errorf("author missing in deployment: namespace '%s' name '%s'", ds.Namespace, ds.Name)
+		return false
+	}
+	return true
+}
+
+// Avoid reporting on pods that has been marked for termination
+func isDaemonSetMarkedForTermination(ds *appsv1.DaemonSet) bool {
+	return ds.DeletionTimestamp != nil
+}

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -89,38 +89,6 @@ func (c *Client) HandleNewDeployments(ctx context.Context) error {
 
 func isDeploymentSuccessful(d *appsv1.Deployment) bool {
 	return deploymentutil.DeploymentComplete(d, &d.Status)
-	// cond := deploymentutil.GetDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
-	// if cond != nil {
-	// 	if cond.Reason == "ProgressDeadlineExceeded" {
-	// 		log.Errorf("deployment %s exceeded its progress deadline", deployment.Name)
-	// 		// TODO: Maybe return a specific error here
-	// 		return http.ReleaseEvent{}, false, nil
-	// 	}
-	// 	// It seems that this reduce unwanted messages when the release-daemon starts.
-	// 	if cond.LastUpdateTime == cond.LastTransitionTime {
-	// 		return http.ReleaseEvent{}, false, nil
-	// 	}
-	// }
-
-	// // Retrieve the new ReplicaSet to determince whether or not this is a new deployment event or not.
-	// newRs, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
-	// if err != nil {
-	// 	return http.ReleaseEvent{}, false, nil
-	// }
-	// //We discard events if the difference between creation time of the ReplicaSet and now is greater than replicaSetTimeDiff
-	// diff := time.Since(newRs.CreationTimestamp.Time)
-	// if diff > replicaSetTimeDiff {
-	// 	return http.ReleaseEvent{}, false, nil
-	// }
-	// return http.ReleaseEvent{
-	// 	Name:          deployment.Name,
-	// 	Namespace:     deployment.Namespace,
-	// 	ResourceType:  "Deployment",
-	// 	ArtifactID:    deployment.Annotations["lunarway.com/artifact-id"],
-	// 	AuthorEmail:   deployment.Annotations["lunarway.com/author"],
-	// 	AvailablePods: deployment.Status.AvailableReplicas,
-	// 	DesiredPods:   *deployment.Spec.Replicas,
-	// }, true, nil
 }
 
 func isDeploymentCorrectlyAnnotated(deploy *appsv1.Deployment) bool {
@@ -147,6 +115,7 @@ func isDeploymentMarkedForTermination(deploy *appsv1.Deployment) bool {
 	return deploy.DeletionTimestamp != nil
 }
 
+// Annotates the DaemonSet with the observed-artifact-id. This is used to differentiate new releases from pod deletion events.
 func annotateDeployment(ctx context.Context, c *kubernetes.Clientset, d *appsv1.Deployment) error {
 	d.Annotations["lunarway.com/observed-artifact-id"] = d.Annotations["lunarway.com/artifact-id"]
 	_, err := c.AppsV1().Deployments(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})

--- a/cmd/daemon/kubernetes/exporter.go
+++ b/cmd/daemon/kubernetes/exporter.go
@@ -11,7 +11,7 @@ import (
 // Exporter sends a formatted event to an upstream.
 type Exporter interface {
 	// Send a message through the exporter.
-	SendSuccessfulDeploymentEvent(c context.Context, event httpinternal.DeploymentEvent) error
+	SendSuccessfulReleaseEvent(c context.Context, event httpinternal.ReleaseEvent) error
 	SendPodErrorEvent(c context.Context, event httpinternal.PodErrorEvent) error
 }
 
@@ -21,7 +21,7 @@ type ReleaseManagerExporter struct {
 	Client      httpinternal.Client
 }
 
-func (e *ReleaseManagerExporter) SendSuccessfulDeploymentEvent(ctx context.Context, event httpinternal.DeploymentEvent) error {
+func (e *ReleaseManagerExporter) SendSuccessfulReleaseEvent(ctx context.Context, event httpinternal.ReleaseEvent) error {
 	e.Log.With("event", event).Infof("SuccesfulDeployment Event")
 	var resp httpinternal.KubernetesNotifyResponse
 	url, err := e.Client.URL("webhook/daemon/k8s/deploy")

--- a/cmd/daemon/kubernetes/exporter.go
+++ b/cmd/daemon/kubernetes/exporter.go
@@ -22,7 +22,7 @@ type ReleaseManagerExporter struct {
 }
 
 func (e *ReleaseManagerExporter) SendSuccessfulReleaseEvent(ctx context.Context, event httpinternal.ReleaseEvent) error {
-	e.Log.With("event", event).Infof("SuccesfulDeployment Event")
+	e.Log.With("event", event).Infof("SuccesfulRelease Event")
 	var resp httpinternal.KubernetesNotifyResponse
 	url, err := e.Client.URL("webhook/daemon/k8s/deploy")
 	if err != nil {

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -32,3 +32,12 @@ func NewClient(kubeConfigPath string, moduloCrashReportNotif float64, e Exporter
 		moduloCrashReportNotif: moduloCrashReportNotif,
 	}, nil
 }
+
+func isCorrectlyAnnotated(annotations map[string]string) bool {
+	if !(annotations["lunarway.com/controlled-by-release-manager"] == "true") &&
+		annotations["lunarway.com/artifact-id"] == "" &&
+		annotations["lunarway.com/author"] == "" {
+		return false
+	}
+	return true
+}

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -1,11 +1,8 @@
 package kubernetes
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
-
 
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -14,14 +11,13 @@ type Client struct {
 	clientset              *kubernetes.Clientset
 	exporter               Exporter
 	moduloCrashReportNotif float64
-	replicaSetTimeDiff     time.Duration
 }
 
 var (
 	ErrWatcherClosed = errors.New("channel closed")
 )
 
-func NewClient(kubeConfigPath string, moduloCrashReportNotif float64, replicaSetTimeDiff time.Duration, e Exporter) (*Client, error) {
+func NewClient(kubeConfigPath string, moduloCrashReportNotif float64, e Exporter) (*Client, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -35,6 +31,5 @@ func NewClient(kubeConfigPath string, moduloCrashReportNotif float64, replicaSet
 		clientset:              clientset,
 		exporter:               e,
 		moduloCrashReportNotif: moduloCrashReportNotif,
-		replicaSetTimeDiff:     replicaSetTimeDiff,
 	}, nil
 }

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -40,7 +40,7 @@ func (c *Client) HandlePodErrors(ctx context.Context) error {
 				continue
 			}
 			// Is this a pod managed by the release manager - and does it contain the information needed?
-			if !isPodCorrectlyAnnotated(pod) {
+			if !isCorrectlyAnnotated(pod.Annotations) {
 				continue
 			}
 			// Avoid reporting on pods that has been marked for termination
@@ -112,20 +112,6 @@ func (c *Client) HandlePodErrors(ctx context.Context) error {
 			}
 		}
 	}
-}
-
-func isPodCorrectlyAnnotated(pod *corev1.Pod) bool {
-	// Just continue if this pod is not controlled by the release manager
-	if !(pod.Annotations["lunarway.com/controlled-by-release-manager"] == "true") {
-		return false
-	}
-
-	// Just discard the event if there's no artifact id
-	if pod.Annotations["lunarway.com/artifact-id"] == "" {
-		log.Errorf("artifact-id missing in pod template: namespace '%s' pod '%s'", pod.Namespace, pod.Name)
-		return false
-	}
-	return true
 }
 
 // Avoid reporting on pods that has been marked for termination

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -101,15 +101,9 @@ func isStatefulSetSuccessful(ss *appsv1.StatefulSet) bool {
 }
 
 func isStatefulSetCorrectlyAnnotated(ss *appsv1.StatefulSet) bool {
-	if !(ss.Annotations["lunarway.com/controlled-by-release-manager"] == "true") {
-		return false
-	}
-	if ss.Annotations["lunarway.com/artifact-id"] == "" {
-		log.Errorf("artifact-id missing in statefulset: namespace '%s' name '%s'", ss.Namespace, ss.Name)
-		return false
-	}
-	if ss.Annotations["lunarway.com/author"] == "" {
-		log.Errorf("author missing in statefulset: namespace '%s' name '%s'", ss.Namespace, ss.Name)
+	if !(ss.Annotations["lunarway.com/controlled-by-release-manager"] == "true") &&
+		ss.Annotations["lunarway.com/artifact-id"] == "" &&
+		ss.Annotations["lunarway.com/author"] == "" {
 		return false
 	}
 	return true

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/prometheus/common/log"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (c *Client) HandleNewStatefulSets(ctx context.Context) error {
+	watcher, err := c.clientset.AppsV1().StatefulSets("").Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			watcher.Stop()
+		case e, ok := <-watcher.ResultChan():
+			if !ok {
+				return ErrWatcherClosed
+			}
+			if e.Object == nil {
+				continue
+			}
+			if e.Type == watch.Deleted {
+				continue
+			}
+			ss, ok := e.Object.(*appsv1.StatefulSet)
+			if !ok {
+				continue
+			}
+
+			// Check if we have all the annotations we need for the release-daemon
+			if !isStatefulSetCorrectlyAnnotated(ss) {
+				continue
+			}
+
+			// Avoid reporting on pods that has been marked for termination
+			if isStefulSetMarkedForTermination(ss) {
+				continue
+			}
+
+			// Verify if the StatefulSet fulfills the criterias for a succesful release
+			ok = isStatefulSetSuccessful(ss)
+			if !ok {
+				continue
+			}
+
+			// In-order to minimize messages and only return events when new releases is detected, we add
+			// a new annotation to the StatefulSet. This annotations tells provides the daemon with some valuable
+			// information about the artifacts running.
+			// When we initially apply a StatefulSet the lunarway.com/artifact-id annotations SHOULD be set.
+			// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
+			// In this state we annotate the StatefulSet with the current artifact-id as the observed.
+			// When we update a StatefulSet we also update the artifact-id, e.g. now observed and actual artifact id
+			// is different. In this case we want to notify, and update the observed with the current artifact id.
+			// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
+			if ss.Annotations["lunarway.com/observed-artifact-id"] == ss.Annotations["lunarway.com/artifact-id"] {
+				continue
+			}
+
+			// Annotate the StatefulSet to be able to skip it next time
+			err = annotateStatefulSet(ctx, c.clientset, ss)
+			if err != nil {
+				log.Errorf("Unable to annotate StatefulSet: %v", err)
+				continue
+			}
+
+			log.Infof("Notify successful StatefulSet: %+v", ss)
+		}
+	}
+}
+
+// Avoid reporting on StatefulSets that has been marked for termination
+func isStefulSetMarkedForTermination(ss *appsv1.StatefulSet) bool {
+	return ss.DeletionTimestamp != nil
+}
+
+func isStatefulSetSuccessful(ss *appsv1.StatefulSet) bool {
+	return ss.Status.Replicas == ss.Status.ReadyReplicas &&
+		ss.Status.Replicas == ss.Status.CurrentReplicas &&
+		ss.Status.Replicas == ss.Status.UpdatedReplicas &&
+		ss.Status.ObservedGeneration >= ss.Generation
+}
+
+func isStatefulSetCorrectlyAnnotated(ss *appsv1.StatefulSet) bool {
+	if !(ss.Annotations["lunarway.com/controlled-by-release-manager"] == "true") {
+		return false
+	}
+	if ss.Annotations["lunarway.com/artifact-id"] == "" {
+		log.Errorf("artifact-id missing in statefulset: namespace '%s' name '%s'", ss.Namespace, ss.Name)
+		return false
+	}
+	if ss.Annotations["lunarway.com/author"] == "" {
+		log.Errorf("author missing in statefulset: namespace '%s' name '%s'", ss.Namespace, ss.Name)
+		return false
+	}
+	return true
+}
+
+func annotateStatefulSet(ctx context.Context, c *kubernetes.Clientset, ss *appsv1.StatefulSet) error {
+	ss.Annotations["lunarway.com/observed-artifact-id"] = ss.Annotations["lunarway.com/artifact-id"]
+	_, err := c.AppsV1().StatefulSets(ss.Namespace).Update(ctx, ss, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -377,22 +377,22 @@ func daemonk8sDeployWebhook(payload *payload, flowSvc *flow.Service) http.Handle
 		// copy span from request context but ignore any deadlines on the request context
 		ctx := opentracing.ContextWithSpan(context.Background(), opentracing.SpanFromContext(r.Context()))
 		logger := log.WithContext(ctx)
-		var k8sDeployEvent httpinternal.DeploymentEvent
-		err := payload.decodeResponse(ctx, r.Body, &k8sDeployEvent)
+		var k8sReleaseEvent httpinternal.ReleaseEvent
+		err := payload.decodeResponse(ctx, r.Body, &k8sReleaseEvent)
 		if err != nil {
 			logger.Errorf("http: daemon k8s deploy webhook: decode request body failed: %v", err)
 			invalidBodyError(w)
 			return
 		}
-		logger = logger.WithFields("event", k8sDeployEvent)
-		err = flowSvc.NotifyK8SDeployEvent(ctx, &k8sDeployEvent)
+		logger = logger.WithFields("event", k8sReleaseEvent)
+		err = flowSvc.NotifyK8SDeployEvent(ctx, &k8sReleaseEvent)
 		if err != nil && errors.Cause(err) != slack.ErrUnknownEmail {
 			logger.Errorf("http: daemon k8s deploy webhook failed: %+v", err)
 		}
 		w.WriteHeader(http.StatusOK)
 		err = payload.encodeResponse(ctx, w, httpinternal.KubernetesNotifyResponse{})
 		if err != nil {
-			logger.Errorf("http: daemon k8s deploy webhook: environment: '%s' marshal response: %v", k8sDeployEvent.Environment, err)
+			logger.Errorf("http: daemon k8s deploy webhook: environment: '%s' marshal response: %v", k8sReleaseEvent.Environment, err)
 		}
 		logger.Infof("http: daemon k8s deploy webhook: handled")
 	}

--- a/e2e-test/daemonset.yaml
+++ b/e2e-test/daemonset.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-daemonset
+  labels:
+    app: nginx
+  annotations:
+    kubernetes.io/change-cause: 'nginx:1.14.1'
+    lunarway.com/author: 'kni@lunar.app'
+    lunarway.com/artifact-id: 'nginx:1.14.1'
+    lunarway.com/controlled-by-release-manager: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        kubernetes.io/change-cause: 'nginx:1.14.1'
+        lunarway.com/author: 'kni@lunar.app'
+        lunarway.com/artifact-id: 'nginx:1.14.1'
+        lunarway.com/controlled-by-release-manager: 'true'
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.1
+        ports:
+        - containerPort: 80

--- a/e2e-test/daemonset.yaml
+++ b/e2e-test/daemonset.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: nginx
   annotations:
-    kubernetes.io/change-cause: 'nginx:1.14.1'
+    kubernetes.io/change-cause: 'nginx:1.14.2'
     lunarway.com/author: 'kni@lunar.app'
-    lunarway.com/artifact-id: 'nginx:1.14.1'
+    lunarway.com/artifact-id: 'nginx:1.14.2'
     lunarway.com/controlled-by-release-manager: 'true'
 spec:
   selector:
@@ -18,13 +18,13 @@ spec:
       labels:
         app: nginx
       annotations:
-        kubernetes.io/change-cause: 'nginx:1.14.1'
+        kubernetes.io/change-cause: 'nginx:1.14.2'
         lunarway.com/author: 'kni@lunar.app'
-        lunarway.com/artifact-id: 'nginx:1.14.1'
+        lunarway.com/artifact-id: 'nginx:1.14.2'
         lunarway.com/controlled-by-release-manager: 'true'
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.1
+        image: nginx:1.14.2
         ports:
         - containerPort: 80

--- a/e2e-test/kind-cluster.yaml
+++ b/e2e-test/kind-cluster.yaml
@@ -2,6 +2,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    extraMounts:
+    - hostPath: ./e2e-test/source-git-repo
+      containerPath: /source-git-repo
+    - hostPath: ./e2e-test/binaries
+      containerPath: /binaries
     # extraPortMappings:
     #   - containerPort: 3030 # fluxd
     #     hostPort: 3030
@@ -18,6 +23,19 @@ nodes:
     #   - containerPort: 15672 # rabbitmq admin
     #     hostPort: 15672
     #     protocol: tcp
+  - role: worker
+    extraMounts:
+    - hostPath: ./e2e-test/source-git-repo
+      containerPath: /source-git-repo
+    - hostPath: ./e2e-test/binaries
+      containerPath: /binaries
+  - role: worker
+    extraMounts:
+    - hostPath: ./e2e-test/source-git-repo
+      containerPath: /source-git-repo
+    - hostPath: ./e2e-test/binaries
+      containerPath: /binaries
+  - role: worker
     extraMounts:
       - hostPath: ./e2e-test/source-git-repo
         containerPath: /source-git-repo

--- a/e2e-test/statefulset.yaml
+++ b/e2e-test/statefulset.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/change-cause: 'nginx-slim:0.8'
+    lunarway.com/author: 'kni@lunar.app'
+    lunarway.com/artifact-id: 'nginx-slim:0.8'
+    lunarway.com/controlled-by-release-manager: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi

--- a/e2e-test/statefulset.yaml
+++ b/e2e-test/statefulset.yaml
@@ -3,9 +3,9 @@ kind: StatefulSet
 metadata:
   name: web
   annotations:
-    kubernetes.io/change-cause: 'nginx-slim:0.8'
+    kubernetes.io/change-cause: 'nginx-slim:0.7'
     lunarway.com/author: 'kni@lunar.app'
-    lunarway.com/artifact-id: 'nginx-slim:0.8'
+    lunarway.com/artifact-id: 'nginx-slim:0.7'
     lunarway.com/controlled-by-release-manager: 'true'
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim:0.7
         ports:
         - containerPort: 80
           name: web

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
 	github.com/prometheus/client_golang v1.2.1
+	github.com/prometheus/common v0.7.0
 	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,10 @@ github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -844,6 +846,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *Service) NotifyK8SDeployEvent(ctx context.Context, event *http.DeploymentEvent) error {
+func (s *Service) NotifyK8SDeployEvent(ctx context.Context, event *http.ReleaseEvent) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.NotifyK8SDeployment")
 	defer span.Finish()
 	span, _ = s.Tracer.FromCtx(ctx, "post k8s deploy slack message")

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -87,11 +87,12 @@ type FluxNotifyRequest struct {
 	FluxEvent   event.Event
 }
 
-type DeploymentEvent struct {
+type ReleaseEvent struct {
 	Name          string `json:"name,omitempty"`
 	Namespace     string `json:"namespace,omitempty"`
+	ResourceType  string `json:"resourceType,omitempty"`
 	AvailablePods int32  `json:"availablePods"`
-	Replicas      int32  `json:"replicas,omitempty"`
+	DesiredPods   int32  `json:"replicas,omitempty"`
 	ArtifactID    string `json:"artifactId,omitempty"`
 	AuthorEmail   string `json:"authorEmail,omitempty"`
 	Environment   string `json:"environment,omitempty"`
@@ -103,12 +104,12 @@ type ContainerError struct {
 }
 
 type PodErrorEvent struct {
-	PodName     string `json:"podName,omitempty"`
-	Namespace   string `json:"namespace,omitempty"`
+	PodName     string           `json:"podName,omitempty"`
+	Namespace   string           `json:"namespace,omitempty"`
 	Errors      []ContainerError `json:"errors,omitempty"`
-	AuthorEmail string `json:"authorEmail,omitempty"`
-	Environment string `json:"environment,omitempty"`
-	ArtifactID  string `json:"artifactId,omitempty"`
+	AuthorEmail string           `json:"authorEmail,omitempty"`
+	Environment string           `json:"environment,omitempty"`
+	ArtifactID  string           `json:"artifactId,omitempty"`
 }
 type KubernetesNotifyResponse struct {
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -274,7 +274,7 @@ func (c *Client) NotifyFluxErrorEvent(ctx context.Context, artifactID, env, emai
 	return err
 }
 
-func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event *http.DeploymentEvent) error {
+func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event *http.ReleaseEvent) error {
 	if c.muteOptions.Kubernetes {
 		return nil
 	}
@@ -286,7 +286,7 @@ func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event *http.Deploymen
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
 		Title:      fmt.Sprintf(":kubernetes: k8s (%s) :white_check_mark:", event.Environment),
 		Color:      MsgColorGreen,
-		Text:       fmt.Sprintf("%s deployed\n%d/%d pods are running\nArtifact: *%s*", event.Name, event.AvailablePods, event.Replicas, event.ArtifactID),
+		Text:       fmt.Sprintf("%s deployed\n%d/%d pods are running (%s)\nArtifact: *%s*", event.Name, event.AvailablePods, event.DesiredPods, event.ResourceType, event.ArtifactID),
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)


### PR DESCRIPTION
This PR adds functionality to the release-daemon to watch for successful releases. 

Only new releases will trigger a notification. Pod deletion or restarts will not trigger a notification as it would have previously. 

In order to control this behavior, the release-daemon adds an annotation to the `DaemonSets` and `StatefulSets` it's watching called `observed-artifact-id`. This is used to determine when a notification should trigger.

This PR also changes the `DeploymentEvent` to a more generic `ReleaseEvent` that can we used for all the different release types. The most significant change is the addition of a `Type`  that will be outputtet in the Slack to indicate which resource type the message is for. We can discuss whether or not this is relevant for developers.

This PR also changes the deployment watch to use the `observed-artifact-id` annotation.