### PR TITLE
Support global only policies

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -330,6 +330,28 @@ func TestService_Get(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name:    "only global policies",
+			service: "notfound",
+			globalPolicies: []BranchRestriction{
+				{
+					ID:          "branch-restriction-prod",
+					BranchRegex: "^master$",
+					Environment: "prod",
+				},
+			},
+			policies: Policies{
+				Service: "notfound",
+				BranchRestrictions: []BranchRestriction{
+					{
+						ID:          "branch-restriction-prod",
+						BranchRegex: "^master$",
+						Environment: "prod",
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
If only global policies are applied for a service the policy.Service.Get method
returns ErrNotFound instead of the global policies. This leads to listing
policies indicates no policies along with any release restrictions are not
enforced.

This change set detects this case and returns the globally applied policies in
this case.