### PR TITLE
Fix parsing of commitMessage to notify author via slack

### DIFF
--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -2,7 +2,6 @@ package flow
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	"github.com/lunarway/release-manager/internal/flux"
@@ -96,7 +95,6 @@ func parseCommitMessage(commitMessage string) (FluxReleaseMessage, error) {
 	if len(matches) < 1 {
 		return FluxReleaseMessage{}, errors.New("not enough matches")
 	}
-	fmt.Printf("matches: %v", matches)
 	return FluxReleaseMessage{
 		Environment:  matches[1],
 		Service:      matches[2],

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/lunarway/release-manager/internal/flux"
@@ -78,14 +79,15 @@ func (s *Service) NotifyFluxEvent(ctx context.Context, event *http.FluxNotifyReq
 }
 
 type FluxReleaseMessage struct {
-	Environment string
-	Service     string
-	ArtifactID  string
-	GitAuthor   string
+	Environment  string
+	Service      string
+	ArtifactID   string
+	GitAuthor    string
+	GitCommitter string
 }
 
 func parseCommitMessage(commitMessage string) (FluxReleaseMessage, error) {
-	pattern := `^\[(?P<env>.*)/(?P<service>.*)\]\s+release\s+(?P<artifact>.*)\s+by\s+(?P<author>.*)`
+	pattern := `^\[(?P<env>.*)/(?P<service>.*)\]\s+release\s+(?P<artifact>.*)\s+by\s+(?P<author>.*)\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>\nArtifact-released-by:\s(?P<committerName>.*)\s<(?P<committerEmail>.*)>`
 	r, err := regexp.Compile(pattern)
 	if err != nil {
 		return FluxReleaseMessage{}, errors.WithMessage(err, "regex didn't match")
@@ -94,11 +96,12 @@ func parseCommitMessage(commitMessage string) (FluxReleaseMessage, error) {
 	if len(matches) < 1 {
 		return FluxReleaseMessage{}, errors.New("not enough matches")
 	}
-
+	fmt.Printf("matches: %v", matches)
 	return FluxReleaseMessage{
-		Environment: matches[1],
-		Service:     matches[2],
-		ArtifactID:  matches[3],
-		GitAuthor:   matches[4],
+		Environment:  matches[1],
+		Service:      matches[2],
+		ArtifactID:   matches[3],
+		GitAuthor:    matches[6],
+		GitCommitter: matches[8],
 	}, nil
 }

--- a/internal/flow/notify_test.go
+++ b/internal/flow/notify_test.go
@@ -15,13 +15,22 @@ func TestCommitMessageExtraction(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "exact values",
+			name:          "only four values match",
 			commitMessage: "[env/service-name] release master-1234567890-1234567890 by test@lunar.app",
+			expected:      FluxReleaseMessage{},
+			err:           errors.New("not enough matches"),
+		},
+		{
+			name: "exact values",
+			commitMessage: `[env/service-name] release master-a037e03657-efc17d9df7 by author@lunar.app
+Artifact-created-by: Author <author@lunar.app>
+Artifact-released-by: Committer <committer@lunar.app>`,
 			expected: FluxReleaseMessage{
-				Environment: "env",
-				Service:     "service-name",
-				ArtifactID:  "master-1234567890-1234567890",
-				GitAuthor:   "test@lunar.app",
+				Environment:  "env",
+				Service:      "service-name",
+				ArtifactID:   "master-a037e03657-efc17d9df7",
+				GitAuthor:    "author@lunar.app",
+				GitCommitter: "committer@lunar.app",
 			},
 			err: nil,
 		},


### PR DESCRIPTION
This PR fixes an issue introduced after adding additional information to the commit message in the config repo. https://github.com/lunarway/release-manager/pull/173

This updates the parsing of the commit message to extract the git author of the original commit. This also introduces the possibility to send a message to the releaser, if we want in the future.