### PR TITLE
Fix commit message parsing

### DIFF
--- a/cmd/server/http/http_test.go
+++ b/cmd/server/http/http_test.go
@@ -92,6 +92,16 @@ func TestExtractInfoFromCommit(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:          "email as author",
+			commitMessage: "[test-service] artifact master-1234ds13g3-12s46g356g by test@lunar.app\nArtifact-created-by: Foo Bar <test@lunar.app>",
+			commitInfo: commitInfo{
+				AuthorEmail: "test@lunar.app",
+				AuthorName:  "Foo Bar",
+				Service:     "test-service",
+			},
+			err: nil,
+		},
+		{
 			name:          "not valid message",
 			commitMessage: "[product] build something",
 			commitInfo:    commitInfo{},

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -280,7 +280,7 @@ func PushArtifact(ctx context.Context, gitSvc *git.Service, artifactFileName, re
 	artifactID := artifactSpec.ID
 	authorName := artifactSpec.Application.AuthorName
 	authorEmail := artifactSpec.Application.AuthorEmail
-	commitMsg := git.ArtifactCommitMessage(artifactSpec.Service, artifactID, authorName)
+	commitMsg := git.ArtifactCommitMessage(artifactSpec.Service, artifactID, authorEmail)
 	fmt.Printf("Committing changes\n")
 	err = gitSvc.SignedCommit(ctx, destinationPath, ".", authorName, authorEmail, commitMsg)
 	if err != nil {

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -86,7 +86,7 @@ type FluxReleaseMessage struct {
 }
 
 func parseCommitMessage(commitMessage string) (FluxReleaseMessage, error) {
-	pattern := `^\[(?P<env>.*)/(?P<service>.*)\]\s+release\s+(?P<artifact>.*)\s+by\s+(?P<author>.*)\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>\nArtifact-released-by:\s(?P<committerName>.*)\s<(?P<committerEmail>.*)>`
+	pattern := `^\[(?P<env>.*)/(?P<service>.*)\]\s+release\s+(?P<artifact>.*)\s+by\s+(?P<author>.*)\sArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>\sArtifact-released-by:\s(?P<committerName>.*)\s<(?P<committerEmail>.*)>`
 	r, err := regexp.Compile(pattern)
 	if err != nil {
 		return FluxReleaseMessage{}, errors.WithMessage(err, "regex didn't match")

--- a/internal/flow/notify_test.go
+++ b/internal/flow/notify_test.go
@@ -21,7 +21,19 @@ func TestCommitMessageExtraction(t *testing.T) {
 			err:           errors.New("not enough matches"),
 		},
 		{
-			name: "exact values",
+			name:          "exact values without newlines",
+			commitMessage: "[env/service-name] release master-a037e03657-efc17d9df7 by author@lunar.app Artifact-created-by: Author <author@lunar.app> Artifact-released-by: Committer <committer@lunar.app>",
+			expected: FluxReleaseMessage{
+				Environment:  "env",
+				Service:      "service-name",
+				ArtifactID:   "master-a037e03657-efc17d9df7",
+				GitAuthor:    "author@lunar.app",
+				GitCommitter: "committer@lunar.app",
+			},
+			err: nil,
+		},
+		{
+			name: "exact values with newlines",
 			commitMessage: `[env/service-name] release master-a037e03657-efc17d9df7 by author@lunar.app
 Artifact-created-by: Author <author@lunar.app>
 Artifact-released-by: Committer <committer@lunar.app>`,


### PR DESCRIPTION
This PR contains two changes. 

First, it fixes the problem of parsing the commit message in the config repo on a flux event. 

Second, it aligns the commit message from artifact to use email and verify that this still works in the release-manager github webhook.