### PR TITLE
Refactor artifact storage into separate package

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lunarway/release-manager/internal/broker/amqp"
 	"github.com/lunarway/release-manager/internal/broker/memory"
 	"github.com/lunarway/release-manager/internal/flow"
-	"github.com/lunarway/release-manager/internal/flow/storage"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/github"
 	"github.com/lunarway/release-manager/internal/grafana"
@@ -182,7 +181,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Slack:            slackClient,
 				Git:              &gitSvc,
 				CanRelease:       policySvc.CanRelease,
-				Storage:          storage.NewGit(startOptions.configRepo.ArtifactFileName, &gitSvc, tracer),
+				Storage:          &gitSvc,
 				Tracer:           tracer,
 				// TODO: figure out a better way of splitting the consumer and publisher
 				// to avoid this chicken and egg issue. It is not a real problem as the

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lunarway/release-manager/internal/broker/amqp"
 	"github.com/lunarway/release-manager/internal/broker/memory"
 	"github.com/lunarway/release-manager/internal/flow"
+	"github.com/lunarway/release-manager/internal/flow/storage"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/github"
 	"github.com/lunarway/release-manager/internal/grafana"
@@ -180,6 +181,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Slack:            slackClient,
 				Git:              &gitSvc,
 				CanRelease:       policySvc.CanRelease,
+				Storage:          storage.NewGit(startOptions.configRepo.ArtifactFileName, &gitSvc, tracer),
 				Tracer:           tracer,
 				// TODO: figure out a better way of splitting the consumer and publisher
 				// to avoid this chicken and egg issue. It is not a real problem as the

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -156,6 +156,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				SSHPrivateKeyPath: startOptions.configRepo.SSHPrivateKeyPath,
 				ConfigRepoURL:     startOptions.configRepo.ConfigRepo,
 				Config:            startOptions.gitConfigOpts,
+				ArtifactFileName:  startOptions.configRepo.ArtifactFileName,
 			}
 
 			github := github.Service{

--- a/internal/flow/artifact_read_storage.go
+++ b/internal/flow/artifact_read_storage.go
@@ -1,0 +1,37 @@
+package flow
+
+import (
+	"context"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+)
+
+type ArtifactReadStorage interface {
+	// ArtifactExists returns whether an artifact with id artifactID is available.
+	ArtifactExists(ctx context.Context, artifactID string) (bool, error)
+
+	// ArtifactSpecification returns the artifact specification for a given
+	// service and artifact ID.
+	ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error)
+
+	// ArtifactPaths returns file system paths for the artifact specification
+	// (specPath) and yaml resources directory (resourcesPath) available on the
+	// file system for copying to releases. The returned close function is
+	// responsible for clean up of the persisted files.
+	ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close func(context.Context), err error)
+
+	// LatestArtifactSpecification returns the latest artifact specification for a
+	// given service and branch.
+	LatestArtifactSpecification(ctx context.Context, service, branch string) (artifact.Spec, error)
+
+	// LatestArtifactPaths returns file system paths for the artifact
+	// specification (specPath) and yaml resources directory (resourcesPath)
+	// available on the file system for copying to releases of the latest artifact
+	// for provided service and branch. The returned close function is responsible
+	// for clean up of the persisted files.
+	LatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close func(context.Context), err error)
+
+	// ArtifactSpecifications returns a list of n newest artifact specifications
+	// for service. They should be ordered by newest first.
+	ArtifactSpecifications(ctx context.Context, service string, n int) ([]artifact.Spec, error)
+}

--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -65,5 +65,5 @@ func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, s
 func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) ([]artifact.Spec, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.DescribeArtifact")
 	defer span.Finish()
-	return s.Storage.GetArtifacts(ctx, service, n)
+	return s.Storage.GetArtifactSpecifications(ctx, service, n)
 }

--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -65,5 +65,5 @@ func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, s
 func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) ([]artifact.Spec, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.DescribeArtifact")
 	defer span.Finish()
-	return s.Storage.GetArtifactSpecifications(ctx, service, n)
+	return s.Storage.ArtifactSpecifications(ctx, service, n)
 }

--- a/internal/flow/describe.go
+++ b/internal/flow/describe.go
@@ -2,7 +2,6 @@ package flow
 
 import (
 	"context"
-	"path"
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
@@ -66,41 +65,5 @@ func (s *Service) DescribeRelease(ctx context.Context, namespace, environment, s
 func (s *Service) DescribeArtifact(ctx context.Context, service string, n int) ([]artifact.Spec, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.DescribeArtifact")
 	defer span.Finish()
-	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
-	if err != nil {
-		return nil, err
-	}
-	defer close(ctx)
-
-	logger := log.WithContext(ctx)
-	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	hashes, err := s.Git.LocateArtifacts(ctx, sourceRepo, service, n)
-	if err != nil {
-		return nil, errors.WithMessage(err, "locate artifacts")
-	}
-	var artifacts []artifact.Spec
-	logger.Debugf("flow/describe: hashes %+v", hashes)
-	for _, hash := range hashes {
-		err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-		if err != nil {
-			return nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-		}
-		branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
-		if err != nil {
-			logger.Errorf("flow/describe: get branch from head failed at hash '%s': skipping hash: %v", hash, err)
-			continue
-		}
-		artifactPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
-		spec, err := artifact.Get(artifactPath)
-		if err != nil {
-			return nil, errors.WithMessagef(err, "get artifact at path '%s' at hash '%s'", artifactPath, hash)
-		}
-		artifacts = append(artifacts, spec)
-	}
-	return artifacts, nil
+	return s.Storage.GetArtifacts(ctx, service, n)
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -229,7 +229,7 @@ func envSpec(root, artifactFileName, service, env, namespace string) (artifact.S
 func (s *Service) sourceSpec(ctx context.Context, service, env, namespace string) (artifact.Spec, error) {
 	switch env {
 	case "dev":
-		return s.Storage.GetLatestArtifactSpecification(ctx, storage.ArtifactLocation{
+		return s.Storage.LatestArtifactSpecification(ctx, storage.ArtifactLocation{
 			Branch:  "master",
 			Service: service,
 		})

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/copy"
-	"github.com/lunarway/release-manager/internal/flow/storage"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/slack"
@@ -34,7 +33,7 @@ type Service struct {
 	Git              *git.Service
 	Tracer           tracing.Tracer
 	CanRelease       func(ctx context.Context, svc, branch, env string) (bool, error)
-	Storage          storage.Storage
+	Storage          Storage
 
 	PublishPromote           func(context.Context, PromoteEvent) error
 	PublishRollback          func(context.Context, RollbackEvent) error
@@ -46,6 +45,18 @@ type Service struct {
 	// NotifyReleaseHook is triggered in a Go routine when a release is completed.
 	// The context.Context is cancelled if the originating flow call is cancelled.
 	NotifyReleaseHook func(ctx context.Context, options NotifyReleaseOptions)
+}
+
+type Storage interface {
+	ArtifactExists(ctx context.Context, artifactID string) (bool, error)
+
+	ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error)
+	ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close func(context.Context), err error)
+
+	LatestArtifactSpecification(ctx context.Context, service, branch string) (artifact.Spec, error)
+	LatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close func(context.Context), err error)
+
+	ArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
 }
 
 type NotifyReleaseOptions struct {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -224,40 +224,6 @@ func envSpec(root, artifactFileName, service, env, namespace string) (artifact.S
 	return artifact.Get(path.Join(releasePath(root, service, env, namespace), artifactFileName))
 }
 
-// sourceSpec returns the Spec of the "previous" environment following promote
-// order.
-func (s *Service) sourceSpec(ctx context.Context, service, env, namespace string) (artifact.Spec, error) {
-	switch env {
-	case "dev":
-		return s.Storage.LatestArtifactSpecification(ctx, storage.ArtifactLocation{
-			Branch:  "master",
-			Service: service,
-		})
-	case "staging":
-		// if namespace is set to the environment we have to look one environment back when locating the artifact.json
-		if namespace == "staging" {
-			namespace = "dev"
-		}
-		return s.releaseSpecification(ctx, releaseLocation{
-			Environment: "dev",
-			Namespace:   namespace,
-			Service:     service,
-		})
-	case "prod":
-		// if namespace is set to the environment we have to look one environment back when locating the artifact.json
-		if namespace == "prod" {
-			namespace = "staging"
-		}
-		return s.releaseSpecification(ctx, releaseLocation{
-			Environment: "staging",
-			Namespace:   namespace,
-			Service:     service,
-		})
-	default:
-		return artifact.Spec{}, ErrUnknownEnvironment
-	}
-}
-
 func srcPath(root, service, branch, env string) string {
 	return path.Join(artifactPath(root, service, branch), env)
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -33,7 +33,7 @@ type Service struct {
 	Git              *git.Service
 	Tracer           tracing.Tracer
 	CanRelease       func(ctx context.Context, svc, branch, env string) (bool, error)
-	Storage          Storage
+	Storage          ArtifactReadStorage
 
 	PublishPromote           func(context.Context, PromoteEvent) error
 	PublishRollback          func(context.Context, RollbackEvent) error
@@ -45,18 +45,6 @@ type Service struct {
 	// NotifyReleaseHook is triggered in a Go routine when a release is completed.
 	// The context.Context is cancelled if the originating flow call is cancelled.
 	NotifyReleaseHook func(ctx context.Context, options NotifyReleaseOptions)
-}
-
-type Storage interface {
-	ArtifactExists(ctx context.Context, artifactID string) (bool, error)
-
-	ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error)
-	ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close func(context.Context), err error)
-
-	LatestArtifactSpecification(ctx context.Context, service, branch string) (artifact.Spec, error)
-	LatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close func(context.Context), err error)
-
-	ArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
 }
 
 type NotifyReleaseOptions struct {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -229,7 +229,7 @@ func envSpec(root, artifactFileName, service, env, namespace string) (artifact.S
 func (s *Service) sourceSpec(ctx context.Context, service, env, namespace string) (artifact.Spec, error) {
 	switch env {
 	case "dev":
-		return s.Storage.GetArtifactSpecification(ctx, storage.ArtifactLocation{
+		return s.Storage.GetLatestArtifactSpecification(ctx, storage.ArtifactLocation{
 			Branch:  "master",
 			Service: service,
 		})

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -171,7 +171,7 @@ func (s *Service) ExecPromote(ctx context.Context, p PromoteEvent) error {
 			closeSource                    func(context.Context)
 			err                            error
 		)
-		// when promoting to dev we use should look for the artifact instead of
+		// when promoting to dev we should look for the artifact instead of
 		// release as the artifact have never been released.
 		if environment == "dev" {
 			artifactSourcePath, sourcePath, closeSource, err = s.Storage.ArtifactPaths(ctx, service, environment, "master", artifactID)

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -176,7 +176,7 @@ func (s *Service) ExecPromote(ctx context.Context, p PromoteEvent) error {
 		// when promoting to dev we use should look for the artifact instead of
 		// release as the artifact have never been released.
 		if environment == "dev" {
-			artifactSourcePath, sourcePath, closeSource, err = s.Storage.GetArtifactPaths(ctx, service, environment, "master", artifactID)
+			artifactSourcePath, sourcePath, closeSource, err = s.Storage.ArtifactPaths(ctx, service, environment, "master", artifactID)
 		} else {
 			artifactSourcePath, sourcePath, closeSource, err = s.releasePaths(ctx, service, environment, artifactID)
 		}

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -30,7 +30,6 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 		}
 		logger.Infof("flow: Promote: using namespace '%s'", namespace)
 
-		// locate the previous environment
 		sourceSpec, err := s.previousSpec(ctx, service, environment, namespace)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))

--- a/internal/flow/promote.go
+++ b/internal/flow/promote.go
@@ -86,7 +86,6 @@ func (s *Service) Promote(ctx context.Context, actor Actor, environment, namespa
 			Namespace:   namespace,
 			Service:     service,
 		})
-		// currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
 		if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
 			return true, errors.WithMessage(err, "get current released spec")
 		}
@@ -177,7 +176,6 @@ func (s *Service) ExecPromote(ctx context.Context, p PromoteEvent) error {
 		// when promoting to dev we use should look for the artifact instead of
 		// release as the artifact have never been released.
 		if environment == "dev" {
-			// TODO: what branch to use here?
 			artifactSourcePath, sourcePath, closeSource, err = s.Storage.GetArtifactPaths(ctx, service, environment, "master", artifactID)
 		} else {
 			artifactSourcePath, sourcePath, closeSource, err = s.releasePaths(ctx, service, environment, artifactID)
@@ -251,7 +249,7 @@ func (s *Service) ExecPromote(ctx context.Context, p PromoteEvent) error {
 
 func (s *Service) releasePaths(ctx context.Context, service, environment, artifactID string) (string, string, storage.CloseFunc, error) {
 	logger := log.WithContext(ctx)
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-paths")
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/copy"
-	"github.com/lunarway/release-manager/internal/flow/storage"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
@@ -36,10 +35,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		return "", ErrReleaseProhibited
 	}
 
-	artifactSpec, err := s.Storage.LatestArtifactSpecification(ctx, storage.ArtifactLocation{
-		Branch:  branch,
-		Service: service,
-	})
+	artifactSpec, err := s.Storage.LatestArtifactSpecification(ctx, service, branch)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 	}
@@ -161,10 +157,7 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
 		}
 
-		artifactSpec, err := s.Storage.LatestArtifactSpecification(ctx, storage.ArtifactLocation{
-			Service: service,
-			Branch:  branch,
-		})
+		artifactSpec, err := s.Storage.LatestArtifactSpecification(ctx, service, branch)
 		if err != nil {
 			return true, errors.WithMessage(err, "get artifact spec")
 		}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -69,7 +69,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 	// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
 	// will then be the default value and this its ID will be the empty string.
 	// currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-	currentSpec, err := s.Storage.GetReleaseSpecification(ctx, storage.ReleaseLocation{
+	currentSpec, err := s.releaseSpecification(ctx, releaseLocation{
 		Environment: environment,
 		Namespace:   namespace,
 		Service:     service,
@@ -137,7 +137,7 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 		actor := event.Actor
 
 		// repo/artifacts/{service}/{branch}/{artifactFileName}
-		artifactSpecPath, artifactPath, closeSource, err := s.Storage.GetArtifactPath(ctx, service, environment, branch)
+		artifactSpecPath, artifactPath, closeSource, err := s.Storage.GetLatestArtifactPaths(ctx, service, environment, branch)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 		}
@@ -239,7 +239,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		return "", errors.WithMessage(err, "locate branch from artifact id")
 	}
 
-	specPath, _, closeSource, err := s.Storage.GetArtifactPathFromArtifactID(ctx, service, environment, branch, artifactID)
+	specPath, _, closeSource, err := s.Storage.GetArtifactPaths(ctx, service, environment, branch, artifactID)
 	if err != nil {
 		return "", errors.WithMessage(err, "locate artifact paths")
 	}
@@ -325,7 +325,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 
 		logger := log.WithContext(ctx)
 
-		artifactSourcePath, sourcePath, closeSource, err := s.Storage.GetArtifactPathFromArtifactID(ctx, service, environment, branch, artifactID)
+		artifactSourcePath, sourcePath, closeSource, err := s.Storage.GetArtifactPaths(ctx, service, environment, branch, artifactID)
 		if err != nil {
 			return true, errors.WithMessage(err, "get artifact paths")
 		}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -68,7 +68,6 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 	// environment. If there is no artifact released to the target environment an
 	// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
 	// will then be the default value and this its ID will be the empty string.
-	// currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
 	currentSpec, err := s.releaseSpecification(ctx, releaseLocation{
 		Environment: environment,
 		Namespace:   namespace,
@@ -169,6 +168,7 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 		if err != nil {
 			return true, errors.WithMessage(err, "get artifact spec")
 		}
+
 		authorName := artifactSpec.Application.AuthorName
 		authorEmail := artifactSpec.Application.AuthorEmail
 		artifactID := artifactSpec.ID

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -36,7 +36,7 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		return "", ErrReleaseProhibited
 	}
 
-	artifactSpec, err := s.Storage.GetArtifactSpecification(ctx, storage.ArtifactLocation{
+	artifactSpec, err := s.Storage.GetLatestArtifactSpecification(ctx, storage.ArtifactLocation{
 		Branch:  branch,
 		Service: service,
 	})
@@ -162,7 +162,7 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
 		}
 
-		artifactSpec, err := s.Storage.GetArtifactSpecification(ctx, storage.ArtifactLocation{
+		artifactSpec, err := s.Storage.GetLatestArtifactSpecification(ctx, storage.ArtifactLocation{
 			Service: service,
 			Branch:  branch,
 		})

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/copy"
+	"github.com/lunarway/release-manager/internal/flow/storage"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
@@ -35,18 +36,10 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 		return "", ErrReleaseProhibited
 	}
 
-	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-branch")
-	if err != nil {
-		return "", err
-	}
-	defer close(ctx)
-	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-	// repo/artifacts/{service}/{branch}/{artifactFileName}
-	artifactSpecPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
-	artifactSpec, err := artifact.Get(artifactSpecPath)
+	artifactSpec, err := s.Storage.GetArtifactSpecification(ctx, storage.ArtifactLocation{
+		Branch:  branch,
+		Service: service,
+	})
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 	}
@@ -75,7 +68,12 @@ func (s *Service) ReleaseBranch(ctx context.Context, actor Actor, environment, s
 	// environment. If there is no artifact released to the target environment an
 	// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
 	// will then be the default value and this its ID will be the empty string.
-	currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+	// currentSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+	currentSpec, err := s.Storage.GetReleaseSpecification(ctx, storage.ReleaseLocation{
+		Environment: environment,
+		Namespace:   namespace,
+		Service:     service,
+	})
 	if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
 		return "", errors.WithMessage(err, "get current released spec")
 	}
@@ -139,15 +137,13 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 		actor := event.Actor
 
 		// repo/artifacts/{service}/{branch}/{artifactFileName}
-		artifactSpecPath := path.Join(artifactPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
-		artifactSpec, err := artifact.Get(artifactSpecPath)
+		artifactSpecPath, artifactPath, closeSource, err := s.Storage.GetArtifactPath(ctx, service, environment, branch)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 		}
+		defer closeSource(ctx)
 
 		// release service to env from the artifact path
-		// repo/artifacts/{service}/{branch}/{env}
-		artifactPath := srcPath(sourceConfigRepoPath, service, branch, environment)
 		// repo/{env}/releases/{ns}/{service}
 		destinationPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
 		logger.Infof("flow: ReleaseBranch: copy resources from %s to %s", artifactPath, destinationPath)
@@ -166,6 +162,13 @@ func (s *Service) ExecReleaseBranch(ctx context.Context, event ReleaseBranchEven
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSpecPath, artifactDestinationPath))
 		}
 
+		artifactSpec, err := s.Storage.GetArtifactSpecification(ctx, storage.ArtifactLocation{
+			Service: service,
+			Branch:  branch,
+		})
+		if err != nil {
+			return true, errors.WithMessage(err, "get artifact spec")
+		}
 		authorName := artifactSpec.Application.AuthorName
 		authorEmail := artifactSpec.Application.AuthorEmail
 		artifactID := artifactSpec.ID
@@ -230,33 +233,17 @@ func (p *ReleaseArtifactIDEvent) Unmarshal(data []byte) error {
 func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environment, service, artifactID string) (string, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.ReleaseArtifactID")
 	defer span.Finish()
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-source")
+
+	branch, err := s.Storage.GetBranch(ctx, service, artifactID)
 	if err != nil {
-		return "", err
+		return "", errors.WithMessage(err, "locate branch from artifact id")
+	}
+
+	specPath, _, closeSource, err := s.Storage.GetArtifactPathFromArtifactID(ctx, service, environment, branch, artifactID)
+	if err != nil {
+		return "", errors.WithMessage(err, "locate artifact paths")
 	}
 	defer closeSource(ctx)
-
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	// FIXME: this is a bottleneck regarding response-time. We do a git
-	// rev-parse to find the hash of the artifact. If we can eliminate this need
-	// we can skip the initial master repo clone
-	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate release '%s'", artifactID)
-	}
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		return "", errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
-
-	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
-	}
 
 	ok, err := s.CanRelease(ctx, service, branch, environment)
 	if err != nil {
@@ -266,12 +253,12 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		return "", ErrReleaseProhibited
 	}
 
-	sourceSpec, err := artifact.Get(srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName))
+	sourceSpec, err := artifact.Get(specPath)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 	}
 	logger := log.WithContext(ctx)
-	logger.Infof("flow: ReleaseArtifactID: hash '%s' id '%s'", hash, sourceSpec.ID)
+	logger.Infof("flow: ReleaseArtifactID: id '%s'", sourceSpec.ID)
 
 	// Verify environment existences
 	envPath := srcPath(sourceConfigRepoPath, service, branch, environment)
@@ -301,7 +288,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 	defer closeDestinationSource(ctx)
 	_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
 	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		return "", errors.WithMessagef(err, "clone into '%s'", destinationConfigRepoPath)
 	}
 	currentSpec, err := envSpec(destinationConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
 	if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
@@ -329,18 +316,20 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.ExecReleaseArtifactID")
 	defer span.Finish()
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
+		service := event.Service
+		branch := event.Branch
+		environment := event.Environment
+		namespace := event.Namespace
+		actor := event.Actor
+		artifactID := event.ArtifactID
+
 		logger := log.WithContext(ctx)
 
-		sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-source")
+		artifactSourcePath, sourcePath, closeSource, err := s.Storage.GetArtifactPathFromArtifactID(ctx, service, environment, branch, artifactID)
 		if err != nil {
-			return true, err
+			return true, errors.WithMessage(err, "get artifact paths")
 		}
 		defer closeSource(ctx)
-
-		sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-		if err != nil {
-			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-		}
 
 		destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
 		if err != nil {
@@ -353,24 +342,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
 		}
 
-		service := event.Service
-		branch := event.Branch
-		environment := event.Environment
-		namespace := event.Namespace
-		actor := event.Actor
-		artifactID := event.ArtifactID
-
-		hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
-		if err != nil {
-			return true, errors.WithMessagef(err, "locate release '%s'", artifactID)
-		}
-		err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-		if err != nil {
-			return true, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-		}
-
 		// release service to env from original release
-		sourcePath := srcPath(sourceConfigRepoPath, service, branch, environment)
 		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
 		logger.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
 
@@ -379,14 +351,13 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			return true, errors.WithMessagef(err, "copy resources from '%s' to '%s'", sourcePath, destinationPath)
 		}
 		// copy artifact spec
-		artifactSourcePath := srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		logger.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
 		err = copy.CopyFile(ctx, artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}
-		sourceSpec, err := artifact.Get(srcPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName))
+		sourceSpec, err := artifact.Get(artifactSourcePath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
 		}

--- a/internal/flow/rollback.go
+++ b/internal/flow/rollback.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
@@ -131,6 +130,17 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
 		logger := log.WithContext(ctx)
 
+		sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-rollback-source")
+		if err != nil {
+			return true, err
+		}
+		defer closeSource(ctx)
+
+		_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
+		if err != nil {
+			return true, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+		}
+
 		service := event.Service
 		environment := event.Environment
 		namespace := event.Namespace
@@ -138,9 +148,9 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 		actor := event.Actor
 		newHash := plumbing.NewHash(event.NewHash)
 
-		artifactSourcePath, sourcePath, closeSource, err := s.getReleasePathFromHash(ctx, newHash.String(), service, environment, namespace)
+		err = s.Git.Checkout(ctx, sourceConfigRepoPath, newHash)
 		if err != nil {
-			return true, errors.WithMessagef(err, "get source paths from hash '%s'", event.NewHash)
+			return true, errors.WithMessagef(err, "checkout previous release hash '%v'", newHash)
 		}
 		defer closeSource(ctx)
 
@@ -157,6 +167,7 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 		}
 
 		// release service to env from original release
+		sourcePath := releasePath(sourceConfigRepoPath, service, environment, namespace)
 		destinationPath := releasePath(destinationConfigRepoPath, service, environment, namespace)
 		logger.Infof("flow: ReleaseArtifactID: copy resources from %s to %s", sourcePath, destinationPath)
 
@@ -165,6 +176,7 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 			return true, errors.WithMessagef(err, "copy resources from '%s' to '%s'", sourcePath, destinationPath)
 		}
 		// copy artifact spec
+		artifactSourcePath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		artifactDestinationPath := path.Join(releasePath(destinationConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
 		logger.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
 		err = copy.CopyFile(ctx, artifactSourcePath, artifactDestinationPath)
@@ -172,7 +184,7 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}
 
-		newSpec, err := artifact.Get(artifactSourcePath)
+		newSpec, err := envSpec(sourceConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
 		if err != nil {
 			return true, errors.WithMessagef(err, "get spec of previous release hash '%v'", newHash)
 		}
@@ -205,35 +217,4 @@ func (s *Service) ExecRollback(ctx context.Context, event RollbackEvent) error {
 		return err
 	}
 	return nil
-}
-
-func (s *Service) getReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, func(context.Context), error) {
-	logger := log.WithContext(ctx)
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-rollback-source")
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
-	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	hash := plumbing.NewHash(hashStr)
-	logger.Debugf("internal/flow: getReleasePathFromHash: release hash '%v'", hash)
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
-
-	resourcesPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
-	specPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	logger.Infof("internal/flow: getReleasePathFromHash: found resources from '%s' and specification at '%s'", resourcesPath, specPath)
-	return specPath, resourcesPath, func(ctx context.Context) {
-		closeSource(ctx)
-	}, nil
 }

--- a/internal/flow/storage/storage.go
+++ b/internal/flow/storage/storage.go
@@ -12,34 +12,24 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-type ReleaseLocation struct {
-	Environment string
-	Namespace   string
-	Service     string
-}
-
 type ArtifactLocation struct {
 	Branch  string
 	Service string
 }
 
 type Storage interface {
-	GetReleaseSpecification(context.Context, ReleaseLocation) (artifact.Spec, error)
 	GetArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
 	GetArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
 	GetBranch(ctx context.Context, service, artifactID string) (string, error)
 
-	GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
-	GetArtifactPath(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close CloseFunc, err error)
+	GetArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
+	GetLatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close CloseFunc, err error)
 
 	// the methods below are defined by the Git implementation and events between
 	// sync and async flow using Git SHA to indicate the releases instead of the
 	// release IDs. We could remove these by removing the passing of storage
 	// details in the events.
-	GetArtifactPathFromHash(ctx context.Context, hash, service, environment string) (specPath, resourcesPath string, close CloseFunc, err error)
-	GetReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, CloseFunc, error)
 	GetHashForArtifact(ctx context.Context, artifactID string) (plumbing.Hash, error)
-	GetHashForRelease(ctx context.Context, artifactID string) (plumbing.Hash, error)
 }
 
 type CloseFunc func(context.Context)
@@ -61,7 +51,7 @@ func NewGit(artifactFileName string, gitService *git.Service, tracer tracing.Tra
 }
 
 func (s *Git) GetBranch(ctx context.Context, service, artifactID string) (string, error) {
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-source")
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-get-branch")
 	if err != nil {
 		return "", err
 	}
@@ -77,11 +67,11 @@ func (s *Git) GetBranch(ctx context.Context, service, artifactID string) (string
 	// we can skip the initial master repo clone
 	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
 	if err != nil {
-		return "", errors.WithMessagef(err, "locate release '%s'", artifactID)
+		return "", errors.WithMessagef(err, "locate artifact '%s'", artifactID)
 	}
 	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
 	if err != nil {
-		return "", errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		return "", errors.WithMessagef(err, "checkout artifact hash '%s'", hash)
 	}
 
 	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
@@ -111,7 +101,7 @@ func (s *Git) GetHashForArtifact(ctx context.Context, artifactID string) (plumbi
 	return hash, nil
 }
 
-func (s *Git) GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (string, string, CloseFunc, error) {
+func (s *Git) GetArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (string, string, CloseFunc, error) {
 	logger := log.WithContext(ctx)
 	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
 	if err != nil {
@@ -134,37 +124,18 @@ func (s *Git) GetArtifactPathFromArtifactID(ctx context.Context, service, enviro
 	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
 	if err != nil {
 		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		return "", "", nil, errors.WithMessagef(err, "checkout artifact hash '%s'", hash)
 	}
 
 	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
 	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
-	logger.Infof("storage/GetArtifactPathFromArtifactID found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	logger.Infof("storage/GetArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
 	return specPath, resourcesPath, func(ctx context.Context) {
 		closeSource(ctx)
 	}, nil
 }
 
-func (s *Git) GetHashForRelease(ctx context.Context, artifactID string) (plumbing.Hash, error) {
-	logger := log.WithContext(ctx)
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-	defer closeSource(ctx)
-	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return plumbing.ZeroHash, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-	hash, err := s.Git.LocateRelease(ctx, sourceRepo, artifactID)
-	if err != nil {
-		return plumbing.ZeroHash, errors.WithMessage(err, "locate artifact")
-	}
-	return hash, nil
-}
-
-func (s *Git) GetArtifactPath(ctx context.Context, service, environment, branch string) (string, string, CloseFunc, error) {
+func (s *Git) GetLatestArtifactPaths(ctx context.Context, service, environment, branch string) (string, string, CloseFunc, error) {
 	logger := log.WithContext(ctx)
 	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-branch")
 	if err != nil {
@@ -177,85 +148,16 @@ func (s *Git) GetArtifactPath(ctx context.Context, service, environment, branch 
 	}
 	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
 	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
-	logger.Infof("storage/GetArtifactPath found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	logger.Infof("storage/GetLatestArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
 	return specPath, resourcesPath, func(ctx context.Context) {
 		close(ctx)
 	}, nil
-}
-
-func (s *Git) GetArtifactPathFromHash(ctx context.Context, hashStr, service, environment string) (string, string, CloseFunc, error) {
-	logger := log.WithContext(ctx)
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
-	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	hash := plumbing.NewHash(hashStr)
-	logger.Debugf("internal/flow: Promote: release hash '%v'", hash)
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
-
-	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, "master", environment)
-	specPath := artifactResourcesPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
-	logger.Infof("storage/GetArtifactPathFromHash found resources from '%s' and specification at '%s'", resourcesPath, specPath)
-	return specPath, resourcesPath, func(ctx context.Context) {
-		closeSource(ctx)
-	}, nil
-}
-
-func (s *Git) GetReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, CloseFunc, error) {
-	logger := log.WithContext(ctx)
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
-	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
-	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	hash := plumbing.NewHash(hashStr)
-	logger.Debugf("internal/flow: Promote: release hash '%v'", hash)
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		closeSource(ctx)
-		return "", "", nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
-	}
-
-	resourcesPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
-	specPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
-	logger.Infof("storage/GetArtifactPathFromHash found resources from '%s' and specification at '%s'", resourcesPath, specPath)
-	return specPath, resourcesPath, func(ctx context.Context) {
-		closeSource(ctx)
-	}, nil
-}
-
-func (s *Git) GetReleaseSpecification(ctx context.Context, location ReleaseLocation) (artifact.Spec, error) {
-	return artifact.Get(path.Join(releasePath(s.Git.MasterPath(), location.Service, location.Environment, location.Namespace), s.ArtifactFileName))
 }
 
 func (s *Git) GetArtifactSpecification(ctx context.Context, location ArtifactLocation) (artifact.Spec, error) {
 	return artifact.Get(path.Join(artifactSpecPath(s.Git.MasterPath(), location.Service, location.Branch), s.ArtifactFileName))
 }
 
-func releasePath(root, service, env, namespace string) string {
-	return path.Join(root, env, "releases", namespace, service)
-}
 func artifactSpecPath(root, service, branch string) string {
 	return path.Join(root, "artifacts", service, branch)
 }

--- a/internal/flow/storage/storage.go
+++ b/internal/flow/storage/storage.go
@@ -26,7 +26,7 @@ type ArtifactLocation struct {
 type Storage interface {
 	GetReleaseSpecification(context.Context, ReleaseLocation) (artifact.Spec, error)
 	GetArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
-	GetArtifacts(ctx context.Context, service string, count int) ([]artifact.Spec, error)
+	GetArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
 	GetBranch(ctx context.Context, service, artifactID string) (string, error)
 
 	GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
@@ -263,7 +263,7 @@ func artifactResourcesPath(root, service, branch, env string) string {
 	return path.Join(artifactSpecPath(root, service, branch), env)
 }
 
-func (s *Git) GetArtifacts(ctx context.Context, service string, count int) ([]artifact.Spec, error) {
+func (s *Git) GetArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error) {
 	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
 	if err != nil {
 		return nil, err

--- a/internal/flow/storage/storage.go
+++ b/internal/flow/storage/storage.go
@@ -1,0 +1,301 @@
+package storage
+
+import (
+	"context"
+	"path"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/tracing"
+	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+type ReleaseLocation struct {
+	Environment string
+	Namespace   string
+	Service     string
+}
+
+type ArtifactLocation struct {
+	Branch  string
+	Service string
+}
+
+type Storage interface {
+	GetReleaseSpecification(context.Context, ReleaseLocation) (artifact.Spec, error)
+	GetArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
+	GetArtifacts(ctx context.Context, service string, count int) ([]artifact.Spec, error)
+
+	GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close func(context.Context) error, err error)
+	GetArtifactPath(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close func(context.Context) error, err error)
+	GetArtifactPathFromHash(ctx context.Context, hash, service, environment string) (specPath, resourcesPath string, close func(context.Context) error, err error)
+	GetReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, func(context.Context) error, error)
+
+	GetHashForArtifact(ctx context.Context, artifactID string) (plumbing.Hash, error)
+	GetHashForRelease(ctx context.Context, artifactID string) (plumbing.Hash, error)
+
+	GetBranch(ctx context.Context, service, artifactID string) (string, error)
+}
+
+type Git struct {
+	ArtifactFileName string
+	Git              *git.Service
+	Tracer           tracing.Tracer
+}
+
+var _ Storage = &Git{}
+
+func NewGit(artifactFileName string, gitService *git.Service, tracer tracing.Tracer) *Git {
+	return &Git{
+		ArtifactFileName: artifactFileName,
+		Git:              gitService,
+		Tracer:           tracer,
+	}
+}
+
+func (s *Git) GetBranch(ctx context.Context, service, artifactID string) (string, error) {
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-source")
+	if err != nil {
+		return "", err
+	}
+	defer closeSource(ctx)
+
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	// FIXME: this is a bottleneck regarding response-time. We do a git
+	// rev-parse to find the hash of the artifact. If we can eliminate this need
+	// we can skip the initial master repo clone
+	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
+	if err != nil {
+		return "", errors.WithMessagef(err, "locate release '%s'", artifactID)
+	}
+	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+	if err != nil {
+		return "", errors.WithMessagef(err, "checkout release hash '%s'", hash)
+	}
+
+	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+	if err != nil {
+		return "", errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
+	}
+	return branch, nil
+}
+
+func (s *Git) GetHashForArtifact(ctx context.Context, artifactID string) (plumbing.Hash, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	defer closeSource(ctx)
+
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return plumbing.ZeroHash, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
+	if err != nil {
+		return plumbing.ZeroHash, errors.WithMessage(err, "locate artifact")
+	}
+	return hash, nil
+}
+
+func (s *Git) GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (string, string, func(context.Context) error, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	if err != nil {
+		return "", "", func(context.Context) error { return nil }, errors.WithMessage(err, "get temp dir")
+	}
+
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessage(err, "locate artifact")
+	}
+
+	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+	}
+
+	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
+	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
+	logger.Infof("storage/GetArtifactPathFromArtifactID found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	return specPath, resourcesPath, func(ctx context.Context) error {
+		closeSource(ctx)
+		return nil
+	}, nil
+}
+
+func (s *Git) GetHashForRelease(ctx context.Context, artifactID string) (plumbing.Hash, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	defer closeSource(ctx)
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return plumbing.ZeroHash, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+	hash, err := s.Git.LocateRelease(ctx, sourceRepo, artifactID)
+	if err != nil {
+		return plumbing.ZeroHash, errors.WithMessage(err, "locate artifact")
+	}
+	return hash, nil
+}
+
+func (s *Git) GetArtifactPath(ctx context.Context, service, environment, branch string) (string, string, func(context.Context) error, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-branch")
+	if err != nil {
+		return "", "", func(context.Context) error { return nil }, err
+	}
+	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		close(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
+	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
+	logger.Infof("storage/GetArtifactPath found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	return specPath, resourcesPath, func(ctx context.Context) error {
+		close(ctx)
+		return nil
+	}, nil
+}
+
+func (s *Git) GetArtifactPathFromHash(ctx context.Context, hashStr, service, environment string) (string, string, func(context.Context) error, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	if err != nil {
+		return "", "", func(context.Context) error { return nil }, err
+	}
+
+	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	hash := plumbing.NewHash(hashStr)
+	logger.Debugf("internal/flow: Promote: release hash '%v'", hash)
+	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+	}
+
+	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, "master", environment)
+	specPath := artifactResourcesPath(sourceConfigRepoPath, service, "master", s.ArtifactFileName)
+	logger.Infof("storage/GetArtifactPathFromHash found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	return specPath, resourcesPath, func(ctx context.Context) error {
+		closeSource(ctx)
+		return nil
+	}, nil
+}
+
+func (s *Git) GetReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, func(context.Context) error, error) {
+	logger := log.WithContext(ctx)
+	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
+	if err != nil {
+		return "", "", func(context.Context) error { return nil }, err
+	}
+
+	// find current released artifact.json for service in env - 1 (dev for staging, staging for prod)
+	logger.Debugf("Cloning source config repo %s into %s", s.Git.ConfigRepoURL, sourceConfigRepoPath)
+	_, err = s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	hash := plumbing.NewHash(hashStr)
+	logger.Debugf("internal/flow: Promote: release hash '%v'", hash)
+	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+	if err != nil {
+		closeSource(ctx)
+		return "", "", func(context.Context) error { return nil }, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+	}
+
+	resourcesPath := releasePath(sourceConfigRepoPath, service, environment, namespace)
+	specPath := path.Join(releasePath(sourceConfigRepoPath, service, environment, namespace), s.ArtifactFileName)
+	logger.Infof("storage/GetArtifactPathFromHash found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	return specPath, resourcesPath, func(ctx context.Context) error {
+		closeSource(ctx)
+		return nil
+	}, nil
+}
+
+func (s *Git) GetReleaseSpecification(ctx context.Context, location ReleaseLocation) (artifact.Spec, error) {
+	return artifact.Get(path.Join(releasePath(s.Git.MasterPath(), location.Service, location.Environment, location.Namespace), s.ArtifactFileName))
+}
+
+func (s *Git) GetArtifactSpecification(ctx context.Context, location ArtifactLocation) (artifact.Spec, error) {
+	return artifact.Get(path.Join(artifactSpecPath(s.Git.MasterPath(), location.Service, location.Branch), s.ArtifactFileName))
+}
+
+func releasePath(root, service, env, namespace string) string {
+	return path.Join(root, env, "releases", namespace, service)
+}
+func artifactSpecPath(root, service, branch string) string {
+	return path.Join(root, "artifacts", service, branch)
+}
+func artifactResourcesPath(root, service, branch, env string) string {
+	return path.Join(artifactSpecPath(root, service, branch), env)
+}
+
+func (s *Git) GetArtifacts(ctx context.Context, service string, count int) ([]artifact.Spec, error) {
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
+	if err != nil {
+		return nil, err
+	}
+	defer close(ctx)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+
+	hashes, err := s.Git.LocateArtifacts(ctx, sourceRepo, service, count)
+	if err != nil {
+		return nil, errors.WithMessage(err, "locate artifacts")
+	}
+	logger := log.WithContext(ctx)
+	var artifacts []artifact.Spec
+	logger.Debugf("flow/describe: hashes %+v", hashes)
+	for _, hash := range hashes {
+		err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "checkout release hash '%s'", hash)
+		}
+		branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+		if err != nil {
+			logger.Errorf("flow/describe: get branch from head failed at hash '%s': skipping hash: %v", hash, err)
+			continue
+		}
+		artifactPath := path.Join(artifactSpecPath(sourceConfigRepoPath, service, branch), s.ArtifactFileName)
+		spec, err := artifact.Get(artifactPath)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "get artifact at path '%s' at hash '%s'", artifactPath, hash)
+		}
+		artifacts = append(artifacts, spec)
+	}
+	return artifacts, nil
+}

--- a/internal/flow/storage/storage.go
+++ b/internal/flow/storage/storage.go
@@ -27,16 +27,19 @@ type Storage interface {
 	GetReleaseSpecification(context.Context, ReleaseLocation) (artifact.Spec, error)
 	GetArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
 	GetArtifacts(ctx context.Context, service string, count int) ([]artifact.Spec, error)
+	GetBranch(ctx context.Context, service, artifactID string) (string, error)
 
 	GetArtifactPathFromArtifactID(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
 	GetArtifactPath(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close CloseFunc, err error)
+
+	// the methods below are defined by the Git implementation and events between
+	// sync and async flow using Git SHA to indicate the releases instead of the
+	// release IDs. We could remove these by removing the passing of storage
+	// details in the events.
 	GetArtifactPathFromHash(ctx context.Context, hash, service, environment string) (specPath, resourcesPath string, close CloseFunc, err error)
 	GetReleasePathFromHash(ctx context.Context, hashStr, service, environment, namespace string) (string, string, CloseFunc, error)
-
 	GetHashForArtifact(ctx context.Context, artifactID string) (plumbing.Hash, error)
 	GetHashForRelease(ctx context.Context, artifactID string) (plumbing.Hash, error)
-
-	GetBranch(ctx context.Context, service, artifactID string) (string, error)
 }
 
 type CloseFunc func(context.Context)

--- a/internal/flow/storage/storage.go
+++ b/internal/flow/storage/storage.go
@@ -18,12 +18,14 @@ type ArtifactLocation struct {
 
 type Storage interface {
 	ArtifactExists(ctx context.Context, artifactID string) (bool, error)
-	GetLatestArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
-	GetArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
-	GetBranch(ctx context.Context, service, artifactID string) (string, error)
 
-	GetArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
-	GetLatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close CloseFunc, err error)
+	ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error)
+	ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close CloseFunc, err error)
+
+	LatestArtifactSpecification(context.Context, ArtifactLocation) (artifact.Spec, error)
+	LatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close CloseFunc, err error)
+
+	ArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
 }
 
 type CloseFunc func(context.Context)
@@ -44,38 +46,7 @@ func NewGit(artifactFileName string, gitService *git.Service, tracer tracing.Tra
 	}
 }
 
-func (s *Git) GetBranch(ctx context.Context, service, artifactID string) (string, error) {
-	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-get-branch")
-	if err != nil {
-		return "", err
-	}
-	defer closeSource(ctx)
-
-	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
-	}
-
-	// FIXME: this is a bottleneck regarding response-time. We do a git
-	// rev-parse to find the hash of the artifact. If we can eliminate this need
-	// we can skip the initial master repo clone
-	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate artifact '%s'", artifactID)
-	}
-	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
-	if err != nil {
-		return "", errors.WithMessagef(err, "checkout artifact hash '%s'", hash)
-	}
-
-	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
-	if err != nil {
-		return "", errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
-	}
-	return branch, nil
-}
-
-func (s *Git) GetArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (string, string, CloseFunc, error) {
+func (s *Git) ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (string, string, CloseFunc, error) {
 	logger := log.WithContext(ctx)
 	sourceConfigRepoPath, closeSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-promote-source")
 	if err != nil {
@@ -103,13 +74,13 @@ func (s *Git) GetArtifactPaths(ctx context.Context, service, environment, branch
 
 	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
 	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
-	logger.Infof("storage/GetArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	logger.Infof("storage/ArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
 	return specPath, resourcesPath, func(ctx context.Context) {
 		closeSource(ctx)
 	}, nil
 }
 
-func (s *Git) GetLatestArtifactPaths(ctx context.Context, service, environment, branch string) (string, string, CloseFunc, error) {
+func (s *Git) LatestArtifactPaths(ctx context.Context, service, environment, branch string) (string, string, CloseFunc, error) {
 	logger := log.WithContext(ctx)
 	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-branch")
 	if err != nil {
@@ -122,13 +93,13 @@ func (s *Git) GetLatestArtifactPaths(ctx context.Context, service, environment, 
 	}
 	resourcesPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, environment)
 	specPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
-	logger.Infof("storage/GetLatestArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
+	logger.Infof("storage/LatestArtifactPaths found resources from '%s' and specification at '%s'", resourcesPath, specPath)
 	return specPath, resourcesPath, func(ctx context.Context) {
 		close(ctx)
 	}, nil
 }
 
-func (s *Git) GetLatestArtifactSpecification(ctx context.Context, location ArtifactLocation) (artifact.Spec, error) {
+func (s *Git) LatestArtifactSpecification(ctx context.Context, location ArtifactLocation) (artifact.Spec, error) {
 	return artifact.Get(path.Join(artifactSpecPath(s.Git.MasterPath(), location.Service, location.Branch), s.ArtifactFileName))
 }
 
@@ -139,7 +110,40 @@ func artifactResourcesPath(root, service, branch, env string) string {
 	return path.Join(artifactSpecPath(root, service, branch), env)
 }
 
-func (s *Git) GetArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error) {
+func (s *Git) ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error) {
+	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
+	if err != nil {
+		return artifact.Spec{}, err
+	}
+	defer close(ctx)
+	sourceRepo, err := s.Git.Clone(ctx, sourceConfigRepoPath)
+	if err != nil {
+		return artifact.Spec{}, errors.WithMessagef(err, "clone into '%s'", sourceConfigRepoPath)
+	}
+	hash, err := s.Git.LocateArtifact(ctx, sourceRepo, artifactID)
+	if err != nil {
+		return artifact.Spec{}, errors.WithMessage(err, "locate artifact")
+	}
+	err = s.Git.Checkout(ctx, sourceConfigRepoPath, hash)
+	if err != nil {
+		return artifact.Spec{}, errors.WithMessagef(err, "checkout hash '%s'", hash)
+	}
+
+	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+	if err != nil {
+		return artifact.Spec{}, errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
+	}
+
+	artifactPath := artifactResourcesPath(sourceConfigRepoPath, service, branch, s.ArtifactFileName)
+	spec, err := artifact.Get(artifactPath)
+	if err != nil {
+		return artifact.Spec{}, errors.WithMessagef(err, "read specification from '%s'", artifactPath)
+	}
+	log.WithContext(ctx).WithFields("spec", spec).Debugf("Found specifications for service '%s'", service)
+	return spec, nil
+}
+
+func (s *Git) ArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error) {
 	sourceConfigRepoPath, close, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-describe-artifact")
 	if err != nil {
 		return nil, err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -43,6 +43,7 @@ type Service struct {
 	SSHPrivateKeyPath string
 	ConfigRepoURL     string
 	Config            *GitConfig
+	ArtifactFileName  string
 
 	masterPath  string
 	masterMutex sync.RWMutex

--- a/internal/git/storage.go
+++ b/internal/git/storage.go
@@ -5,12 +5,9 @@ import (
 	"path"
 
 	"github.com/lunarway/release-manager/internal/artifact"
-	"github.com/lunarway/release-manager/internal/flow"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
 )
-
-var _ flow.Storage = &Service{}
 
 func (s *Service) ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (string, string, func(context.Context), error) {
 	logger := log.WithContext(ctx)
@@ -95,7 +92,7 @@ func (s *Service) ArtifactSpecification(ctx context.Context, service, artifactID
 		return artifact.Spec{}, errors.WithMessagef(err, "checkout hash '%s'", hash)
 	}
 
-	branch, err := git.BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
+	branch, err := BranchFromHead(ctx, sourceRepo, s.ArtifactFileName, service)
 	if err != nil {
 		return artifact.Spec{}, errors.WithMessagef(err, "locate branch from commit hash '%s'", hash)
 	}


### PR DESCRIPTION
This got a bit out of hand, but there are no functional changes except a subtle
bug fix. :) 

It is a change to package `flow` to extract the artifact storage layer into an
interface. The storage is still Git for now, but the interface is not
implemented by package `git` instead. This will eventually be replaced with AWS
S3 blob storage and with the new `flow.Storage` interface it is clear what a
storage layer needs to provide.

This will also make it simpler to implement in-memory storages for testing the
flows without touching external mechanisms.

The heart of the change is as mentioned the `flow.Storage` interface.

```go
type Storage interface {
	ArtifactExists(ctx context.Context, artifactID string) (bool, error)

	ArtifactSpecification(ctx context.Context, service, artifactID string) (artifact.Spec, error)
	ArtifactPaths(ctx context.Context, service, environment, branch, artifactID string) (specPath, resourcesPath string, close func(context.Context), err error)

	LatestArtifactSpecification(ctx context.Context, service, branch string) (artifact.Spec, error)
	LatestArtifactPaths(ctx context.Context, service, environment, branch string) (specPath, resourcesPath string, close func(context.Context), err error)

	ArtifactSpecifications(ctx context.Context, service string, count int) ([]artifact.Spec, error)
}
```

It allows the `flow` package to check for the existence of artifacts along with
fetching specifications for a specific artifact of a `n` artifacts.

The `ArtifactPaths` and `LatestArtifactPaths` methods are the methods providing
access to the actual resources of an artifact. Currently these are paths to the
file system, but I think we should come up with something better later on. Maybe
it will become clear with the S3 storage implementation what makes sense.

### Bug fix in promote commit messages

During the change I found a bug in the commit messages of promote operations.
The are currently resulting in the commit message `[env/service] release by
bso@lunar.app`. Note the missing artifact ID. This was introduced in
b1c9fe82f11e11cd2abb1e084ead74dc2f0a8e9c (#140).