### PR TITLE
Validate environment in synchronous step of release flows

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -699,6 +699,10 @@ func release(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 					Error(w, fmt.Sprintf("artifact '%s' not found for service '%s'", req.ArtifactID, req.Service), http.StatusBadRequest)
 				}
 				return
+			case flow.ErrUnknownEnvironment:
+				logger.Infof("http: release: service '%s' environment '%s': release rejected: %v", req.Service, req.Environment, err)
+				Error(w, fmt.Sprintf("unknown environment: %s", req.Environment), http.StatusBadRequest)
+				return
 			case flow.ErrUnknownConfiguration:
 				logger.Infof("http: release: service '%s' environment '%s' branch '%s' artifact id '%s': release rejected: source configuration not found: %v", req.Service, req.Environment, req.Branch, req.ArtifactID, err)
 				Error(w, fmt.Sprintf("configuration for environment '%s' not found for service '%s'. Is the environment specified in 'shuttle.yaml'?", req.Environment, req.Service), http.StatusBadRequest)

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -29,7 +29,6 @@ var (
 type Service struct {
 	ArtifactFileName string
 	UserMappings     map[string]string
-	Environments     []string
 	Slack            *slack.Client
 	Git              *git.Service
 	Tracer           tracing.Tracer

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -29,6 +29,7 @@ var (
 type Service struct {
 	ArtifactFileName string
 	UserMappings     map[string]string
+	Environments     []string
 	Slack            *slack.Client
 	Git              *git.Service
 	Tracer           tracing.Tracer


### PR DESCRIPTION
This fixes a bug where events are not being consumed because of an error with the environment. 

This PR adds validation upfront, to ensure we can process the event - and further informs the caller of an error in the given environment flag.