### PR TITLE
S3 artifact MD5 signing

### DIFF
--- a/cmd/server/http/create_artifact.go
+++ b/cmd/server/http/create_artifact.go
@@ -21,7 +21,8 @@ func createArtifact(payload *payload, artifactWriteStorage ArtifactWriteStorage)
 			return
 		}
 
-		uploadURL, err := artifactWriteStorage.CreateArtifact(req.Artifact)
+		logger.Infof("http: artifact: creating artiact for '%s' hash '%x'", req.Artifact.ID, req.MD5)
+		uploadURL, err := artifactWriteStorage.CreateArtifact(req.Artifact, req.MD5)
 		if err != nil {
 			logger.Errorf("http: artifact: create: storage failed failed creating artifact: %v", err)
 			unknownError(w)
@@ -41,5 +42,5 @@ func createArtifact(payload *payload, artifactWriteStorage ArtifactWriteStorage)
 
 type ArtifactWriteStorage interface {
 	// CreateArtifact creates the artifact in the storage and returns an URL for uploading the artifact zipped
-	CreateArtifact(artifactSpec artifact.Spec) (string, error)
+	CreateArtifact(artifactSpec artifact.Spec, md5 string) (string, error)
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -4,6 +4,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -303,20 +305,6 @@ func PushArtifactToReleaseManager(ctx context.Context, releaseManagerClient *htt
 		return "", errors.WithMessagef(err, "path '%s'", artifactSpecPath)
 	}
 
-	path, err := releaseManagerClient.URL(fmt.Sprintf("artifacts/create"))
-	if err != nil {
-		return "", errors.WithMessage(err, "push artifact URL generation failed")
-	}
-
-	resp := httpinternal.ArtifactUploadResponse{}
-	err = releaseManagerClient.Do(http.MethodPost, path, httpinternal.ArtifactUploadRequest{
-		Artifact: artifactSpec,
-	}, &resp)
-	if err != nil {
-		return "", errors.WithMessage(err, "create artifact request failed")
-	}
-	log.WithFields("artifactID", artifactSpec.ID, "uploadURL", resp.ArtifactUploadURL).Infof("artifact upload URL created for %s", artifactSpec.ID)
-
 	files := listFiles(resourceRoot)
 
 	zipContent, err := zipFiles(files)
@@ -325,7 +313,31 @@ func PushArtifactToReleaseManager(ctx context.Context, releaseManagerClient *htt
 	}
 	log.WithFields("artifactID", artifactSpec.ID, "artifactFiles", files).Infof("artifact zip created for %s", artifactSpec.ID)
 
-	err = uploadFile(resp.ArtifactUploadURL, zipContent, artifactSpec)
+	zipMD5 := md5.New()
+	_, err = zipMD5.Write(zipContent)
+	if err != nil {
+		return "", errors.Wrap(err, "calculate md5 hash")
+	}
+	zipMD5s := base64.StdEncoding.EncodeToString(zipMD5.Sum(nil))
+
+	log.WithFields("artifactID", artifactSpec.ID, "artifactFiles", files).Infof("calculated zip md5: %x", zipMD5s)
+
+	path, err := releaseManagerClient.URL(fmt.Sprintf("artifacts/create"))
+	if err != nil {
+		return "", errors.WithMessage(err, "push artifact URL generation failed")
+	}
+
+	resp := httpinternal.ArtifactUploadResponse{}
+	err = releaseManagerClient.Do(http.MethodPost, path, httpinternal.ArtifactUploadRequest{
+		Artifact: artifactSpec,
+		MD5:      zipMD5s,
+	}, &resp)
+	if err != nil {
+		return "", errors.WithMessage(err, "create artifact request failed")
+	}
+	log.WithFields("artifactID", artifactSpec.ID, "uploadURL", resp.ArtifactUploadURL).Infof("artifact upload URL created for %s", artifactSpec.ID)
+
+	err = uploadFile(resp.ArtifactUploadURL, zipContent, artifactSpec, string(zipMD5s))
 	if err != nil {
 		return "", errors.WithMessage(err, "upload artifact failed")
 	}
@@ -445,7 +457,7 @@ func zipFiles(files []fileInfo) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func uploadFile(url string, fileContent []byte, artifactSpec artifact.Spec) error {
+func uploadFile(url string, fileContent []byte, artifactSpec artifact.Spec, md5 string) error {
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(fileContent))
 	if err != nil {
 		return err
@@ -457,10 +469,7 @@ func uploadFile(url string, fileContent []byte, artifactSpec artifact.Spec) erro
 	}
 	req.Header.Set("x-amz-meta-artifact-spec", jsonSpec)
 
-	// TODO: MD5
-	//h := md5.New()
-	//md5s := base64.StdEncoding.EncodeToString(h.Sum(nil))
-	//req.Header.Set("Content-MD5", md5s)
+	req.Header.Set("Content-MD5", md5)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -206,6 +206,7 @@ type DescribeArtifactResponse struct {
 
 type ArtifactUploadRequest struct {
 	Artifact artifact.Spec `json:"artifact,omitempty"`
+	MD5      string        `json:"md5,omitempty"`
 }
 
 type ArtifactUploadResponse struct {

--- a/internal/s3storage/s3storage.go
+++ b/internal/s3storage/s3storage.go
@@ -50,7 +50,7 @@ func (s *Service) InitializeBucket() error {
 	return nil
 }
 
-func (s *Service) CreateArtifact(artifactSpec artifact.Spec) (string, error) {
+func (s *Service) CreateArtifact(artifactSpec artifact.Spec, md5 string) (string, error) {
 	jsonSpec, err := artifact.Encode(artifactSpec, false)
 	if err != nil {
 		return "", err
@@ -63,10 +63,7 @@ func (s *Service) CreateArtifact(artifactSpec artifact.Spec) (string, error) {
 			"artifact-spec": aws.String(jsonSpec),
 		},
 	})
-	// TODO: Add MD5 content hashing
-	// h := md5.New()
-	// md5s := base64.StdEncoding.EncodeToString(h.Sum(nil))
-	// req.HTTPRequest.Header.Set("Content-MD5", md5s)
+	req.HTTPRequest.Header.Set("Content-MD5", md5)
 
 	uploadURL, err := req.Presign(15 * time.Minute)
 	if err != nil {


### PR DESCRIPTION
This PR contains the addition of artifact signing. The artifact CLI calculates an MD5 checksum of the zip and pushes that to the server when creating the artifact.
This enables S3 validation of the upload to ensure that the object has not been tampered with in flight.