### PR TITLE
S3 subscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ RABBITMQ_INTEGRATION_HOST_CONTAINER=rm-rabbitmq
 
 rabbitmq-background:
 	@echo "Starting RabbitMQ in background"
-	-docker run --rm --hostname rabbitmq -p 5672:5672 -p 15672:15672 -e RABBITMQ_DEFAULT_USER=lunar -e RABBITMQ_DEFAULT_PASS=lunar --name ${RABBITMQ_INTEGRATION_HOST_CONTAINER} -d rabbitmq:3-management
+	-docker start ${RABBITMQ_INTEGRATION_HOST_CONTAINER} 2>/dev/null || docker run --rm --hostname rabbitmq -p 5672:5672 -p 15672:15672 -e RABBITMQ_DEFAULT_USER=lunar -e RABBITMQ_DEFAULT_PASS=lunar --name ${RABBITMQ_INTEGRATION_HOST_CONTAINER} -d rabbitmq:3-management
 
 rabbitmq-background-stop:
 	@echo "Stopping RabbitMQ in background"

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -30,6 +30,7 @@ func NewCommand() (*cobra.Command, error) {
 	var branchRestrictions []policy.BranchRestriction
 	var logConfiguration *log.Configuration
 	var slackMuteOpts slack.MuteOptions
+	var s3storageOpts s3storageOptions
 
 	var command = &cobra.Command{
 		Use:   "server",
@@ -63,6 +64,7 @@ func NewCommand() (*cobra.Command, error) {
 		githubAPIToken:            &githubAPIToken,
 		configRepo:                &configRepoOpts,
 		gitConfigOpts:             &gitConfigOpts,
+		s3storage:                 &s3storageOpts,
 		http:                      &httpOpts,
 		gpgKeyPaths:               &gpgKeyPaths,
 		broker:                    &brokerOpts,
@@ -94,6 +96,7 @@ func NewCommand() (*cobra.Command, error) {
 	registerBrokerFlags(command, &brokerOpts)
 	registerSlackNotificationFlags(command, &slackMuteOpts)
 	registerGitFlags(command, &gitConfigOpts)
+	registerS3Flags(command, &s3storageOpts)
 	logConfiguration = log.RegisterFlags(command)
 
 	return command, nil
@@ -129,6 +132,10 @@ func registerGitFlags(cmd *cobra.Command, opts *git.GitConfig) {
 	cmd.PersistentFlags().StringVar(&opts.User, "git-user", "HamAstrochimp", "the user that all commits will be committed with.")
 	cmd.PersistentFlags().StringVar(&opts.Email, "git-email", "operations@lunar.app", "the email that all commits will be committed with.")
 	cmd.PersistentFlags().StringVar(&opts.SigningKey, "git-signing-key", "", "the signingkey which all commits will be signed with. The path to the key has to be provided.")
+}
+
+func registerS3Flags(cmd *cobra.Command, opts *s3storageOptions) {
+	cmd.PersistentFlags().StringVar(&opts.S3BucketName, "s3-artifact-storage-bucket-name", "", "the S3 bucket to store artifacts in.")
 }
 
 // parseBranchRestrictions pases a slice of key-value pairs formatted as

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -353,7 +353,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				done <- errors.WithMessage(err, "broker")
 			}()
 
-			sqsHandler := func() error {
+			sqsHandler := func(msg string) error {
 				return nil
 			}
 

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -413,7 +413,6 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					err := s3storageSvc.Close()
 					if err != nil {
 						log.Errorf("Failed to close s3 storage: %v", err)
-						done <- errors.WithMessage(err, "s3 storage")
 					}
 				}()
 			}

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -383,7 +383,10 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			if s3storageSvc != nil {
 				sqsHandler := func(msg string) error {
 					var s3event s3storage.S3Event
-					s3event.Unmarshal([]byte(msg))
+					err := s3event.Unmarshal([]byte(msg))
+					if err != nil {
+						return errors.WithMessage(err, "unmarshal S3Event")
+					}
 
 					if len(s3event.Records) == 0 {
 						log.With("sqsMessage", msg).Infof("Skipping SQS message because it does not look like S3 notification")

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -203,6 +203,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Git:              &gitSvc,
 				CanRelease:       policySvc.CanRelease,
 				Storage:          storage,
+				Policy:           &policySvc,
 				Tracer:           tracer,
 				// TODO: figure out a better way of splitting the consumer and publisher
 				// to avoid this chicken and egg issue. It is not a real problem as the
@@ -212,6 +213,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				PublishReleaseArtifactID: nil,
 				PublishReleaseBranch:     nil,
 				PublishRollback:          nil,
+				PublishNewArtifact:       nil,
 				// retries for comitting changes into config repo
 				// can be required for racing writes
 				MaxRetries: 3,
@@ -316,6 +318,14 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 						return errors.WithMessage(err, "unmarshal event")
 					}
 					return flowSvc.ExecRollback(context.Background(), event)
+				},
+				flow.NewArtifactEvent{}.Type(): func(d []byte) error {
+					var event flow.NewArtifactEvent
+					err := event.Unmarshal(d)
+					if err != nil {
+						return errors.WithMessage(err, "unmarshal event")
+					}
+					return flowSvc.ExecNewArtifact(context.Background(), event)
 				},
 			}
 

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -164,6 +164,10 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			err = s3storageSvc.InitializeSQS()
+			if err != nil {
+				return err
+			}
 			err = s3storageSvc.InitializeBucket()
 			if err != nil {
 				return err

--- a/cmd/server/http/create_artifact.go
+++ b/cmd/server/http/create_artifact.go
@@ -25,7 +25,7 @@ func createArtifact(payload *payload, artifactWriteStorage ArtifactWriteStorage)
 			return
 		}
 
-		logger.Infof("http: artifact: creating artiact for '%s' hash '%x'", req.Artifact.ID, req.MD5)
+		logger.Infof("http: artifact: creating artifact for '%s/%s' with hash '%x'", req.Artifact.Service, req.Artifact.ID, req.MD5)
 		uploadURL, err := artifactWriteStorage.CreateArtifact(req.Artifact, req.MD5)
 		if err != nil {
 			logger.Errorf("http: artifact: create: storage failed failed creating artifact: %v", err)

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -694,18 +694,15 @@ type commitInfo struct {
 	Service     string
 }
 
-var extractInfoFromCommitRegex = regexp.MustCompile(`^\[(?P<service>.*)\]( artifact (?P<artifactID>[^ ]+) by)?.*\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>`)
-var extractInfoFromCommitRegexNamesLookup = make(map[string]int)
-
-func init() {
+func extractInfoFromCommit() func(string) (commitInfo, error) {
+	extractInfoFromCommitRegex := regexp.MustCompile(`^\[(?P<service>.*)\]( artifact (?P<artifactID>[^ ]+) by)?.*\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>`)
+	extractInfoFromCommitRegexNamesLookup := make(map[string]int)
 	for index, name := range extractInfoFromCommitRegex.SubexpNames() {
 		if name != "" {
 			extractInfoFromCommitRegexNamesLookup[name] = index
 		}
 	}
-}
 
-func extractInfoFromCommit() func(string) (commitInfo, error) {
 	return func(message string) (commitInfo, error) {
 		matches := extractInfoFromCommitRegex.FindStringSubmatch(message)
 		if matches == nil {

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -465,6 +465,7 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 			if err != nil {
 				logger.Infof("http: github webhook: service '%s': could not publish new artifact event for %s: %v", commitInfo.Service, commitInfo.ArtifactID, err)
 				unknownError(w)
+				return
 			}
 			logger.Infof("http: github webhook: handled successfully: service '%s' branch '%s' commit '%s'", commitInfo.Service, branch, payload.HeadCommit.ID)
 			w.WriteHeader(http.StatusOK)

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -23,7 +23,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/multierr"
 	"gopkg.in/go-playground/webhooks.v5/github"
 )
 
@@ -462,50 +461,10 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 				return
 			}
 
-			logger = logger.WithFields("branch", branch, "service", commitInfo.Service, "commit", payload.HeadCommit)
-			// lookup policies for branch
-			autoReleases, err := policySvc.GetAutoReleases(ctx, commitInfo.Service, branch)
+			err = flowSvc.NewArtifact(ctx, commitInfo.Service, commitInfo.ArtifactID)
 			if err != nil {
-				logger.Errorf("http: github webhook: service '%s' branch '%s': get auto release policies failed: %v", commitInfo.Service, branch, err)
-				err := slackClient.NotifySlackPolicyFailed(ctx, commitInfo.AuthorEmail, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Auto release policy failed for service %s and %s", commitInfo.Service, branch))
-				if err != nil {
-					logger.Errorf("http: github webhook: get auto-release policies: error notifying slack: %v", err)
-				}
-				unknownError(w)
-				return
-			}
-			logger.Infof("http: github webhook: service '%s' branch '%s': found %d release policies", commitInfo.Service, branch, len(autoReleases))
-			var errs error
-			for _, autoRelease := range autoReleases {
-				releaseID, err := flowSvc.ReleaseBranch(ctx, flow.Actor{
-					Name:  commitInfo.AuthorName,
-					Email: commitInfo.AuthorEmail,
-				}, autoRelease.Environment, commitInfo.Service, autoRelease.Branch)
-				if err != nil {
-					if errorCause(err) != git.ErrNothingToCommit {
-						errs = multierr.Append(errs, err)
-						err := slackClient.NotifySlackPolicyFailed(ctx, commitInfo.AuthorEmail, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", commitInfo.Service, autoRelease.Environment, autoRelease.Branch))
-						if err != nil {
-							logger.Errorf("http: github webhook: auto-release failed: error notifying slack: %v", err)
-						}
-						continue
-					}
-					logger.Infof("http: github webhook: service '%s': auto-release from policy '%s' to '%s': %v", commitInfo.Service, autoRelease.ID, autoRelease.Environment, err)
-					continue
-				}
-				//TODO: Parse and switch to signoff user
-				err = slackClient.NotifySlackPolicySucceeded(ctx, commitInfo.AuthorEmail, ":rocket: Release Manager :white_check_mark:", fmt.Sprintf("Service *%s* will be auto released to *%s*\nArtifact: <%s|*%s*>", commitInfo.Service, autoRelease.Environment, payload.HeadCommit.URL, releaseID))
-				if err != nil {
-					if errors.Cause(err) != slack.ErrUnknownEmail {
-						logger.Errorf("http: github webhook: auto-release succeeded: error notifying slack: %v", err)
-					}
-				}
-				logger.Infof("http: github webhook: service '%s': auto-release from policy '%s' of %s to %s", commitInfo.Service, autoRelease.ID, releaseID, autoRelease.Environment)
-			}
-			if errs != nil {
-				logger.Errorf("http: github webhook: service '%s' branch '%s': auto-release failed with one or more errors: %v", commitInfo.Service, branch, errs)
-				unknownError(w)
-				return
+				logger.Infof("http: github webhook: service '%s': could not publish new artifact event for %s: %s", commitInfo.Service, commitInfo.ArtifactID, err)
+				w.WriteHeader(http.StatusInternalServerError)
 			}
 			logger.Infof("http: github webhook: handled successfully: service '%s' branch '%s' commit '%s'", commitInfo.Service, branch, payload.HeadCommit.ID)
 			w.WriteHeader(http.StatusOK)
@@ -728,23 +687,34 @@ func convertTimeToEpoch(t time.Time) int64 {
 }
 
 type commitInfo struct {
+	ArtifactID  string
 	AuthorName  string
 	AuthorEmail string
 	Service     string
 }
 
+var extractInfoFromCommitRegex = regexp.MustCompile(`^\[(?P<service>.*)\]( artifact (?P<artifactID>[^ ]+) by)?.*\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>`)
+var extractInfoFromCommitRegexNamesLookup = make(map[string]int)
+
+func init() {
+	for index, name := range extractInfoFromCommitRegex.SubexpNames() {
+		if name != "" {
+			extractInfoFromCommitRegexNamesLookup[name] = index
+		}
+	}
+}
+
 func extractInfoFromCommit() func(string) (commitInfo, error) {
-	pattern := `^\[(?P<service>.*)\].*\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>`
-	regex := regexp.MustCompile(pattern)
 	return func(message string) (commitInfo, error) {
-		matches := regex.FindStringSubmatch(message)
+		matches := extractInfoFromCommitRegex.FindStringSubmatch(message)
 		if matches == nil {
 			return commitInfo{}, errors.New("no match")
 		}
 		return commitInfo{
-			Service:     matches[1],
-			AuthorName:  matches[2],
-			AuthorEmail: matches[3],
+			Service:     matches[extractInfoFromCommitRegexNamesLookup["service"]],
+			ArtifactID:  matches[extractInfoFromCommitRegexNamesLookup["artifactID"]],
+			AuthorName:  matches[extractInfoFromCommitRegexNamesLookup["authorName"]],
+			AuthorEmail: matches[extractInfoFromCommitRegexNamesLookup["authorEmail"]],
 		}, nil
 	}
 }

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -463,8 +463,8 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 
 			err = flowSvc.NewArtifact(ctx, commitInfo.Service, commitInfo.ArtifactID)
 			if err != nil {
-				logger.Infof("http: github webhook: service '%s': could not publish new artifact event for %s: %s", commitInfo.Service, commitInfo.ArtifactID, err)
-				w.WriteHeader(http.StatusInternalServerError)
+				logger.Infof("http: github webhook: service '%s': could not publish new artifact event for %s: %v", commitInfo.Service, commitInfo.ArtifactID, err)
+				unknownError(w)
 			}
 			logger.Infof("http: github webhook: handled successfully: service '%s' branch '%s' commit '%s'", commitInfo.Service, branch, payload.HeadCommit.ID)
 			w.WriteHeader(http.StatusOK)

--- a/cmd/server/http/http_test.go
+++ b/cmd/server/http/http_test.go
@@ -85,6 +85,7 @@ func TestExtractInfoFromCommit(t *testing.T) {
 			name:          "exact values",
 			commitMessage: "[test-service] artifact master-1234ds13g3-12s46g356g by Foo Bar\nArtifact-created-by: Foo Bar <test@lunar.app>",
 			commitInfo: commitInfo{
+				ArtifactID:  "master-1234ds13g3-12s46g356g",
 				AuthorEmail: "test@lunar.app",
 				AuthorName:  "Foo Bar",
 				Service:     "test-service",
@@ -95,6 +96,7 @@ func TestExtractInfoFromCommit(t *testing.T) {
 			name:          "email as author",
 			commitMessage: "[test-service] artifact master-1234ds13g3-12s46g356g by test@lunar.app\nArtifact-created-by: Foo Bar <test@lunar.app>",
 			commitInfo: commitInfo{
+				ArtifactID:  "master-1234ds13g3-12s46g356g",
 				AuthorEmail: "test@lunar.app",
 				AuthorName:  "Foo Bar",
 				Service:     "test-service",

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -337,7 +337,7 @@ func PushArtifactToReleaseManager(ctx context.Context, releaseManagerClient *htt
 	}
 	log.WithFields("artifactID", artifactSpec.ID, "uploadURL", resp.ArtifactUploadURL).Infof("artifact upload URL created for %s", artifactSpec.ID)
 
-	err = uploadFile(resp.ArtifactUploadURL, zipContent, artifactSpec, string(zipMD5s))
+	err = uploadFile(resp.ArtifactUploadURL, zipContent, string(zipMD5s))
 	if err != nil {
 		return "", errors.WithMessage(err, "upload artifact failed")
 	}
@@ -457,19 +457,14 @@ func zipFiles(files []fileInfo) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func uploadFile(url string, fileContent []byte, artifactSpec artifact.Spec, md5 string) error {
+func uploadFile(url string, fileContent []byte, md5 string) error {
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(fileContent))
 	if err != nil {
 		return err
 	}
 
-	jsonSpec, err := artifact.Encode(artifactSpec, false)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("x-amz-meta-artifact-spec", jsonSpec)
 	req.Header.Set("Content-MD5", md5)
-  
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lunarway/release-manager/internal/git"
 	httpinternal "github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/policy"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/lunarway/release-manager/internal/try"
@@ -41,11 +42,13 @@ type Service struct {
 	Tracer           tracing.Tracer
 	CanRelease       func(ctx context.Context, svc, branch, env string) (bool, error)
 	Storage          ArtifactReadStorage
+	Policy           *policy.Service
 
 	PublishPromote           func(context.Context, PromoteEvent) error
 	PublishRollback          func(context.Context, RollbackEvent) error
 	PublishReleaseArtifactID func(context.Context, ReleaseArtifactIDEvent) error
 	PublishReleaseBranch     func(context.Context, ReleaseBranchEvent) error
+	PublishNewArtifact       func(context.Context, NewArtifactEvent) error
 
 	MaxRetries int
 

--- a/internal/flow/new_artifact.go
+++ b/internal/flow/new_artifact.go
@@ -1,0 +1,122 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/slack"
+	"github.com/lunarway/release-manager/internal/try"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+)
+
+// NewArtifact should be triggered when a new artifact is ready
+func (s *Service) NewArtifact(ctx context.Context, service, artifactID string) error {
+	span, ctx := s.Tracer.FromCtx(ctx, "flow.NewArtifact")
+	defer span.Finish()
+
+	err := s.PublishNewArtifact(ctx, NewArtifactEvent{
+		Service:    service,
+		ArtifactID: artifactID,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type NewArtifactEvent struct {
+	Service    string `json:"service,omitempty"`
+	ArtifactID string `json:"artifactId,omitempty"`
+}
+
+func (NewArtifactEvent) Type() string {
+	return "newArtifact"
+}
+
+func (p NewArtifactEvent) Marshal() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+func (p *NewArtifactEvent) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, p)
+}
+
+// ExecNewArtifact is handling behavior of release manager when new artifacts are generated and ready
+func (s *Service) ExecNewArtifact(ctx context.Context, e NewArtifactEvent) error {
+	span, ctx := s.Tracer.FromCtx(ctx, "flow.ExecNewArtifact")
+	defer span.Finish()
+
+	logger := log.WithContext(ctx)
+
+	artifactSpec, err := s.Storage.ArtifactSpecification(ctx, e.Service, e.ArtifactID)
+
+	logger = logger.WithFields("branch", artifactSpec.Application.Branch, "service", artifactSpec.Service, "commit", artifactSpec.Application.SHA)
+	// lookup policies for branch
+	autoReleases, err := s.Policy.GetAutoReleases(ctx, artifactSpec.Service, artifactSpec.Application.Branch)
+	if err != nil {
+		logger.Errorf("flow: exec new artifact: service '%s' branch '%s': get auto release policies failed: %v", artifactSpec.Service, artifactSpec.Application.Branch, err)
+		err := s.Slack.NotifySlackPolicyFailed(ctx, artifactSpec.Application.AuthorEmail, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Auto release policy failed for service %s and %s", artifactSpec.Service, artifactSpec.Application.Branch))
+		if err != nil {
+			logger.Errorf("flow: exec new artifact: get auto-release policies: error notifying slack: %v", err)
+		}
+		return err
+	}
+	logger.Infof("flow: exec new artifact: service '%s' branch '%s': found %d release policies", artifactSpec.Service, artifactSpec.Application.Branch, len(autoReleases))
+	var errs error
+	for _, autoRelease := range autoReleases {
+		releaseID, err := s.ReleaseBranch(ctx, Actor{
+			Name:  artifactSpec.Application.AuthorName,
+			Email: artifactSpec.Application.AuthorEmail,
+		}, autoRelease.Environment, artifactSpec.Service, autoRelease.Branch)
+		if err != nil {
+			if errorCause(err) != git.ErrNothingToCommit {
+				errs = multierr.Append(errs, err)
+				err := s.Slack.NotifySlackPolicyFailed(ctx, artifactSpec.Application.AuthorEmail, ":rocket: Release Manager :no_entry:", fmt.Sprintf("Service %s was not released into %s from branch %s.\nYou can deploy manually using `hamctl`:\nhamctl release --service %[1]s --branch %[3]s --env %[2]s", artifactSpec.Service, autoRelease.Environment, autoRelease.Branch))
+				if err != nil {
+					logger.Errorf("flow: exec new artifact: auto-release failed: error notifying slack: %v", err)
+				}
+				continue
+			}
+			logger.Infof("flow: exec new artifact: service '%s': auto-release from policy '%s' to '%s': %v", artifactSpec.Service, autoRelease.ID, autoRelease.Environment, err)
+			continue
+		}
+		//TODO: Parse and switch to signoff user
+		err = s.Slack.NotifySlackPolicySucceeded(ctx, artifactSpec.Application.AuthorEmail, ":rocket: Release Manager :white_check_mark:", fmt.Sprintf("Service *%s* will be auto released to *%s*\nArtifact: <%s|*%s*>", artifactSpec.Service, autoRelease.Environment, artifactSpec.Application.URL, releaseID))
+		if err != nil {
+			if errors.Cause(err) != slack.ErrUnknownEmail {
+				logger.Errorf("flow: exec new artifact: auto-release succeeded: error notifying slack: %v", err)
+			}
+		}
+		logger.Infof("flow: exec new artifact: service '%s': auto-release from policy '%s' of %s to %s", artifactSpec.Service, autoRelease.ID, releaseID, autoRelease.Environment)
+	}
+	if errs != nil {
+		logger.Errorf("flow: exec new artifact: service '%s' branch '%s': auto-release failed with one or more errors: %v", artifactSpec.Service, artifactSpec.Application.Branch, errs)
+		return errs
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func errorCause(err error) error {
+	// get cause before and after multierr unwrap to handle wrapped multierrs and
+	// multierrs with wrapped errors
+	errs := multierr.Errors(errors.Cause(err))
+	if len(errs) == 0 {
+		return nil
+	}
+	for i := len(errs) - 1; i >= 0; i-- {
+		err := errs[i]
+		if err != try.ErrTooManyRetries {
+			return errors.Cause(err)
+		}
+	}
+	return err
+}

--- a/internal/s3storage/s3events.go
+++ b/internal/s3storage/s3events.go
@@ -27,26 +27,26 @@ type S3EventRecord struct {
 }
 
 type S3EventRecordIdentity struct {
-	PrincipalId string `json:"principalId,omitempty"` //"AWS:AROAIVBPOFACJXCN6JNTG:eki@lunar.app"
+	PrincipalId string `json:"principalId,omitempty"`
 }
 
 type S3EventRecordData struct {
-	S3SchemaVersion string                  `json:"s3SchemaVersion,omitempty"` //"1.0",
-	ConfigurationId string                  `json:"configurationId,omitempty"` //"ZWU1OTJlYTAtOTBhMC00NzkwLWE1NTEtMWE2NGM0MTU5YWRl",
+	S3SchemaVersion string                  `json:"s3SchemaVersion,omitempty"`
+	ConfigurationId string                  `json:"configurationId,omitempty"`
 	Bucket          S3EventRecordDataBucket `json:"bucket,omitempty"`
 	Object          S3EventRecordDataObject `json:"object,omitempty"`
 }
 
 type S3EventRecordDataBucket struct {
-	Name          string                `json:"name,omitempty"` //"eki-lunar-artifacts",
+	Name          string                `json:"name,omitempty"`
 	OwnerIdentity S3EventRecordIdentity `json:"ownerIdentity,omitempty"`
-	Arn           string                `json:"arn,omitempty"` //"arn:aws:s3:::eki-lunar-artifacts"
+	Arn           string                `json:"arn,omitempty"`
 }
 
 type S3EventRecordDataObject struct {
-	Key       string `json:"key,omitempty"` //"test-service/master-20200604-1303",
+	Key       string `json:"key,omitempty"`
 	Size      int    `json:"size,omitempty"`
-	ETag      string `json:"eTag,omitempty"`      //"c12e30c98ebc8cffb28215a61651614e",
-	VersionID string `json:"versionId,omitempty"` // object version if bucket is versioning-enabled, otherwise null
-	Sequencer string `json:"sequencer,omitempty"` //"005ED8D51FB571C1E8"
+	ETag      string `json:"eTag,omitempty"`
+	VersionID string `json:"versionId,omitempty"`
+	Sequencer string `json:"sequencer,omitempty"`
 }

--- a/internal/s3storage/s3events.go
+++ b/internal/s3storage/s3events.go
@@ -1,0 +1,52 @@
+package s3storage
+
+import (
+	"encoding/json"
+)
+
+// S3Event describes events received from S3 notification service.
+// They are, kind of, documented here: https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
+type S3Event struct {
+	Records []S3EventRecord `json:"Records,omitempty"`
+}
+
+func (p *S3Event) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, p)
+}
+
+type S3EventRecord struct {
+	EventVersion      string                `json:"eventVersion,omitempty"`
+	EventSource       string                `json:"eventSource,omitempty"`
+	AwsRegion         string                `json:"awsRegion,omitempty"`
+	EventTime         string                `json:"eventTime,omitempty"`
+	EventName         string                `json:"eventName,omitempty"`
+	UserIdentity      S3EventRecordIdentity `json:"userIdentity,omitempty"`
+	RequestParameters map[string]string     `json:"requestParameters,omitempty"`
+	ResponseElements  map[string]string     `json:"responseElements,omitempty"`
+	S3                S3EventRecordData     `json:"s3,omitempty"`
+}
+
+type S3EventRecordIdentity struct {
+	PrincipalId string `json:"principalId,omitempty"` //"AWS:AROAIVBPOFACJXCN6JNTG:eki@lunar.app"
+}
+
+type S3EventRecordData struct {
+	S3SchemaVersion string                  `json:"s3SchemaVersion,omitempty"` //"1.0",
+	ConfigurationId string                  `json:"configurationId,omitempty"` //"ZWU1OTJlYTAtOTBhMC00NzkwLWE1NTEtMWE2NGM0MTU5YWRl",
+	Bucket          S3EventRecordDataBucket `json:"bucket,omitempty"`
+	Object          S3EventRecordDataObject `json:"object,omitempty"`
+}
+
+type S3EventRecordDataBucket struct {
+	Name          string                `json:"name,omitempty"` //"eki-lunar-artifacts",
+	OwnerIdentity S3EventRecordIdentity `json:"ownerIdentity,omitempty"`
+	Arn           string                `json:"arn,omitempty"` //"arn:aws:s3:::eki-lunar-artifacts"
+}
+
+type S3EventRecordDataObject struct {
+	Key       string `json:"key,omitempty"` //"test-service/master-20200604-1303",
+	Size      int    `json:"size,omitempty"`
+	ETag      string `json:"eTag,omitempty"`      //"c12e30c98ebc8cffb28215a61651614e",
+	VersionID string `json:"versionId,omitempty"` // object version if bucket is versioning-enabled, otherwise null
+	Sequencer string `json:"sequencer,omitempty"` //"005ED8D51FB571C1E8"
+}

--- a/internal/s3storage/s3storage.go
+++ b/internal/s3storage/s3storage.go
@@ -207,6 +207,7 @@ func (s *Service) startSQSHandler(handler func(msg string) error) {
 				err := handler(*message.Body)
 				if err != nil {
 					log.With("messageID", *message.MessageId, "messageBody", *message.Body).Errorf("Failed handling SQS message. Error: %s", err)
+					continue
 				} else {
 					log.With("messageID", *message.MessageId, "messageBody", *message.Body).Infof("Handled SQS message %s", *message.MessageId)
 				}

--- a/internal/s3storage/s3storage.go
+++ b/internal/s3storage/s3storage.go
@@ -1,12 +1,14 @@
 package s3storage
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/tracing"
@@ -14,26 +16,87 @@ import (
 )
 
 type Service struct {
-	bucketName string
-	s3client   *s3.S3
-	tracer     tracing.Tracer
+	region      string
+	bucketName  string
+	s3client    *s3.S3
+	sqsClient   *sqs.SQS
+	tracer      tracing.Tracer
+	sqsQueueURL string
+	sqsQueueARN string
 }
 
 func New(bucketName string, tracer tracing.Tracer) (*Service, error) {
+	region := "eu-west-1"
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("eu-west-1"),
+		Region: aws.String(region),
 	})
 	if err != nil {
 		return nil, err
 	}
-	// Create a S3 client from just a session.
+
 	s3client := s3.New(sess)
+	sqsClient := sqs.New(sess)
 
 	return &Service{
+		region:     region,
 		bucketName: bucketName,
 		s3client:   s3client,
+		sqsClient:  sqsClient,
 		tracer:     tracer,
 	}, nil
+}
+
+func (s *Service) InitializeSQS() error {
+	// Amazon SQS returns only an error if the request includes attributes whose values differ from those of the existing queue.
+	queue, err := s.sqsClient.CreateQueue(&sqs.CreateQueueInput{
+		QueueName: aws.String(s.sqsQueueName()),
+	})
+	if err != nil {
+		return errors.Wrap(err, "create sqs queue")
+	}
+	log.Infof("Created queue with url: %s", *queue.QueueUrl)
+	s.sqsQueueURL = *queue.QueueUrl
+
+	queueAttributes, err := s.sqsClient.GetQueueAttributes(&sqs.GetQueueAttributesInput{
+		QueueUrl:       queue.QueueUrl,
+		AttributeNames: []*string{aws.String(sqs.QueueAttributeNameQueueArn)},
+	})
+	if err != nil {
+		return errors.Wrap(err, "get sqs queue ARN")
+	}
+	s.sqsQueueARN = *queueAttributes.Attributes[sqs.QueueAttributeNameQueueArn]
+
+	log.Infof("SQS queue arn acquired: %s", s.sqsQueueARN)
+
+	go func() {
+		for {
+			output, err := s.sqsClient.ReceiveMessage(&sqs.ReceiveMessageInput{
+				QueueUrl:            aws.String(s.sqsQueueURL),
+				MaxNumberOfMessages: aws.Int64(1),
+				WaitTimeSeconds:     aws.Int64(5),
+			})
+
+			if err != nil {
+				log.Errorf("failed to fetch sqs message %v", err)
+			}
+
+			for _, message := range output.Messages {
+				log.Infof("Received message %s: %#v", *message.MessageId, *message.Body)
+				s.sqsClient.DeleteMessage(&sqs.DeleteMessageInput{
+					QueueUrl:      &s.sqsQueueURL,
+					ReceiptHandle: message.ReceiptHandle,
+				})
+			}
+		}
+	}()
+
+	// aerr, isAwsErr := err.(awserr.Error)
+	// if isAwsErr && (aerr.Code() == sqs.Que || aerr.Code() == s3.ErrCodeBucketAlreadyExists) {
+	// 	log.WithFields("type", "s3storage").Info("sqs queue already exists")
+	// 	return nil
+	// }
+	log.WithFields("type", "s3storage").Info("s3 bucket create")
+	return nil
 }
 
 func (s *Service) InitializeBucket() error {
@@ -44,11 +107,29 @@ func (s *Service) InitializeBucket() error {
 	if isAwsErr && (aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou || aerr.Code() == s3.ErrCodeBucketAlreadyExists) {
 		log.WithFields("type", "s3storage").Info("s3 bucket already exists")
 		return nil
-	}
-	if err != nil {
+	} else if err != nil {
 		return errors.Wrap(err, "create bucket")
 	}
-	log.WithFields("type", "s3storage").Info("s3 bucket create")
+	log.WithFields("type", "s3storage").Info("s3 bucket ensured")
+
+	_, err = s.s3client.PutBucketNotificationConfiguration(&s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(s.bucketName),
+		NotificationConfiguration: &s3.NotificationConfiguration{
+			QueueConfigurations: []*s3.QueueConfiguration{
+				&s3.QueueConfiguration{
+					QueueArn: aws.String(s.sqsQueueARN),
+					Events: []*string{
+						aws.String(s3.EventS3ObjectCreated),
+					},
+				},
+			},
+		},
+	})
+
+	if err == nil {
+		return errors.Wrap(err, "update bucket notifications")
+	}
+
 	return nil
 }
 
@@ -68,3 +149,20 @@ func (s *Service) CreateArtifact(artifactSpec artifact.Spec, md5 string) (string
 
 	return uploadURL, nil
 }
+
+func (s *Service) sqsQueueName() string {
+	return fmt.Sprintf("%s-s3-bucket-notifications", s.bucketName)
+}
+
+// func (s *Service) sqsQueueArn() string {
+// 	https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue
+
+// 	re := regexp.MustCompile(^`https://sqs.(?P<region>[^.]+).amazonaws.com/(?P<accountnumber>[^/]+)/(?P<queuename>.*)$`)
+// 	fmt.Println(re.MatchString(s.sqsQueueURL))
+// 	fmt.Printf("%q\n", re.SubexpNames())
+// 	reversed := fmt.Sprintf("${%s} ${%s}", re.SubexpNames()[2], re.SubexpNames()[1])
+// 	fmt.Println(reversed)
+// 	fmt.Println(re.ReplaceAllString("Alan Turing", reversed))
+
+// 	return fmt.Sprintf("arn:aws:sqs:%s:%s:%s", region, "", s.sqsQueueName())
+// }

--- a/internal/s3storage/s3storage.go
+++ b/internal/s3storage/s3storage.go
@@ -105,7 +105,7 @@ func (s *Service) InitializeSQS(handler func(msg string) error) error {
 		}),
 	})
 	if err != nil {
-		log.With("policy", policy, "bucketName", s.bucketName, "Error", fmt.Sprintf("%s", err)).Errorf("Failed update policy: %s", err)
+		log.With("policy", policy, "bucketName", s.bucketName, "Error", err).Errorf("Failed update policy: %s", err)
 		return errors.Wrap(err, "update sqs permission")
 	}
 	log.Infof("SQS policy updated for s3 bucket %s to SQS %s", s.bucketName, s.sqsQueueARN)
@@ -164,6 +164,7 @@ func (s *Service) CreateArtifact(artifactSpec artifact.Spec, md5 string) (string
 	return uploadURL, nil
 }
 
+// Close closes the S3 storage service. Multiple calls to this method will result in a panic.
 func (s *Service) Close() error {
 	if s.sqsHandlerQuitChannel != nil {
 		close(s.sqsHandlerQuitChannel)


### PR DESCRIPTION
This PR is kind of two-fold.

The first part is about the S3 Storage that gets support for registering an AWS SQS Queue automatically including:
- Creating the SQS Queue if not existing
- Defining permissions on that SQS Queue to let S3 Notification Service send messages to that queue
- Updating the S3 buckets Notification configuration to send all CreateObject notifications to that queue.
- Continuously listening for new events on the SQS queue while the release manager is running.

The second part is about refactoring the execution of Auto Release Policies out of the Github Webhook logic. It is now set up so that Github Webhooks trigger a new broker event type called `NewArtifact`, which then asynchronously triggers the same Auto Release Policy logic as before.
This is done so the same logic and the same events can also be used by S3 events. 

This consequently means that S3 events are being moved as quickly as possible from the external AWS Queue system to our main queue system, which makes the system easier to reason about
