### PR TITLE
Ack and slack notify

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -316,7 +316,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					log.Errorf("errorhandling could not unmarshal event of type %s to generic event with error: %s", msgType, unmarshalErr)
 					return
 				}
-				slackErr := slackClient.NotifyReleaseManagerError(ctx, event.Service, event.Environment, event.Branch, event.Namespace, event.Actor.Email, err)
+				slackErr := slackClient.NotifyReleaseManagerError(ctx, msgType, event.Service, event.Environment, event.Branch, event.Namespace, event.Actor.Email, err)
 				if slackErr != nil {
 					log.Errorf("slack notification failed with error %s", slackErr)
 				}

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -308,6 +308,20 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					return flowSvc.ExecRollback(context.Background(), event)
 				},
 			}
+
+			errorHandler := func(msgType string, msgBody []byte, err error) {
+				var event flow.GenericEvent
+				unmarshalErr := event.Unmarshal(msgBody)
+				if unmarshalErr != nil {
+					log.Errorf("errorhandling could not unmarshal event of type %s to generic event with error: %s", msgType, unmarshalErr)
+					return
+				}
+				slackErr := slackClient.NotifyReleaseManagerError(ctx, event.Service, event.Environment, event.Branch, event.Namespace, event.Actor.Email, err)
+				if slackErr != nil {
+					log.Errorf("slack notification failed with error %s", slackErr)
+				}
+			}
+
 			brokerImpl, err := getBroker(startOptions.broker)
 			if err != nil {
 				return errors.WithMessage(err, "setup broker")
@@ -339,8 +353,8 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				}
 			}()
 			go func() {
-				err := brokerImpl.StartConsumer(eventHandlers)
-				done <- errors.WithMessage(err, "amqp broker")
+				err := brokerImpl.StartConsumer(eventHandlers, errorHandler)
+				done <- errors.WithMessage(err, "broker")
 			}()
 
 			sigs := make(chan os.Signal, 1)

--- a/internal/broker/amqp/amqp.go
+++ b/internal/broker/amqp/amqp.go
@@ -93,7 +93,7 @@ func (s *Worker) Close() error {
 
 // StartConsumer starts the consumer on the worker. The method is blocking and
 // will only return if the worker is stopped with Close.
-func (s *Worker) StartConsumer(handlers map[string]func([]byte) error) error {
+func (s *Worker) StartConsumer(handlers map[string]func([]byte) error, errorHandler func(msgType string, msgBody []byte, err error)) error {
 	for {
 		select {
 		// worker is instructed to shutdown from a Close call
@@ -103,7 +103,7 @@ func (s *Worker) StartConsumer(handlers map[string]func([]byte) error) error {
 		// worker has a new connection that can be used to consume messages with the handler
 		case conn := <-s.currentConsumer:
 			// this call is blocking as long as the connection is available.
-			err := conn.Start(s.config.Logger, handlers)
+			err := conn.Start(s.config.Logger, handlers, errorHandler)
 			if err != nil {
 				return err
 			}

--- a/internal/broker/amqp/amqp_test.go
+++ b/internal/broker/amqp/amqp_test.go
@@ -92,7 +92,7 @@ func TestWorker_PublishAndConsumer(t *testing.T) {
 				logger.Infof("Received %s", msg.Message)
 				return nil
 			},
-		})
+		}, func(msgType string, msgBody []byte, err error) {})
 		assert.EqualError(t, err, broker.ErrBrokerClosed.Error(), "unexpected consumer error")
 	}()
 
@@ -237,7 +237,7 @@ func TestWorker_reconnection(t *testing.T) {
 			atomic.AddInt32(&consumedCount, 1)
 			return nil
 		},
-	})
+	}, func(msgType string, msgBody []byte, err error) {})
 	logger.Infof("TEST: worker error: %v", err)
 	assert.EqualError(t, err, broker.ErrBrokerClosed.Error(), "consumer returned unexpected error")
 	wg.Wait()

--- a/internal/broker/amqp/consumer.go
+++ b/internal/broker/amqp/consumer.go
@@ -104,7 +104,7 @@ func (c *consumer) Start(logger *log.Logger, handlers map[string]func([]byte) er
 				"status":       "failed",
 				"responseTime": duration,
 				"error":        fmt.Sprintf("%+v", err),
-			}).Errorf("[consumer] [FAILED] Failed to handle message: trigger error handling and acking: %v", err)
+			}).Errorf("[consumer] [FAILED] Failed to handle message: trigger error handling and nacking with no requeue: %v", err)
 			// TODO: remove comments to allow for redelivery. This will put events
 			// into the unacknowledged state
 
@@ -112,7 +112,7 @@ func (c *consumer) Start(logger *log.Logger, handlers map[string]func([]byte) er
 			//  logger.WithFields("error", fmt.Sprintf("%+v", err)).Errorf("Failed to nack message: %v", err)
 			// }
 			errorHandler(msg.Type, msg.Body, err)
-			msg.Ack(false)
+			msg.Nack(false, false)
 			continue
 		}
 		logger.With("res", map[string]interface{}{

--- a/internal/broker/amqp/consumer.go
+++ b/internal/broker/amqp/consumer.go
@@ -100,24 +100,32 @@ func (c *consumer) Start(logger *log.Logger, handlers map[string]func([]byte) er
 		err := handler(msg.Body)
 		duration := time.Since(now).Milliseconds()
 		if err != nil {
-			logger.With("res", map[string]interface{}{
+			res := map[string]interface{}{
 				"status":       "failed",
 				"responseTime": duration,
 				"error":        fmt.Sprintf("%+v", err),
-			}).Errorf("[consumer] [FAILED] Failed to handle message: trigger error handling and nacking with no requeue: %v", err)
-			// TODO: remove comments to allow for redelivery. This will put events
-			// into the unacknowledged state
-
-			// err := msg.Nack(false, true) if err != nil {
-			//  logger.WithFields("error", fmt.Sprintf("%+v", err)).Errorf("Failed to nack message: %v", err)
-			// }
-			errorHandler(msg.Type, msg.Body, err)
-			msg.Nack(false, false)
+				"redelivered":  msg.Redelivered,
+			}
+			if msg.Redelivered {
+				logger.With("res", res).Errorf("[consumer] [FAILED] Failed to handle message: trigger error handling and nacking with no requeue")
+				errorHandler(msg.Type, msg.Body, err)
+				err = msg.Nack(false, false)
+				if err != nil {
+					logger.Errorf("Failed to nack message: %v", err)
+				}
+				continue
+			}
+			logger.With("res", res).Errorf("[consumer] [FAILED] Failed to handle message: requeuing")
+			err = msg.Nack(false, true)
+			if err != nil {
+				logger.Errorf("Failed to nack message: %v", err)
+			}
 			continue
 		}
 		logger.With("res", map[string]interface{}{
 			"status":       "ok",
 			"responseTime": duration,
+			"redelivered":  msg.Redelivered,
 		}).Info("[OK] Event handled successfully")
 		err = msg.Ack(false)
 		if err != nil {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -11,7 +11,7 @@ type Broker interface {
 	Publish(ctx context.Context, message Publishable) error
 	// StartConsumer consumes messages on a broker. This method is blocking and
 	// will always return with ErrBrokerClosed after calls to Close.
-	StartConsumer(handlers map[string]func([]byte) error) error
+	StartConsumer(handlers map[string]func([]byte) error, errorHandler func(msgType string, msgBody []byte, err error)) error
 	// Close closes the broker.
 	Close() error
 }

--- a/internal/broker/memory/memory_test.go
+++ b/internal/broker/memory/memory_test.go
@@ -67,7 +67,7 @@ func TestBroker_PublishAndConsumer(t *testing.T) {
 				logger.Infof("Received %s", msg.Message)
 				return nil
 			},
-		})
+		}, func(msgType string, msgBody []byte, err error) {})
 		assert.EqualError(t, err, broker.ErrBrokerClosed.Error(), "unexpected consumer error")
 	}()
 

--- a/internal/flow/generic_event.go
+++ b/internal/flow/generic_event.go
@@ -1,0 +1,15 @@
+package flow
+
+import "encoding/json"
+
+type GenericEvent struct {
+	Service     string `json:"service,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+	Actor       Actor  `json:"actor,omitempty"`
+}
+
+func (p *GenericEvent) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, p)
+}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -18,12 +18,13 @@ type Client struct {
 }
 
 type MuteOptions struct {
-	Flux             bool
-	Kubernetes       bool
-	Policy           bool
-	ReleaseProcessed bool
-	Releases         bool
-	BuildStatus      bool
+	Flux                bool
+	Kubernetes          bool
+	Policy              bool
+	ReleaseProcessed    bool
+	Releases            bool
+	BuildStatus         bool
+	ReleaseManagerError bool
 }
 
 var (
@@ -37,12 +38,13 @@ func NewClient(token string, emailMappings map[string]string) (*Client, error) {
 		log.Infof("slack: skipping: no token, so no slack notification")
 		return &Client{
 			muteOptions: MuteOptions{
-				Flux:             true,
-				Kubernetes:       true,
-				Policy:           true,
-				ReleaseProcessed: true,
-				Releases:         true,
-				BuildStatus:      true,
+				Flux:                true,
+				Kubernetes:          true,
+				Policy:              true,
+				ReleaseProcessed:    true,
+				Releases:            true,
+				BuildStatus:         true,
+				ReleaseManagerError: true,
 			},
 		}, nil
 	}
@@ -62,12 +64,13 @@ func NewMuteableClient(token string, emailMappings map[string]string, muteOption
 		log.Infof("slack: skipping: no token, so no slack notification")
 		return &Client{
 			muteOptions: MuteOptions{
-				Flux:             true,
-				Kubernetes:       true,
-				Policy:           true,
-				ReleaseProcessed: true,
-				Releases:         true,
-				BuildStatus:      true,
+				Flux:                true,
+				Kubernetes:          true,
+				Policy:              true,
+				ReleaseProcessed:    true,
+				Releases:            true,
+				BuildStatus:         true,
+				ReleaseManagerError: true,
 			},
 		}, nil
 	}
@@ -367,4 +370,28 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 		return err
 	}
 	return err
+}
+
+func (c *Client) NotifyReleaseManagerError(ctx context.Context, service, environment, branch, namespace, authorEmail string, err error) error {
+	if c.muteOptions.ReleaseManagerError {
+		return nil
+	}
+	userID, err := c.getIdByEmail(ctx, authorEmail)
+	if err != nil {
+		// If user id somehow couldn't be found, post the message to #squad-nasa
+		userID = "#squad-nasa"
+	}
+
+	asUser := slack.MsgOptionAsUser(true)
+	attachments := slack.MsgOptionAttachments(slack.Attachment{
+		Title:      fmt.Sprintf(":boom: Release Manager failed :x:"),
+		Color:      MsgColorRed,
+		Text:       fmt.Sprintf("Failed handling event in release manager for:\nService: %s\nEnvironment: %s\nBranch: %s\nNamespace: %s\nError: %s", service, environment, branch, namespace, err),
+		MarkdownIn: []string{"text", "fields"},
+	})
+	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -372,14 +372,15 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	return err
 }
 
-func (c *Client) NotifyReleaseManagerError(ctx context.Context, msgType, service, environment, branch, namespace, authorEmail string, err error) error {
+func (c *Client) NotifyReleaseManagerError(ctx context.Context, msgType, service, environment, branch, namespace, actorEmail string, err error) error {
 	if c.muteOptions.ReleaseManagerError {
 		return nil
 	}
-	userID, err := c.getIdByEmail(ctx, authorEmail)
+	userID, err := c.getIdByEmail(ctx, actorEmail)
 	if err != nil {
 		// If user id somehow couldn't be found, post the message to #squad-nasa
-		userID = "#squad-nasa"
+		log.With("actorEmail", actorEmail).Infof("slack: skipping: no user id found, so no slack notification")
+		return nil
 	}
 
 	asUser := slack.MsgOptionAsUser(true)


### PR DESCRIPTION
This PR introduces an Error handler to the broker implementation, that supports a generic error handling when something goes wrong with receiving messages.
It also ack's all messages afterwards, so nothing gets blocked. 