### PR TITLE
Fix bug in completion annotations

### DIFF
--- a/cmd/hamctl/command/completion/completion.go
+++ b/cmd/hamctl/command/completion/completion.go
@@ -11,9 +11,10 @@ import (
 // completionFunc is the bash function identifier that should be called upon
 // completion requests.
 func FlagAnnotation(c *cobra.Command, f string, completionFunc string) {
-	c.Flag(f).Annotations = map[string][]string{
-		cobra.BashCompCustom: []string{completionFunc},
+	if c.Flag(f).Annotations == nil {
+		c.Flag(f).Annotations = map[string][]string{}
 	}
+	c.Flag(f).Annotations[cobra.BashCompCustom] = []string{completionFunc}
 }
 
 // Hamctl contains bash completions for the hamctl command.

--- a/cmd/hamctl/command/completion/completion_test.go
+++ b/cmd/hamctl/command/completion/completion_test.go
@@ -1,0 +1,55 @@
+package completion_test
+
+import (
+	"testing"
+
+	"github.com/lunarway/release-manager/cmd/hamctl/command/completion"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagAnnotation(t *testing.T) {
+	tt := []struct {
+		name        string
+		setup       func() *cobra.Command
+		flag        string
+		annotations map[string][]string
+	}{
+		{
+			name: "required flag before completion",
+			flag: "f",
+			setup: func() *cobra.Command {
+				c := cobra.Command{}
+				c.Flags().String("f", "", "")
+				c.MarkFlagRequired("f")
+				completion.FlagAnnotation(&c, "f", "compFunc")
+				return &c
+			},
+			annotations: map[string][]string{
+				cobra.BashCompCustom:          {"compFunc"},
+				cobra.BashCompOneRequiredFlag: {"true"},
+			},
+		},
+		{
+			name: "required flag after completion",
+			flag: "f",
+			setup: func() *cobra.Command {
+				c := cobra.Command{}
+				c.Flags().String("f", "", "")
+				completion.FlagAnnotation(&c, "f", "compFunc")
+				c.MarkFlagRequired("f")
+				return &c
+			},
+			annotations: map[string][]string{
+				cobra.BashCompCustom:          {"compFunc"},
+				cobra.BashCompOneRequiredFlag: {"true"},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := tc.setup()
+			assert.Equal(t, tc.annotations, cmd.Flag(tc.flag).Annotations)
+		})
+	}
+}


### PR DESCRIPTION
Currently if a hamctl release command is issued without an 'env' flag the
command is accepted and pushed to the server. The flag is marked required but
due to a bug in completion.FlagAnnotation the required annotation is dropped.

This change set ensures to not change existing annotations on the flag before
setting the bash completion annotation