### PR TITLE
Add server side input validation

### DIFF
--- a/cmd/server/http/create_artifact.go
+++ b/cmd/server/http/create_artifact.go
@@ -21,6 +21,10 @@ func createArtifact(payload *payload, artifactWriteStorage ArtifactWriteStorage)
 			return
 		}
 
+		if !req.Validate(w) {
+			return
+		}
+
 		logger.Infof("http: artifact: creating artiact for '%s' hash '%x'", req.Artifact.ID, req.MD5)
 		uploadURL, err := artifactWriteStorage.CreateArtifact(req.Artifact, req.MD5)
 		if err != nil {

--- a/cmd/server/http/describe.go
+++ b/cmd/server/http/describe.go
@@ -96,7 +96,7 @@ func describeRelease(ctx context.Context, payload *payload, flowSvc *flow.Servic
 			}
 			switch errorCause(err) {
 			case artifact.ErrFileNotFound:
-				Error(w, fmt.Sprintf("no release of service '%s' available in environment '%s'. Are you missing a namespace?", service, environment), http.StatusBadRequest)
+				httpinternal.Error(w, fmt.Sprintf("no release of service '%s' available in environment '%s'. Are you missing a namespace?", service, environment), http.StatusBadRequest)
 				return
 			default:
 				logger.Errorf("http: describe release: service '%s' environment '%s': failed: %v", service, environment, err)
@@ -134,7 +134,7 @@ func describeArtifact(ctx context.Context, payload *payload, flowSvc *flow.Servi
 		}
 		count, err := strconv.Atoi(countParam)
 		if err != nil || count <= 0 {
-			Error(w, fmt.Sprintf("invalid value '%s' of count. Must be a positive integer.", countParam), http.StatusBadRequest)
+			httpinternal.Error(w, fmt.Sprintf("invalid value '%s' of count. Must be a positive integer.", countParam), http.StatusBadRequest)
 			return
 		}
 		logger := log.WithContext(ctx).WithFields("service", service, "count", count)
@@ -148,7 +148,7 @@ func describeArtifact(ctx context.Context, payload *payload, flowSvc *flow.Servi
 			}
 			switch errorCause(err) {
 			case git.ErrArtifactNotFound:
-				Error(w, fmt.Sprintf("no artifacts available for service '%s'.", service), http.StatusBadRequest)
+				httpinternal.Error(w, fmt.Sprintf("no artifacts available for service '%s'.", service), http.StatusBadRequest)
 				return
 			default:
 				logger.Errorf("http: describe artifact: service '%s': failed: %v", service, err)

--- a/cmd/server/http/error.go
+++ b/cmd/server/http/error.go
@@ -1,51 +1,37 @@
 package http
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	httpinternal "github.com/lunarway/release-manager/internal/http"
-	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/try"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
 
-func Error(w http.ResponseWriter, message string, statusCode int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	err := json.NewEncoder(w).Encode(httpinternal.ErrorResponse{
-		Status:  statusCode,
-		Message: message,
-	})
-	if err != nil {
-		log.Errorf("json encoding failed in error response: %v", err)
-	}
-}
-
 func unknownError(w http.ResponseWriter) {
-	Error(w, "unknown error", http.StatusInternalServerError)
+	httpinternal.Error(w, "unknown error", http.StatusInternalServerError)
 }
 
 func invalidBodyError(w http.ResponseWriter) {
-	Error(w, "invalid body", http.StatusBadRequest)
+	httpinternal.Error(w, "invalid body", http.StatusBadRequest)
 }
 
 func cancelled(w http.ResponseWriter) {
-	Error(w, "request cancelled", http.StatusBadRequest)
+	httpinternal.Error(w, "request cancelled", http.StatusBadRequest)
 }
 
 func requiredFieldError(w http.ResponseWriter, field string) {
-	Error(w, fmt.Sprintf("field %s required but was empty", field), http.StatusBadRequest)
+	httpinternal.Error(w, fmt.Sprintf("field %s required but was empty", field), http.StatusBadRequest)
 }
 
 func requiredQueryError(w http.ResponseWriter, field string) {
-	Error(w, fmt.Sprintf("query param %s required but was empty", field), http.StatusBadRequest)
+	httpinternal.Error(w, fmt.Sprintf("query param %s required but was empty", field), http.StatusBadRequest)
 }
 
 func notFound(w http.ResponseWriter) {
-	Error(w, "not found", http.StatusNotFound)
+	httpinternal.Error(w, "not found", http.StatusNotFound)
 }
 
 // errorCause unwraps err from pkg/errors messages and if err contains a

--- a/internal/http/error.go
+++ b/internal/http/error.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/lunarway/release-manager/internal/log"
+)
+
+type ErrorResponse struct {
+	Status  int    `json:"status,omitempty"`
+	Message string `json:"message,omitempty"`
+	ID      string `json:"-"`
+}
+
+var _ error = &ErrorResponse{}
+
+func (e *ErrorResponse) Error() string {
+	if e.ID != "" {
+		return fmt.Sprintf("%s\nReference: %s", e.Message, e.ID)
+	}
+	return e.Message
+}
+
+func Error(w http.ResponseWriter, message string, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	err := json.NewEncoder(w).Encode(ErrorResponse{
+		Status:  statusCode,
+		Message: message,
+	})
+	if err != nil {
+		log.Errorf("json encoding failed in error response: %v", err)
+	}
+}
+
+type validationErrors struct {
+	errs []string
+}
+
+func (v *validationErrors) Append(err string) {
+	v.errs = append(v.errs, err)
+}
+
+func (v *validationErrors) Evaluate(w http.ResponseWriter) bool {
+	if len(v.errs) != 0 {
+		Error(w, v.String(), http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func (v *validationErrors) String() string {
+	var errs []string
+	for _, err := range v.errs {
+		errs = append(errs, fmt.Sprintf("  %s", err))
+	}
+	return fmt.Sprintf("input not valid:\n%s\n", strings.Join(errs, "\n"))
+}
+
+func emptyString(s string) bool {
+	return len(strings.TrimSpace(s)) == 0
+}
+
+func requiredField(f string) string {
+	return fmt.Sprintf("Required field '%s' was empty", f)
+}
+
+func filterEmptyStrings(ss []string) []string {
+	var f []string
+	for _, s := range ss {
+		s = strings.TrimSpace(s)
+		if len(s) == 0 {
+			continue
+		}
+		f = append(f, s)
+	}
+	return f
+}


### PR DESCRIPTION
Currently a number of HTTP endpoints does not validate inputs before calling
internal methods. This leads to unexpected results like releasing to an empty
environment. (fixed client side with d25d488ffc1262feb0d9e55a9682441bbf421b0e
(#189)).

This change set adds a Validate method to all HTTP request models that is called
in the HTTP handlers to ensure that data is present before proceeding.