### PR TITLE
Introduce Service Filtering

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/policy"
 	"github.com/lunarway/release-manager/internal/s3storage"
+	"github.com/lunarway/release-manager/internal/servicefilter"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/pkg/errors"
@@ -108,6 +109,7 @@ type startOptions struct {
 	gpgKeyPaths               *[]string
 	userMappings              *map[string]string
 	branchRestrictionPolicies *[]policy.BranchRestriction
+	serviceFilter             servicefilter.ServiceFilter
 }
 
 func NewStart(startOptions *startOptions) *cobra.Command {
@@ -205,6 +207,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Storage:          storage,
 				Policy:           &policySvc,
 				Tracer:           tracer,
+				ServiceFilter:    startOptions.serviceFilter,
 				// TODO: figure out a better way of splitting the consumer and publisher
 				// to avoid this chicken and egg issue. It is not a real problem as the
 				// consumer is started later on and this we are sure this gets set, it

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -20,6 +20,7 @@ import (
 	httpinternal "github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/policy"
+	"github.com/lunarway/release-manager/internal/servicefilter"
 	"github.com/lunarway/release-manager/internal/slack"
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/lunarway/release-manager/internal/try"
@@ -43,6 +44,7 @@ type Service struct {
 	CanRelease       func(ctx context.Context, svc, branch, env string) (bool, error)
 	Storage          ArtifactReadStorage
 	Policy           *policy.Service
+	ServiceFilter    servicefilter.ServiceFilter
 
 	PublishPromote           func(context.Context, PromoteEvent) error
 	PublishRollback          func(context.Context, RollbackEvent) error

--- a/internal/servicefilter/includeall.go
+++ b/internal/servicefilter/includeall.go
@@ -1,0 +1,11 @@
+package servicefilter
+
+type includeAll struct{}
+
+func NewIncludeAll() ServiceFilter {
+	return &includeAll{}
+}
+
+func (includeAll) IsIncluded(service string) bool {
+	return true
+}

--- a/internal/servicefilter/regex.go
+++ b/internal/servicefilter/regex.go
@@ -1,0 +1,24 @@
+package servicefilter
+
+import (
+	"regexp"
+)
+
+type regex struct {
+	re *regexp.Regexp
+}
+
+func FromStringRegex(regexString string) (ServiceFilter, error) {
+	re, err := regexp.Compile(`^\[(?P<service>.*)\]( artifact (?P<artifactID>[^ ]+) by)?.*\nArtifact-created-by:\s(?P<authorName>.*)\s<(?P<authorEmail>.*)>`)
+
+	if err != nil {
+		return nil, err
+	}
+	return &regex{
+		re: re,
+	}, nil
+}
+
+func (r *regex) IsIncluded(service string) bool {
+	return false
+}

--- a/internal/servicefilter/servicefilter.go
+++ b/internal/servicefilter/servicefilter.go
@@ -1,0 +1,5 @@
+package servicefilter
+
+type ServiceFilter interface {
+	IsIncluded(service string) bool
+}


### PR DESCRIPTION
The idea here is to be able to run Release Manager for a subset of services. This will allow us to roll out
release manager with 2 (or more) bulk heads, limiting the impact of deploying a release manager with buggy behavior.

Also we could have release-manager 1 deploy release-manager 2 and the other way around.
