### PR TITLE
Add missing error checks

### DIFF
--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -33,9 +33,15 @@ Release latest artifact from branch 'master' of service 'product' into environme
 				if err != nil {
 					return err
 				}
-				actions.ReleaseArtifactID(client, *service, environment, artifactID, intent.NewReleaseBranch(branch))
+				err = actions.ReleaseArtifactID(client, *service, environment, artifactID, intent.NewReleaseBranch(branch))
+				if err != nil {
+					return err
+				}
 			case artifact != "":
-				actions.ReleaseArtifactID(client, *service, environment, artifact, intent.NewReleaseArtifact())
+				err := actions.ReleaseArtifactID(client, *service, environment, artifact, intent.NewReleaseArtifact())
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -375,7 +375,12 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 							log.With("s3event", s3event).Infof("Got s3 object creation event on %s which can't be parsed to service and artifact id", record.S3.Object.Key)
 							continue
 						}
-						flowSvc.NewArtifact(ctx, parts[0], parts[1])
+						service := parts[0]
+						artifactID := parts[1]
+						err = flowSvc.NewArtifact(ctx, service, artifactID)
+						if err != nil {
+							return errors.WithMessagef(err, "new artifact for service '%s' artifact id '%s'", service, artifactID)
+						}
 					}
 					return nil
 				}


### PR DESCRIPTION
If the ReleaseArtifactID command fails in hamctl release no error is written to the screen.

If we cannot create a new artifact on S3 events we also do nothing to record the error.

This change adds error checks to both these places.

Found with go get -u github.com/kisielk/errcheck

    errcheck ./...