### PR TITLE
Fix commit parsing issue

### DIFF
--- a/internal/commitinfo/commitinfo.go
+++ b/internal/commitinfo/commitinfo.go
@@ -68,11 +68,11 @@ func ParseCommitInfo(commitMessage string) (CommitInfo, error) {
 	}
 
 	matches := parseCommitInfoFromCommitMessageRegex.FindStringSubmatch(convInfo.Message)
-	if matches == nil {
-		return CommitInfo{}, errors.Wrap(ErrNoMatch, fmt.Sprintf("commit message '%s' does not match expected message structure", convInfo.Message))
+	if matches == nil && !convInfo.HasField(FieldReleaseIntent) {
+		return CommitInfo{}, errors.Wrap(ErrNoMatch, fmt.Sprintf("commit message '%s' does have a Release-intent field and did not match expected message structure", convInfo.Message))
 	}
 
-	if matches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "artifact" {
+	if matches != nil && matches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "artifact" {
 		return CommitInfo{}, errors.Wrap(ErrNoMatch, fmt.Sprintf("commit type '%s' is not considered a match", matches[parseCommitInfoFromCommitMessageRegexLookup.Type]))
 	}
 
@@ -87,18 +87,18 @@ func ParseCommitInfo(commitMessage string) (CommitInfo, error) {
 	intentObj := parseIntent(convInfo, matches)
 
 	service := convInfo.Field(FieldService)
-	if service == "" {
+	if matches != nil && service == "" {
 		service = matches[parseCommitInfoFromCommitMessageRegexLookup.Service]
 	}
 	environment := convInfo.Field(FieldEnvironment)
-	if environment == "" {
+	if matches != nil && environment == "" {
 		environment = matches[parseCommitInfoFromCommitMessageRegexLookup.Environment]
 	}
 	artifactID := convInfo.Field(FieldArtifactID)
-	if artifactID == "" {
+	if matches != nil && artifactID == "" {
 		artifactID = matches[parseCommitInfoFromCommitMessageRegexLookup.ArtifactID]
 	}
-	if releasedBy.Email == "" {
+	if matches != nil && releasedBy.Email == "" {
 		releasedBy = NewPersonInfo("", matches[parseCommitInfoFromCommitMessageRegexLookup.ReleaseByEmail])
 	}
 

--- a/internal/commitinfo/commitinfo.go
+++ b/internal/commitinfo/commitinfo.go
@@ -69,7 +69,7 @@ func ParseCommitInfo(commitMessage string) (CommitInfo, error) {
 
 	matches := parseCommitInfoFromCommitMessageRegex.FindStringSubmatch(convInfo.Message)
 	if matches == nil && !convInfo.HasField(FieldReleaseIntent) {
-		return CommitInfo{}, errors.Wrap(ErrNoMatch, fmt.Sprintf("commit message '%s' does have a Release-intent field and did not match expected message structure", convInfo.Message))
+		return CommitInfo{}, errors.Wrap(ErrNoMatch, fmt.Sprintf("commit message '%s' do not have a Release-intent field and did not match expected message structure", convInfo.Message))
 	}
 
 	if matches != nil && matches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "artifact" {

--- a/internal/commitinfo/commitinfo_test.go
+++ b/internal/commitinfo/commitinfo_test.go
@@ -149,6 +149,27 @@ func TestParseCommitInfo(t *testing.T) {
 				Intent:            intent.NewRollback("test-s3-push-1337-1337"),
 			},
 		},
+		{
+			name: "Auto release intent should match",
+			commitMessage: []string{
+				"[prod/houston-web] auto release master-937e50b532-c27bd51ad3 by chb@lunar.app",
+				"",
+				"Service: houston-web",
+				"Environment: prod",
+				"Artifact-ID: master-937e50b532-c27bd51ad3",
+				"Artifact-released-by: Casper Bornebusch <chb@lunar.app>",
+				"Artifact-created-by: Casper Bornebusch <chb@lunar.app>",
+				"Release-intent: AutoRelease",
+			},
+			commitInfo: CommitInfo{
+				ArtifactID:        "master-937e50b532-c27bd51ad3",
+				Environment:       "prod",
+				Service:           "houston-web",
+				ArtifactCreatedBy: NewPersonInfo("Casper Bornebusch", "chb@lunar.app"),
+				ReleasedBy:        NewPersonInfo("Casper Bornebusch", "chb@lunar.app"),
+				Intent:            intent.NewAutoRelease(),
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/commitinfo/conventional.go
+++ b/internal/commitinfo/conventional.go
@@ -41,6 +41,15 @@ func (i *ConventionalCommitInfo) SetField(name string, value string) {
 	i.Fields = append(i.Fields, NewField(name, value))
 }
 
+func (i ConventionalCommitInfo) HasField(name string) bool {
+	for _, field := range i.Fields {
+		if field.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (i ConventionalCommitInfo) String() string {
 	var txts []string
 	if i.Message != "" {

--- a/internal/commitinfo/intent.go
+++ b/internal/commitinfo/intent.go
@@ -5,13 +5,14 @@ import (
 )
 
 const (
+	FieldReleaseIntent           = "Release-intent"
 	FieldRollbackOfArtifactId    = "Rollback-of-artifact-id"
 	FieldReleaseOfBranch         = "Release-of-branch"
 	FieldPromotedFromEnvironment = "Promoted-from-environment"
 )
 
 func parseIntent(cci ConventionalCommitInfo, commitMessageMatches []string) intent.Intent {
-	switch cci.Field("Release-intent") {
+	switch cci.Field(FieldReleaseIntent) {
 	case intent.TypeReleaseBranch:
 		return intent.NewReleaseBranch(cci.Field(FieldReleaseOfBranch))
 	case intent.TypePromote:
@@ -22,7 +23,7 @@ func parseIntent(cci ConventionalCommitInfo, commitMessageMatches []string) inte
 		return intent.NewAutoRelease()
 	default:
 		// A check for compatability reasons, for back when only the message was saying it was a rollback.
-		if commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "rollback" {
+		if commitMessageMatches != nil && commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "rollback" {
 			return intent.NewRollback(commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.PreviousArtifactID])
 		}
 		return intent.NewReleaseArtifact()
@@ -30,7 +31,7 @@ func parseIntent(cci ConventionalCommitInfo, commitMessageMatches []string) inte
 }
 
 func addIntentToConventionalCommitInfo(intentObj intent.Intent, cci *ConventionalCommitInfo) {
-	cci.SetField("Release-intent", intentObj.Type)
+	cci.SetField(FieldReleaseIntent, intentObj.Type)
 	switch intentObj.Type {
 	case intent.TypeReleaseBranch:
 		cci.SetField(FieldReleaseOfBranch, intentObj.ReleaseBranch.Branch)


### PR DESCRIPTION
Some commits weren't parsed correctly, but this makes commit title parsing less important, and will always try to read fields first.