### PR TITLE
Fix bug in commit message parsing for flux commits

### DIFF
--- a/cmd/daemon/flux/exporter.go
+++ b/cmd/daemon/flux/exporter.go
@@ -2,6 +2,7 @@ package flux
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	httpinternal "github.com/lunarway/release-manager/internal/http"
@@ -26,7 +27,7 @@ type ReleaseManagerExporter struct {
 }
 
 func (f *ReleaseManagerExporter) Send(_ context.Context, event event.Event) error {
-	f.Log.With("event", event).Infof("flux event logged")
+	f.Log.With("event", fmt.Sprintf("%#v", event)).Infof("flux event logged")
 	var resp httpinternal.FluxNotifyResponse
 	url, err := f.Client.URL("webhook/daemon/flux")
 	if err != nil {

--- a/cmd/server/http/daemon_flux_webhook.go
+++ b/cmd/server/http/daemon_flux_webhook.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/lunarway/release-manager/internal/flow"
@@ -29,7 +30,7 @@ func daemonFluxWebhook(payload *payload, flowSvc *flow.Service) http.HandlerFunc
 		}
 		logger = logger.WithFields(
 			"environment", fluxNotifyEvent.Environment,
-			"event", fluxNotifyEvent.FluxEvent)
+			"event", fmt.Sprintf("%#v", fluxNotifyEvent.FluxEvent))
 
 		err = flowSvc.NotifyFluxEvent(ctx, &fluxNotifyEvent)
 		if err != nil && errors.Cause(err) != slack.ErrUnknownEmail {

--- a/internal/commitinfo/commitinfo.go
+++ b/internal/commitinfo/commitinfo.go
@@ -120,4 +120,4 @@ var parseCommitInfoFromCommitMessageRegexLookup = struct {
 	Type               int
 	ReleaseByEmail     int
 }{}
-var parseCommitInfoFromCommitMessageRegex = regexp.MustCompile(`^\[(?P<Environment>[^/]+)/(?P<Service>.*)\] (?P<Type>[a-z]+)( (?P<PreviousArtifactID>[^ ]+) to)? (?P<ArtifactID>[^ ]+)( by (?P<ReleaseByEmail>.*))?$`, &parseCommitInfoFromCommitMessageRegexLookup)
+var parseCommitInfoFromCommitMessageRegex = regexp.MustCompile(`^\[(?P<Environment>[^/]+)/(?P<Service>.*)\] (?P<Type>[a-z ]+)( (?P<PreviousArtifactID>[^ ]+) to)? (?P<ArtifactID>[^ ]+)( by (?P<ReleaseByEmail>.*))?$`, &parseCommitInfoFromCommitMessageRegexLookup)

--- a/internal/commitinfo/commitinfo_test.go
+++ b/internal/commitinfo/commitinfo_test.go
@@ -170,6 +170,30 @@ func TestParseCommitInfo(t *testing.T) {
 				Intent:            intent.NewAutoRelease(),
 			},
 		},
+		{
+			name: "single line commit message from flux for auto release commit",
+			commitMessage: []string{
+				"[dev/finance-manager] auto release master-2f20470a40-0f65a98846 by nko@lunar.app",
+			},
+			commitInfo: CommitInfo{
+				ArtifactID:        "master-2f20470a40-0f65a98846",
+				Environment:       "dev",
+				Service:           "finance-manager",
+				ArtifactCreatedBy: NewPersonInfo("", ""),
+				ReleasedBy:        NewPersonInfo("", "nko@lunar.app"),
+				Intent:            intent.NewAutoRelease(),
+			},
+			correctCommitMessage: []string{
+				"[dev/finance-manager] auto release master-2f20470a40-0f65a98846 by nko@lunar.app",
+				"",
+				"Service: finance-manager",
+				"Environment: dev",
+				"Artifact-ID: master-2f20470a40-0f65a98846",
+				"Artifact-released-by:  <nko@lunar.app>",
+				"Artifact-created-by:  <>",
+				"Release-intent: AutoRelease",
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/commitinfo/intent.go
+++ b/internal/commitinfo/intent.go
@@ -26,6 +26,11 @@ func parseIntent(cci ConventionalCommitInfo, commitMessageMatches []string) inte
 		if commitMessageMatches != nil && commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "rollback" {
 			return intent.NewRollback(commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.PreviousArtifactID])
 		}
+		// flux only publishes the first line of commit messages so there will not
+		// be an intent field.
+		if commitMessageMatches != nil && commitMessageMatches[parseCommitInfoFromCommitMessageRegexLookup.Type] == "auto release" {
+			return intent.NewAutoRelease()
+		}
 		return intent.NewReleaseArtifact()
 	}
 }


### PR DESCRIPTION
Flux only publishes the first line of commit messages when syncing. After the
introduction of multiline commit messages in the release-manager and the shared
handling of commit parsing in package commitinfo we broke the notifications for
running pods.

This change fixes the byg by handling commits of type "auto release" separatly
when parsing the intent.

The regex used to parse the commit info is also updated to allow multi word
"types", e.g. "auto release".

Lastly logs of flux's event.Event type is expanded to all fields instead of its
String implementation. Currently a prettyfied string is shown in the logs
instead of the complete contents.