### PR TITLE
Add amqpextra reconnecting broker implementation

### DIFF
--- a/cmd/amqp/main.go
+++ b/cmd/amqp/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"math/rand"
+	"sync"
+
+	"github.com/streadway/amqp"
+)
+
+// main is a CLI for publishing messages to a RabbitMQ cluster. It is used to
+// test load scenarios against a running RabbitMQ instance/cluster.
+//
+// Use flag count and size to define how many and how large the messages to
+// publish should be.
+func main() {
+	size := flag.Int("size", 10, "Size of payload in bytes")
+	count := flag.Int("count", 10, "Number of messages to publish")
+	flag.Parse()
+
+	amqpConn, err := amqp.DialConfig("amqp://lunar:lunar@localhost:5672", amqp.Config{
+		Vhost: "/",
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer amqpConn.Close()
+
+	channel, err := amqpConn.Channel()
+	if err != nil {
+		panic(err)
+	}
+	defer channel.Close()
+	err = channel.ExchangeDeclare("amqp-load", "topic", true, false, false, false, nil)
+	if err != nil {
+		panic(err)
+	}
+	_, err = channel.QueueDeclare("load", true, false, false, false, nil)
+	if err != nil {
+		panic(err)
+	}
+	err = channel.QueueBind("load", "#", "amqp-load", false, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(*count)
+	log.Printf("Publishing %d messages", *count)
+	p := payload(*size)
+	for i := 0; i < *count; i++ {
+		go func() {
+			defer wg.Done()
+			err = channel.Publish("amqp-load", "load", false, false, amqp.Publishing{
+				Body: p,
+			})
+			if err != nil {
+				panic(err)
+			}
+		}()
+	}
+	log.Printf("Waiting for publications to complete")
+	wg.Wait()
+}
+
+func payload(i int) []byte {
+	p := make([]byte, i)
+	_, err := rand.Read(p)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -122,7 +122,6 @@ func registerBrokerFlags(cmd *cobra.Command, c *brokerOptions) {
 	cmd.PersistentFlags().StringVar(&c.AMQP.Password, "amqp-password", "", "AMQP password")
 	cmd.PersistentFlags().StringVar(&c.AMQP.VirtualHost, "amqp-virtualhost", "/", "AMQP virtual host")
 	cmd.PersistentFlags().DurationVar(&c.AMQP.ReconnectionTimeout, "amqp-reconnection-timeouts", 5*time.Second, "AMQP reconnection attempt timeout")
-	cmd.PersistentFlags().DurationVar(&c.AMQP.RepublishTimeout, "amqp-republish-timeouts", 1*time.Second, "AMQP republish attempt timeout used if a publish fails or publish confirmations are not received")
 	cmd.PersistentFlags().IntVar(&c.AMQP.Prefetch, "amqp-prefetch", 1, "AMQP queue prefetch")
 	cmd.PersistentFlags().StringVar(&c.AMQP.Exchange, "amqp-exchange", "release-manager", "AMQP exchange")
 	cmd.PersistentFlags().StringVar(&c.AMQP.Queue, "amqp-queue", "release-manager", "AMQP queue")

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -74,7 +74,6 @@ type amqpOptions struct {
 	Port                int
 	VirtualHost         string
 	ReconnectionTimeout time.Duration
-	RepublishTimeout    time.Duration
 	Prefetch            int
 	Exchange            string
 	Queue               string
@@ -417,7 +416,6 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 				Port:        amqpOptions.Port,
 			},
 			ReconnectionTimeout: amqpOptions.ReconnectionTimeout,
-			RepublishTimeout:    amqpOptions.RepublishTimeout,
 			Exchange:            amqpOptions.Exchange,
 			Queue:               amqpOptions.Queue,
 			RoutingKey:          "#",

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lunarway/release-manager/cmd/server/gpg"
 	"github.com/lunarway/release-manager/cmd/server/http"
 	"github.com/lunarway/release-manager/internal/broker"
-	"github.com/lunarway/release-manager/internal/broker/amqp"
+	"github.com/lunarway/release-manager/internal/broker/amqpextra"
 	"github.com/lunarway/release-manager/internal/broker/memory"
 	"github.com/lunarway/release-manager/internal/flow"
 	"github.com/lunarway/release-manager/internal/git"
@@ -408,8 +408,8 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 	case BrokerTypeAMQP:
 		amqpOptions := c.AMQP
 		log.Info("Using an AMQP broker")
-		return amqp.NewWorker(amqp.Config{
-			Connection: amqp.ConnectionConfig{
+		return amqpextra.New(amqpextra.Config{
+			Connection: amqpextra.ConnectionConfig{
 				Host:        amqpOptions.Host,
 				User:        amqpOptions.User,
 				Password:    amqpOptions.Password,

--- a/e2e-test/rabbitmq.yaml
+++ b/e2e-test/rabbitmq.yaml
@@ -15,6 +15,18 @@ spec:
       port: 15672
       targetPort: 15672
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: rabbitmq
+data:
+  rabbitmq.conf: |
+    default_user = lunar
+    default_pass = lunar
+    # watermark is set above k8s limits to simulate OOMKilled under heavy load
+    vm_memory_high_watermark.absolute = 1000MB
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,14 +51,18 @@ spec:
         app: rabbitmq
         type: deployment
     spec:
+      volumes:
+        - name: config
+          configMap:
+            name: rabbitmq
+        - name: data
+          emptyDir: {}
       containers:
         - name: rabbitmq
           image: rabbitmq:3-management
           env:
-            - name: RABBITMQ_DEFAULT_USER
-              value: lunar
-            - name: RABBITMQ_DEFAULT_PASS
-              value: lunar
+            - name: RABBITMQ_CONFIG_FILE
+              value: /etc/rabbitmq-config/rabbitmq
           ports:
             - name: amqp
               containerPort: 5672
@@ -54,3 +70,14 @@ spec:
             - name: admin
               containerPort: 15672
               hostPort: 15672
+          resources:
+            requests:
+              memory: "384Mi"
+            limits:
+              memory: "384Mi"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/rabbitmq-config
+            # support durable queues across restarts
+            - name: data
+              mountPath: /var/lib/rabbitmq

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/gorilla/websocket v1.4.1
 	github.com/lunarway/color v1.7.0
+	github.com/makasim/amqpextra v0.14.3
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/makasim/amqpextra v0.14.3 h1:tc47uFSxZFzaDsjxaXNpMXXTkW4ajRb9axwFm2QTsDM=
+github.com/makasim/amqpextra v0.14.3/go.mod h1:T3kPpCDBs0F4cwc44SIL+zmfEcGQy9O08/QTq/VB+Ys=
 github.com/manifoldco/promptui v0.7.0 h1:3l11YT8tm9MnwGFQ4kETwkzpAwY2Jt9lCrumCUW4+z4=
 github.com/manifoldco/promptui v0.7.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
@@ -589,6 +591,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
+github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71 h1:2MR0pKUzlP3SGgj5NYJe/zRYDwOu9ku6YHy+Iw7l5DM=
 github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -648,6 +651,7 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0 h1:f3WCSC2KzAcBXGATIxAB1E2XuCpNU255wNKZ505qi3E=
@@ -820,6 +824,7 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c h1:IGkKhmfzcztjm6gYkykvu/N
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191203044616-8db96347c98b h1:Sy1DjH/r7cGw1YgmYpyjq2Px1NC4ja8wTxcEwHkuIiI=
 golang.org/x/tools v0.0.0-20191203044616-8db96347c98b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/broker/amqpextra/amqpextra.go
+++ b/internal/broker/amqpextra/amqpextra.go
@@ -1,0 +1,87 @@
+package amqpextra
+
+import (
+	"time"
+
+	"github.com/makasim/amqpextra"
+	"github.com/streadway/amqp"
+)
+
+// Worker is a RabbitMQ consumer and publisher. It configures an AMQP channel to
+// consume messages from a queue along with a publisher to publish messages to
+// an exchange.
+//
+// It transparently recovers from connection failures and publishes are blocked
+// during recovery.
+type Worker struct {
+	conn      *amqpextra.Connection
+	consumer  *amqpextra.Consumer
+	publisher *amqpextra.Publisher
+	config    Config
+}
+
+// New allocates, intializes and returns a new Worker instance.
+func New(c Config) (*Worker, error) {
+	logger := c.Logger.WithFields(
+		"host", c.Connection.Host,
+		"user", c.Connection.User,
+		"port", c.Connection.Port,
+		"virtualHost", c.Connection.VirtualHost,
+		"exchange", c.Exchange,
+		"queue", c.Queue,
+		"prefetch", c.Prefetch,
+		"reconnectionTimeout", c.ReconnectionTimeout,
+	)
+
+	logger.Infof("Connecting to: %s", c.Connection.String())
+
+	conn := amqpextra.DialConfig([]string{c.Connection.Raw()}, amqp.Config{
+		Heartbeat: 60 * time.Second,
+		Vhost:     c.Connection.VirtualHost,
+	})
+	conn.SetLogger(newLogger(c.Logger))
+	conn.SetReconnectSleep(c.ReconnectionTimeout)
+
+	<-conn.Ready()
+
+	w := &Worker{
+		conn:      conn,
+		config:    c,
+		publisher: conn.Publisher(),
+	}
+	err := w.declareExchange()
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *Worker) declareExchange() error {
+	amqpConn, err := w.conn.Conn()
+	if err != nil {
+		return err
+	}
+	channel, err := amqpConn.Channel()
+	if err != nil {
+		return err
+	}
+	err = channel.ExchangeDeclare(
+		w.config.Exchange,
+		"topic", // kind
+		true,    // durable
+		false,   // autoDelete
+		false,   // internal
+		false,   // noWait
+		nil,     // args
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the worker stopping any active consumers and publishes.
+func (w *Worker) Close() error {
+	w.conn.Close()
+	return nil
+}

--- a/internal/broker/amqpextra/config.go
+++ b/internal/broker/amqpextra/config.go
@@ -1,0 +1,39 @@
+package amqpextra
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lunarway/release-manager/internal/log"
+)
+
+// Config configures a worker.
+type Config struct {
+	Connection          ConnectionConfig
+	Exchange            string
+	Queue               string
+	RoutingKey          string
+	Prefetch            int
+	ReconnectionTimeout time.Duration
+	Logger              *log.Logger
+}
+
+// ConnectionConfig configures an AMQP connection.
+type ConnectionConfig struct {
+	Host        string
+	User        string
+	Password    string
+	VirtualHost string
+	Port        int
+}
+
+// Raw returns a raw connection string used to dial. Notice that this will
+// reveal the password if the result is logged.
+func (c *ConnectionConfig) Raw() string {
+	return fmt.Sprintf("amqp://%s:%s@%s:%d/%s", c.User, c.Password, c.Host, c.Port, c.VirtualHost)
+}
+
+// String returns a masked connection string safe for logging.
+func (c *ConnectionConfig) String() string {
+	return fmt.Sprintf("amqp://%s:%s@%s:%d/%s", c.User, "***", c.Host, c.Port, c.VirtualHost)
+}

--- a/internal/broker/amqpextra/consumer.go
+++ b/internal/broker/amqpextra/consumer.go
@@ -1,0 +1,63 @@
+package amqpextra
+
+import (
+	"github.com/lunarway/release-manager/internal/broker"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+)
+
+// StartConsumer consumes messages from an AMQP queue. The method is blocking
+// and will always return with ErrBrokerClosed after calls to Close. In case an
+// event is dropped after failed handlings and redelivery func eventDropped is
+// called.
+//
+// The workers configured queue is declared on startup along with a binding to
+// the exchange with routing key.
+func (w *Worker) StartConsumer(handlers map[string]func([]byte) error, eventDropped func(msgType string, msgBody []byte, err error)) error {
+	w.consumer = w.conn.Consumer(w.config.Queue, &mux{
+		handlers:     handlers,
+		log:          w.config.Logger,
+		eventDropped: eventDropped,
+	})
+	w.consumer.Use(loggerMiddleware(w.config.Logger))
+	defer w.consumer.Close()
+
+	w.consumer.SetInitFunc(func(conn *amqp.Connection) (*amqp.Channel, <-chan amqp.Delivery, error) {
+		channel, err := conn.Channel()
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "create channel")
+		}
+		_, err = channel.QueueDeclare(w.config.Queue, true, false, false, false, nil)
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "declare queue")
+		}
+
+		err = channel.QueueBind(w.config.Queue, w.config.RoutingKey, w.config.Exchange, false, nil)
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "bind to queue")
+		}
+
+		err = channel.Qos(w.config.Prefetch, 0, false)
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "set qos on queue")
+		}
+
+		msgCh, err := channel.Consume(
+			w.config.Queue,
+			"",
+			false,
+			false,
+			false,
+			false,
+			nil,
+		)
+		if err != nil {
+			return nil, nil, errors.WithMessage(err, "consume messages")
+		}
+
+		return channel, msgCh, nil
+	})
+	w.consumer.Run()
+
+	return broker.ErrBrokerClosed
+}

--- a/internal/broker/amqpextra/consumer_middleware.go
+++ b/internal/broker/amqpextra/consumer_middleware.go
@@ -1,0 +1,49 @@
+package amqpextra
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/makasim/amqpextra"
+	"github.com/streadway/amqp"
+)
+
+func loggerMiddleware(logger *log.Logger) func(w amqpextra.Worker) amqpextra.Worker {
+	return func(w amqpextra.Worker) amqpextra.Worker {
+		return amqpextra.WorkerFunc(func(ctx context.Context, msg amqp.Delivery) interface{} {
+			logger := logger.With(
+				"routingKey", msg.RoutingKey,
+				"messageId", msg.MessageId,
+				"eventType", msg.Type,
+				"correlationId", msg.CorrelationId,
+				"redelivered", msg.Redelivered,
+				"headers", fmt.Sprintf("%#v", msg.Headers),
+			)
+			logger.Infof("[consumer] Received message type=%s from exchange=%s routingKey=%s messageId=%s correlationId=%s timestamp=%s", msg.Type, msg.Exchange, msg.RoutingKey, msg.MessageId, msg.CorrelationId, msg.Timestamp)
+			now := time.Now()
+
+			err := w.ServeMsg(ctx, msg)
+
+			duration := time.Since(now).Milliseconds()
+
+			if err != nil {
+				res := map[string]interface{}{
+					"status":       "failed",
+					"responseTime": duration,
+					"error":        fmt.Sprintf("%+v", err),
+					"redelivered":  msg.Redelivered,
+				}
+				logger.With("res", res).Errorf("[consumer] [FAILED] Failed to handle message: %v", err)
+				return err
+			}
+			logger.With("res", map[string]interface{}{
+				"status":       "ok",
+				"responseTime": duration,
+				"redelivered":  msg.Redelivered,
+			}).Info("[consumer] [OK] Event handled successfully")
+			return nil
+		})
+	}
+}

--- a/internal/broker/amqpextra/consumer_mux.go
+++ b/internal/broker/amqpextra/consumer_mux.go
@@ -1,0 +1,56 @@
+package amqpextra
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/makasim/amqpextra"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+)
+
+// mux implements interface amqpextra.Worker  and facilitates message
+// multiplexing to message handlers based on message type.
+type mux struct {
+	handlers     map[string]func([]byte) error
+	log          *log.Logger
+	eventDropped func(msgType string, msgBody []byte, err error)
+}
+
+var _ amqpextra.Worker = &mux{}
+
+func (m mux) ServeMsg(ctx context.Context, msg amqp.Delivery) interface{} {
+	handler, ok := m.handlers[msg.Type]
+	if !ok {
+		m.nack(msg, false, "no handler")
+		return fmt.Errorf("unprocessable event type '%s': event dropped", msg.Type)
+	}
+
+	err := handler(msg.Body)
+	if err != nil {
+		if msg.Redelivered {
+			m.eventDropped(msg.Type, msg.Body, err)
+			m.nack(msg, false, "nack without requeue due redelivery failed")
+			return errors.WithMessage(err, "messaged dropped")
+		}
+		m.nack(msg, true, "nack with requeue failed")
+		return errors.WithMessage(err, "message requeued")
+	}
+	m.ack(msg)
+	return nil
+}
+
+func (m mux) ack(msg amqp.Delivery) {
+	err := msg.Nack(false, false)
+	if err != nil {
+		m.log.Errorf("ack failed for event '%s': %v", msg.Type, err)
+	}
+}
+
+func (m mux) nack(msg amqp.Delivery, requeue bool, reason string) {
+	err := msg.Nack(false, requeue)
+	if err != nil {
+		m.log.Errorf("%s for event '%s': %v", reason, msg.Type, err)
+	}
+}

--- a/internal/broker/amqpextra/logger.go
+++ b/internal/broker/amqpextra/logger.go
@@ -1,0 +1,33 @@
+package amqpextra
+
+import (
+	"strings"
+
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/makasim/amqpextra"
+)
+
+// newLogger returns an amqpextra.LoggerFunc that logs with levels to l based on
+// the format prefix of the logged lines.
+func newLogger(l *log.Logger) amqpextra.LoggerFunc {
+	// prefixes of log lines from github.com/makasim/amqpextra
+	var (
+		debugPrefix = "[DEBUG]"
+		warnPrefix  = "[WARN]"
+		errorPrefix = "[ERROR]"
+	)
+	return func(format string, args ...interface{}) {
+		if strings.HasPrefix(format, debugPrefix) {
+			l.Debugf(strings.TrimPrefix(format, debugPrefix), args...)
+			return
+		}
+		if strings.HasPrefix(format, warnPrefix) {
+			l.Infof(strings.TrimPrefix(format, warnPrefix), args...)
+			return
+		}
+		if strings.HasPrefix(format, errorPrefix) {
+			l.Errorf(strings.TrimPrefix(format, errorPrefix), args...)
+			return
+		}
+	}
+}

--- a/internal/broker/amqpextra/publish.go
+++ b/internal/broker/amqpextra/publish.go
@@ -1,0 +1,88 @@
+package amqpextra
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lunarway/release-manager/internal/broker"
+	"github.com/lunarway/release-manager/internal/tracing"
+	"github.com/makasim/amqpextra"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+)
+
+// Publish publishes a Publishable message to AMQP. It will block until the
+// message is confirmed on the server. In case of connection failures the method
+// will block until connection is restored and message has been confirmed on the
+// server.
+//
+// If ctx is cancelled before completing the publish the operation is cancelled.
+func (w *Worker) Publish(ctx context.Context, message broker.Publishable) error {
+	correlationID := tracing.RequestIDFromContext(ctx)
+	messageType := message.Type()
+	messageID, err := uuid.NewRandom()
+	if err != nil {
+		w.config.Logger.Errorf("Failed to create a correlation ID. Continues execution: %v", err)
+	}
+	body, err := message.Marshal()
+	if err != nil {
+		return errors.WithMessage(err, "marshal message")
+	}
+
+	logger := w.config.Logger.With(
+		"body", message,
+		"routingKey", w.config.RoutingKey,
+		"messageId", messageID,
+		"eventType", messageType,
+		"correlationId", correlationID,
+	)
+	logger.Infof("[publisher] Publishing message type=%s from exchange=%s routingKey=%s messageId=%s correlationId=%s", messageType, w.config.Exchange, w.config.RoutingKey, messageID, correlationID)
+
+	now := time.Now()
+
+	resultCh := make(chan error, 1)
+	w.publisher.Publish(amqpextra.Publishing{
+		Context:   ctx,
+		Exchange:  w.config.Exchange,
+		Key:       w.config.RoutingKey,
+		Immediate: false,
+		Mandatory: false,
+		WaitReady: true, // wait for the publisher to be ready instead of returning an error.
+		ResultCh:  resultCh,
+		Message: amqp.Publishing{
+			Type:          message.Type(),
+			Body:          body,
+			MessageId:     messageID.String(),
+			CorrelationId: correlationID,
+			ContentType:   "application/json",
+			DeliveryMode:  amqp.Persistent, // this ensures messages are persisted to disk
+		},
+	})
+	err = <-resultCh
+
+	duration := time.Since(now).Milliseconds()
+
+	if err != nil {
+		logger.With(
+			"messageId", messageID,
+			"eventType", messageType,
+			"correlationId", tracing.RequestIDFromContext(ctx),
+			"res", map[string]interface{}{
+				"status":       "failed",
+				"responseTime": duration,
+				"error":        err,
+			}).Errorf("[publisher] [FAILED] Failed to publish message: %v", err)
+		return errors.WithMessage(err, "publish message")
+	}
+
+	logger.With(
+		"messageId", messageID,
+		"eventType", messageType,
+		"correlationId", tracing.RequestIDFromContext(ctx),
+		"res", map[string]interface{}{
+			"status":       "ok",
+			"responseTime": duration,
+		}).Info("[publisher] [OK] Published message successfully")
+	return nil
+}


### PR DESCRIPTION
Currently the amqp broker implementation looses connectivity if the RabbitMQ
instance it is connected to gets OOMKilled in kubernetes.

Instead of trying to fix the complex reconnection logic in package amqp the
module github.com/makasim/amqpextra is adds as a dependency. It transparently
handles reconnections correctly along with simplifying our own implementation by
orders of magnitude.

The behaviour is the same as package amqp and the broker has been replaced in
the server start command.

A utility CLI amqp is added used to simulate workloads on a RabbitMQ instance.
It is used to flood the instance while the server is connected to RabbitMQ and
ensure that we recover correctly after OOMKilled events.