### PR TITLE
feature/Release Manager Url Environment Variable

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -3,7 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"os"
+	"golang.org/x/tools/go/ssa/interp/testdata/src/os"
 	"path"
 
 	"github.com/lunarway/release-manager/internal/flow"
@@ -48,8 +48,8 @@ func pushCommand(options *Options) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&releaseManagerClient.BaseURL, "http-base-url", os.Getenv("HAMCTL_URL"), "address of the http release manager server")
-	command.Flags().StringVar(&releaseManagerClient.Metadata.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
+	command.Flags().StringVar(&releaseManagerClient.BaseURL, "http-base-url", os.Getenv("ARTIFACT_URL"), "address of the http release manager server")
+	command.Flags().StringVar(&releaseManagerClient.Metadata.AuthToken, "http-auth-token", "", "auth token for the http service")
 
 	// errors are skipped here as the only case they can occour are if thee flag
 	// does not exist on the command.

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 
 	"github.com/lunarway/release-manager/internal/flow"
@@ -47,8 +48,8 @@ func pushCommand(options *Options) *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&releaseManagerClient.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
-	command.Flags().StringVar(&releaseManagerClient.Metadata.AuthToken, "http-auth-token", "", "auth token for the http service")
+	command.Flags().StringVar(&releaseManagerClient.BaseURL, "http-base-url", os.Getenv("HAMCTL_URL"), "address of the http release manager server")
+	command.Flags().StringVar(&releaseManagerClient.Metadata.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 
 	// errors are skipped here as the only case they can occour are if thee flag
 	// does not exist on the command.

--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -3,7 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"golang.org/x/tools/go/ssa/interp/testdata/src/os"
+	"os"
 	"path"
 
 	"github.com/lunarway/release-manager/internal/flow"

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -34,6 +34,15 @@ func NewCommand(version *string) (*cobra.Command, error) {
 			defaultShuttleString(shuttleSpecFromFile, &service, func(s *shuttleSpec) string {
 				return s.Vars.Service
 			})
+
+			if client.BaseURL == "" {
+				client.BaseURL = os.Getenv("HAMCTL_URL")
+			}
+
+			if client.Metadata.AuthToken == "" {
+				client.Metadata.AuthToken = os.Getenv("HAMCTL_AUTH_TOKEN")
+			}
+
 			var missingFlags []string
 			if service == "" {
 				missingFlags = append(missingFlags, "service")
@@ -44,10 +53,12 @@ func NewCommand(version *string) (*cobra.Command, error) {
 					missingFlags = append(missingFlags, "user-email")
 				}
 			}
+
 			client.Metadata.CallerEmail = email
 			if len(missingFlags) != 0 {
 				return errors.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlags, `", "`))
 			}
+
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {
@@ -62,10 +73,12 @@ func NewCommand(version *string) (*cobra.Command, error) {
 	command.AddCommand(NewDescribe(&client, &service))
 	command.AddCommand(NewCompletion(command))
 	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 120*time.Second, "HTTP request timeout")
-	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", os.Getenv("HAMCTL_URL"), "address of the http release manager server")
-	command.PersistentFlags().StringVar(&client.Metadata.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
+	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "", "address of the http release manager server")
+	command.PersistentFlags().StringVar(&client.Metadata.AuthToken, "http-auth-token", "", "auth token for the http service")
 	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")
 	command.PersistentFlags().StringVar(&email, "user-email", "", "email of user performing the command (defaults to Git configurated user.email)")
+
+
 	return command, nil
 }
 

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -53,12 +53,10 @@ func NewCommand(version *string) (*cobra.Command, error) {
 					missingFlags = append(missingFlags, "user-email")
 				}
 			}
-
 			client.Metadata.CallerEmail = email
 			if len(missingFlags) != 0 {
 				return errors.Errorf(`required flag(s) "%s" not set`, strings.Join(missingFlags, `", "`))
 			}
-
 			return nil
 		},
 		Run: func(c *cobra.Command, args []string) {

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -62,7 +62,7 @@ func NewCommand(version *string) (*cobra.Command, error) {
 	command.AddCommand(NewDescribe(&client, &service))
 	command.AddCommand(NewCompletion(command))
 	command.PersistentFlags().DurationVar(&client.Timeout, "http-timeout", 120*time.Second, "HTTP request timeout")
-	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", "https://release-manager.dev.lunarway.com", "address of the http release manager server")
+	command.PersistentFlags().StringVar(&client.BaseURL, "http-base-url", os.Getenv("HAMCTL_URL"), "address of the http release manager server")
 	command.PersistentFlags().StringVar(&client.Metadata.AuthToken, "http-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "auth token for the http service")
 	command.PersistentFlags().StringVar(&service, "service", "", "service name to execute commands for")
 	command.PersistentFlags().StringVar(&email, "user-email", "", "email of user performing the command (defaults to Git configurated user.email)")


### PR DESCRIPTION
These changes enable us to change the release manager url via environment variables instead of defaulting to the dev 
lunarway release manager

** Caution **

We need to make sure that the environment variable is set. Otherwise the cli will stop working


- Set http url default value based on os env variable
- Updated push artifact command to also use default os env variables
