### PR TITLE
Use native Git for reading configuration

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -1,0 +1,50 @@
+package git
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// CommitterDetails returns name and email read for a Git configuration file.
+//
+// Fetching the configuration values are delegated to the git CLI and follows
+// precedence rules defined by Git.
+func CommitterDetails() (string, string, error) {
+	name, err := getGitConfig("user.name")
+	if err != nil {
+		return "", "", errors.WithMessage(err, "Failed to get credentials with 'git config --get user.name'")
+	}
+	email, err := getGitConfig("user.email")
+	if err != nil {
+		return "", "", errors.WithMessage(err, "Failed to get credentials with 'git config --get user.email'")
+	}
+	return name, email, nil
+}
+
+// getGitConfig reads a git configuration field and returns its value as a
+// string.
+func getGitConfig(field string) (string, error) {
+	cmd := exec.Command("git", "config", "--get", field)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", errors.WithMessage(err, "get stdout pipe for command")
+	}
+	err = cmd.Start()
+	if err != nil {
+		return "", errors.WithMessage(err, "start command")
+	}
+	stdoutData, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		return "", errors.WithMessage(err, "read stdout data of command")
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(stdoutData)), nil
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,82 +3,8 @@ package git
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestCredentials(t *testing.T) {
-	tt := []struct {
-		name     string
-		paths    []string
-		userName string
-		email    string
-		err      error
-	}{
-		{
-			name: "complete set",
-			paths: []string{
-				"testdata/user_set_1",
-			},
-			userName: "Foo",
-			email:    "foo@foo.com",
-			err:      nil,
-		},
-		{
-			name: "first path missing email",
-			paths: []string{
-				"testdata/email_missing",
-				"testdata/user_set_1",
-			},
-			userName: "Foo",
-			email:    "foo@foo.com",
-			err:      nil,
-		},
-		{
-			name: "first path missing name",
-			paths: []string{
-				"testdata/name_missing",
-				"testdata/user_set_1",
-			},
-			userName: "Foo",
-			email:    "foo@foo.com",
-			err:      nil,
-		},
-		{
-			name: "configuration file not found in first path",
-			paths: []string{
-				"testdata/unknown_path",
-				"testdata/user_set_1",
-			},
-			userName: "Foo",
-			email:    "foo@foo.com",
-			err:      nil,
-		},
-		{
-			name: "configuration file not found in all paths",
-			paths: []string{
-				"testdata/unknown_path_1",
-				"testdata/unknown_path_2",
-			},
-			userName: "",
-			email:    "",
-			err:      errors.New("failed to read Git credentials from paths: [testdata/unknown_path_1 testdata/unknown_path_2]"),
-		},
-	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			userName, email, err := credentials(tc.paths...)
-			t.Logf("error: %v", err)
-			if tc.err != nil {
-				assert.EqualError(t, err, tc.err.Error(), "output error not as expected")
-			} else {
-				assert.NoError(t, err, "unexpected output error")
-			}
-			assert.Equal(t, tc.userName, userName, "user name not as expected")
-			assert.Equal(t, tc.email, email, "email not as expected")
-		})
-	}
-}
 
 func TestLocateReleaseCondition(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
Currently we use go-git to parse Git configuration, but the parsing is based on
static file lookups in a local .git/config file or the blobal .gitconfig. This
does not support Git's includeIf directives and also make hierarchical
configuraiton unusable by hamctl.

This change introduces use of the git CLI instead and thus delegates precedence
rules to native Git. This adds support for includeIf along with also making it
simpler to understand how it is done.