### PR TITLE
Remove github.com/weaveworks/flux dependency

### DIFF
--- a/cmd/daemon/flux/exporter.go
+++ b/cmd/daemon/flux/exporter.go
@@ -5,20 +5,19 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/lunarway/release-manager/internal/flux"
 	httpinternal "github.com/lunarway/release-manager/internal/http"
-
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/weaveworks/flux/event"
 )
 
 type Message struct {
-	Event event.Event
+	Event flux.Event
 }
 
 // Exporter sends a formatted event to an upstream.
 type Exporter interface {
 	// Send a message through the exporter.
-	Send(c context.Context, event event.Event) error
+	Send(c context.Context, event flux.Event) error
 }
 type ReleaseManagerExporter struct {
 	Log         *log.Logger
@@ -26,7 +25,7 @@ type ReleaseManagerExporter struct {
 	Client      httpinternal.Client
 }
 
-func (f *ReleaseManagerExporter) Send(_ context.Context, event event.Event) error {
+func (f *ReleaseManagerExporter) Send(_ context.Context, event flux.Event) error {
 	f.Log.With("event", fmt.Sprintf("%#v", event)).Infof("flux event logged")
 	var resp httpinternal.FluxNotifyResponse
 	url, err := f.Client.URL("webhook/daemon/flux")

--- a/cmd/daemon/flux/fake_exporter_test.go
+++ b/cmd/daemon/flux/fake_exporter_test.go
@@ -3,14 +3,14 @@ package flux_test
 import (
 	"context"
 
-	"github.com/weaveworks/flux/event"
+	"github.com/lunarway/release-manager/internal/flux"
 )
 
 type FakeExporter struct {
-	Sent []event.Event
+	Sent []flux.Event
 }
 
-func (f *FakeExporter) Send(_ context.Context, event event.Event) error {
+func (f *FakeExporter) Send(_ context.Context, event flux.Event) error {
 	f.Sent = append(f.Sent, event)
 	return nil
 }

--- a/cmd/daemon/flux/v6.go
+++ b/cmd/daemon/flux/v6.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/weaveworks/flux/event"
+	"github.com/lunarway/release-manager/internal/flux"
 )
 
 // HandleV6 Flux events
@@ -35,8 +35,8 @@ func HandleV6(api API) {
 }
 
 // ParseFluxEvent for doing flux event from Json into a flux Event struct.
-func ParseFluxEvent(reader io.Reader) (event.Event, error) {
-	var evt event.Event
+func ParseFluxEvent(reader io.Reader) (flux.Event, error) {
+	var evt flux.Event
 	err := json.NewDecoder(reader).Decode(&evt)
 	return evt, err
 }

--- a/cmd/daemon/flux/v6_test.go
+++ b/cmd/daemon/flux/v6_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/lunarway/release-manager/cmd/daemon/flux"
+	intflux "github.com/lunarway/release-manager/internal/flux"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/stretchr/testify/assert"
-	"github.com/weaveworks/flux/event"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -54,7 +54,7 @@ func TestFluxEventsMocks(t *testing.T) {
 	NewFluxUpdatePolicyEvent()
 }
 
-func NewFluxSyncEvent() event.Event {
+func NewFluxSyncEvent() intflux.Event {
 	evt, _ := flux.ParseFluxEvent(bytes.NewBufferString(`{
     "id": 0,
     "serviceIDs": [
@@ -80,7 +80,7 @@ func NewFluxSyncEvent() event.Event {
 	return evt
 }
 
-func NewFluxSyncErrorEvent() event.Event {
+func NewFluxSyncErrorEvent() intflux.Event {
 	evt, _ := flux.ParseFluxEvent(bytes.NewBufferString(`{
   "id": 0,
   "serviceIDs": [
@@ -118,7 +118,7 @@ func NewFluxSyncErrorEvent() event.Event {
 	return evt
 }
 
-func NewFluxCommitEvent() event.Event {
+func NewFluxCommitEvent() intflux.Event {
 	evt, _ := flux.ParseFluxEvent(bytes.NewBufferString(`{
     "id": 0,
     "serviceIDs": [
@@ -157,7 +157,7 @@ func NewFluxCommitEvent() event.Event {
 	return evt
 }
 
-func NewFluxAutoReleaseEvent() event.Event {
+func NewFluxAutoReleaseEvent() intflux.Event {
 	evt, _ := flux.ParseFluxEvent(bytes.NewBufferString(`{
     "id": 0,
     "serviceIDs": [
@@ -199,7 +199,7 @@ func NewFluxAutoReleaseEvent() event.Event {
 	return evt
 }
 
-func NewFluxUpdatePolicyEvent() event.Event {
+func NewFluxUpdatePolicyEvent() intflux.Event {
 	evt, _ := flux.ParseFluxEvent(bytes.NewBufferString(`{
     "id": 0,
     "serviceIDs": [

--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,12 @@ go 1.13
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
-	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/aws/aws-sdk-go v1.36.8
 	github.com/cyphar/filepath-securejoin v0.2.2
-	github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 // indirect
-	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.3.1 // indirect
-	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/lunarway/color v1.7.0
 	github.com/makasim/amqpextra v0.14.3
@@ -23,17 +19,14 @@ require (
 	github.com/nlopes/slack v0.6.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
-	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/common v0.15.0
-	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/streadway/amqp v1.0.1-0.20200716223359-e6b33f460591
 	github.com/stretchr/testify v1.6.1
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible
-	github.com/weaveworks/flux v0.0.0-20190411145155-fea56bc3feee
 	go.opencensus.io v0.22.5
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnl
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
-github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -172,12 +170,8 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 h1:yWHOI+vFjEsAakUTSrtqc/SAHrhSkmn48pqjidZX3QA=
-github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
-github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -398,8 +392,6 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -656,8 +648,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
-github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 h1:tFwafIEMf0B7NlcxV/zJ6leBIa81D3hgGSgsE5hCkOQ=
-github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -718,8 +708,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 h1:7YvPJVmEeFHR1Tj9sZEYsmarJEQfMVYpd/Vyy/A8dqE=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
-github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -818,8 +806,6 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/weaveworks/flux v0.0.0-20190411145155-fea56bc3feee h1:3Qf3d3xls38/EH9y1UyK7A/QwN7fFHSFVy/t03r34DA=
-github.com/weaveworks/flux v0.0.0-20190411145155-fea56bc3feee/go.mod h1:rr7ztBXPHDIsIF1qGlrNFaXEz4wuXgQqtYD7FlWKAn0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/internal/flux/flux.go
+++ b/internal/flux/flux.go
@@ -1,52 +1,26 @@
 package flux
 
-import (
-	"github.com/weaveworks/flux/event"
-	"github.com/weaveworks/flux/update"
-)
 
-func GetCommits(meta event.EventMetadata) []event.Commit {
+func GetCommits(meta EventMetadata) []Commit {
 	switch v := meta.(type) {
-	case *event.CommitEventMetadata:
-		return []event.Commit{
-			event.Commit{
+	case *CommitEventMetadata:
+		return []Commit{
+			{
 				Revision: v.Revision,
 			},
 		}
-	case *event.SyncEventMetadata:
+	case *SyncEventMetadata:
 		return v.Commits
 	default:
-		return []event.Commit{}
+		return []Commit{}
 	}
 }
 
-func GetResult(meta event.EventMetadata) update.Result {
+func GetErrors(meta EventMetadata) []ResourceError {
 	switch v := meta.(type) {
-	case *event.AutoReleaseEventMetadata:
-		return v.Result
-	case *event.ReleaseEventMetadata:
-		return v.Result
-	default:
-		return update.Result{}
-	}
-}
-
-func GetChangedImages(meta event.EventMetadata) []string {
-	switch v := meta.(type) {
-	case *event.AutoReleaseEventMetadata:
-		return v.Result.ChangedImages()
-	case *event.ReleaseEventMetadata:
-		return v.Result.ChangedImages()
-	default:
-		return []string{}
-	}
-}
-
-func GetErrors(meta event.EventMetadata) []event.ResourceError {
-	switch v := meta.(type) {
-	case *event.SyncEventMetadata:
+	case *SyncEventMetadata:
 		return v.Errors
 	default:
-		return []event.ResourceError{}
+		return []ResourceError{}
 	}
 }

--- a/internal/flux/upstream_event.go
+++ b/internal/flux/upstream_event.go
@@ -1,0 +1,160 @@
+package flux
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+/*
+	This file contains models copied from github.com/fluxcd/flux for deserializing
+	events from flux websocket connections. It is maintained here to limit the
+	import scope to only the fields we use and this limit transitive
+	dependenencies of the flux project.
+*/
+
+const (
+	EventCommit = "commit"
+	EventSync   = "sync"
+)
+
+type Event struct {
+	// Type is the type of event, usually "release" for now, but could be other
+	// things later
+	Type string `json:"type"`
+
+	// Metadata is Event.Type-specific metadata. If an event has no metadata,
+	// this will be nil.
+	Metadata EventMetadata `json:"metadata,omitempty"`
+}
+
+func (e Event) String() string {
+	switch e.Type {
+	case EventCommit:
+		metadata := e.Metadata.(*CommitEventMetadata)
+		svcStr := "<no changes>"
+		return fmt.Sprintf("Commit: %s, %s", shortRevision(metadata.Revision), svcStr)
+	case EventSync:
+		metadata := e.Metadata.(*SyncEventMetadata)
+		revStr := "<no revision>"
+		if 0 < len(metadata.Commits) && len(metadata.Commits) <= 2 {
+			revStr = shortRevision(metadata.Commits[0].Revision)
+		} else if len(metadata.Commits) > 2 {
+			revStr = fmt.Sprintf(
+				"%s..%s",
+				shortRevision(metadata.Commits[len(metadata.Commits)-1].Revision),
+				shortRevision(metadata.Commits[0].Revision),
+			)
+		}
+		svcStr := "no workloads changed"
+		return fmt.Sprintf("Sync: %s, %s", revStr, svcStr)
+	default:
+		return fmt.Sprintf("Unknown event: %s", e.Type)
+	}
+}
+
+func shortRevision(rev string) string {
+	if len(rev) <= 7 {
+		return rev
+	}
+	return rev[:7]
+}
+
+// CommitEventMetadata is the metadata for when new git commits are created
+type CommitEventMetadata struct {
+	Revision string `json:"revision,omitempty"`
+}
+
+// Commit represents the commit information in a sync event. We could
+// use git.Commit, but that would lead to an import cycle, and may
+// anyway represent coupling (of an internal API to serialised data)
+// that we don't want.
+type Commit struct {
+	Revision string `json:"revision"`
+	Message  string `json:"message"`
+}
+
+type ResourceError struct {
+	// ID    ID
+	Path  string
+	Error string
+}
+
+// SyncEventMetadata is the metadata for when new a commit is synced to the cluster
+type SyncEventMetadata struct {
+	Commits []Commit        `json:"commits,omitempty"`
+	Errors  []ResourceError `json:"errors,omitempty"`
+}
+
+type UnknownEventMetadata map[string]interface{}
+
+func (e *Event) UnmarshalJSON(in []byte) error {
+	type alias Event
+	var wireEvent struct {
+		*alias
+		MetadataBytes json.RawMessage `json:"metadata,omitempty"`
+	}
+	wireEvent.alias = (*alias)(e)
+
+	// Now unmarshall custom wireEvent with RawMessage
+	if err := json.Unmarshal(in, &wireEvent); err != nil {
+		return err
+	}
+	if wireEvent.Type == "" {
+		return errors.New("Event type is empty")
+	}
+
+	// The cases correspond to kinds of event that we care about
+	// processing e.g., for notifications.
+	switch wireEvent.Type {
+
+	case EventCommit:
+		var metadata CommitEventMetadata
+		if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+			return err
+		}
+		e.Metadata = &metadata
+		break
+	case EventSync:
+		var metadata SyncEventMetadata
+		if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+			return err
+		}
+		e.Metadata = &metadata
+		break
+	default:
+		if len(wireEvent.MetadataBytes) > 0 {
+			var metadata UnknownEventMetadata
+			if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+				return err
+			}
+			e.Metadata = metadata
+		}
+	}
+
+	// By default, leave the Event Metadata as map[string]interface{}
+	return nil
+}
+
+// EventMetadata is a type safety trick used to make sure that Metadata field
+// of Event is always a pointer, so that consumers can cast without being
+// concerned about encountering a value type instead. It works by virtue of the
+// fact that the method is only defined for pointer receivers; the actual
+// method chosen is entirely arbitrary.
+type EventMetadata interface {
+	Type() string
+}
+
+func (cem *CommitEventMetadata) Type() string {
+	return EventCommit
+}
+
+func (cem *SyncEventMetadata) Type() string {
+	return EventSync
+}
+
+// Special exception from pointer receiver rule, as UnknownEventMetadata is a
+// type alias for a map
+func (uem UnknownEventMetadata) Type() string {
+	return "unknown"
+}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/flux"
 	"github.com/lunarway/release-manager/internal/intent"
-	"github.com/weaveworks/flux/event"
 )
 
 type StatusRequest struct {
@@ -80,7 +80,7 @@ type FluxNotifyResponse struct {
 
 type FluxNotifyRequest struct {
 	Environment string `json:"environment,omitempty"`
-	FluxEvent   event.Event
+	FluxEvent   flux.Event
 }
 
 func (r FluxNotifyRequest) Validate(w http.ResponseWriter) bool {


### PR DESCRIPTION
Currently we depend on the github.com/weaveworks/flux module to parse flux
websocket events. We only rely on a couple of fields in the data model but
depend on all transitive dependencies of the flux project.

Further more the flux module has moved into github.com/fluxcd/flux after being
adopted by CNCF. A change in the new module structure does not allow us to
import the used packages anymore.

This change removes the dependency by copying the used models into this project.
It has little impact on readability but simplifies the dependency tree.