### PR TITLE
Upgrade Go to 1.15.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.13.x"
+- "1.15.6"
 script:
 - go build ./...
 - make integration-test VERBOSE=yes

--- a/Dockerfile-daemon
+++ b/Dockerfile-daemon
@@ -1,4 +1,4 @@
-FROM golang:1.13.5 as builder
+FROM golang:1.15.6 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.13.5 as builder
+FROM golang:1.15.6 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -25,4 +25,3 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /app/server .
 
 ENTRYPOINT [ "./server", "start" ]
-


### PR DESCRIPTION
Contains several minor changes to the standard library and the runtime. No
notable impact on our usage is expected.