### PR TITLE
Check error from release action

### DIFF
--- a/cmd/hamctl/command/describe.go
+++ b/cmd/hamctl/command/describe.go
@@ -67,6 +67,9 @@ Format the output with a custom template:
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			releasesResponse, err := actions.ReleasesFromEnvironment(client, *service, environment, count)
+			if err != nil {
+				return err
+			}
 			if len(template) == 0 {
 				template = describeReleaseDefaultTemplate
 			}


### PR DESCRIPTION
Currently if the describe releases action fails when running hamctl describe
release no error is reported but an empty describe output is shown. This happens
as the err is not checked from the action call in hamctl.

```
$ hamctl describe release --service svc --env test --http-base-url http://nonsence
Service:
Environment:
```

This change adds an error check.

```
$ hamctl describe release --service svc --env test --http-base-url http://nonsence
Error: could not connect to the release-manager server. Are you connected to the internet and, if required, a VPN?
```