### PR TITLE
Extract version command setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,20 @@ current_dir := $(dir $(mkfile_path))
 
 build: build_hamctl build_server build_artifact build_daemon
 
+VERSION=$(shell git rev-parse HEAD)
+GO_BUILD=go build -ldflags='-s -w -X main.version=$(VERSION)'
+
 build_artifact:
-	go build -o dist/artifact ./cmd/artifact
+	${GO_BUILD} -o dist/artifact ./cmd/artifact
 
 build_hamctl:
-	go build -o dist/hamctl ./cmd/hamctl
+	${GO_BUILD} -o dist/hamctl ./cmd/hamctl
 
 build_server:
-	go build -o dist/server ./cmd/server
+	${GO_BUILD} -o dist/server ./cmd/server
 
 build_daemon:
-	go build -o dist/daemon ./cmd/daemon
+	${GO_BUILD} -o dist/daemon ./cmd/daemon
 
 build_daemon_docker:
 ifeq ($(TAG),)

--- a/cmd/artifact/command/root.go
+++ b/cmd/artifact/command/root.go
@@ -13,8 +13,8 @@ type Options struct {
 	EmailSuffix     string
 }
 
-// NewCommand returns a new instance of a rm-gen-spec command.
-func NewCommand() (*cobra.Command, error) {
+// NewRoot returns a new instance of an artifact command.
+func NewRoot(version string) (*cobra.Command, error) {
 	var options Options
 	var command = &cobra.Command{
 		Use:   "artifact",
@@ -29,12 +29,15 @@ func NewCommand() (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&options.SlackToken, "slack-token", "", "slack token to be used for notifications")
 	command.PersistentFlags().StringVar(&options.MessageFileName, "message-file", "message.json", "file to store intermediate slack messages")
 	command.PersistentFlags().StringVar(&options.EmailSuffix, "email-suffix", "", "company email suffix to expect. E.g.: '@example.com'")
-	command.AddCommand(initCommand(&options))
-	command.AddCommand(endCommand(&options))
-	command.AddCommand(addCommand(&options))
-	command.AddCommand(pushCommand(&options))
-	command.AddCommand(failureCommand(&options))
-	command.AddCommand(successfulCommand(&options))
+	command.AddCommand(
+		addCommand(&options),
+		endCommand(&options),
+		failureCommand(&options),
+		initCommand(&options),
+		pushCommand(&options),
+		successfulCommand(&options),
+		versionCommand(version),
+	)
 	command.MarkFlagRequired("email-suffix")
 	return command, nil
 }

--- a/cmd/artifact/command/version.go
+++ b/cmd/artifact/command/version.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func versionCommand(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version number of artifact",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
+}

--- a/cmd/artifact/main.go
+++ b/cmd/artifact/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/artifact/command"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -21,19 +19,11 @@ func main() {
 		},
 		Development: false,
 	})
-	c, err := command.NewCommand()
+	c, err := command.NewRoot(version)
 	if err != nil {
 		log.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "prints the version number of artifact",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
-		},
-	}
-	c.AddCommand(versionCmd)
 	err = c.Execute()
 	if err != nil {
 		log.Errorf("Error: %v", err)

--- a/cmd/daemon/command/root.go
+++ b/cmd/daemon/command/root.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DaemonCommand returns a new instance of a daemon command.
-func DaemonCommand() (*cobra.Command, error) {
+// NewRoot returns a new instance of a daemon command.
+func NewRoot(version string) (*cobra.Command, error) {
 	var command = &cobra.Command{
 		Use:   "daemon",
 		Short: "daemon",
@@ -13,6 +13,9 @@ func DaemonCommand() (*cobra.Command, error) {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(StartDaemon())
+	command.AddCommand(
+		StartDaemon(),
+		NewVersion(version),
+	)
 	return command, nil
 }

--- a/cmd/daemon/command/version.go
+++ b/cmd/daemon/command/version.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersion(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version number of artifact",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
+}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/daemon/command"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -14,20 +12,11 @@ var (
 )
 
 func main() {
-	c, err := command.DaemonCommand()
+	c, err := command.NewRoot(version)
 	if err != nil {
 		log.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
-
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "prints the version number of artifact",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
-		},
-	}
-	c.AddCommand(versionCmd)
 	err = c.Execute()
 	if err != nil {
 		log.Errorf("Error: %v", err)

--- a/cmd/hamctl/command/version.go
+++ b/cmd/hamctl/command/version.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersion(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version number of hamctl",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
+}

--- a/cmd/hamctl/main.go
+++ b/cmd/hamctl/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/hamctl/command"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -13,19 +12,11 @@ var (
 )
 
 func main() {
-	c, err := command.NewCommand(&version)
+	c, err := command.NewRoot(&version)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "prints the version number of hamctl",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
-		},
-	}
-	c.AddCommand(versionCmd)
 	err = c.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand returns a new instance of a hamctl command.
-func NewCommand() (*cobra.Command, error) {
+// NewRoot returns a new instance of a hamctl command.
+func NewRoot(version string) (*cobra.Command, error) {
 	var brokerOpts brokerOptions
 	var httpOpts http.Options
 	var grafanaOpts grafanaOptions
@@ -59,21 +59,24 @@ func NewCommand() (*cobra.Command, error) {
 			c.HelpFunc()(c, args)
 		},
 	}
-	command.AddCommand(NewStart(&startOptions{
-		grafana:                   &grafanaOpts,
-		slackAuthToken:            &slackAuthToken,
-		githubAPIToken:            &githubAPIToken,
-		configRepo:                &configRepoOpts,
-		gitConfigOpts:             &gitConfigOpts,
-		s3storage:                 &s3storageOpts,
-		http:                      &httpOpts,
-		gpgKeyPaths:               &gpgKeyPaths,
-		broker:                    &brokerOpts,
-		slackMutes:                &slackMuteOpts,
-		userMappings:              &userMappings,
-		branchRestrictionPolicies: &branchRestrictions,
-		emailSuffix:               &emailSuffix,
-	}))
+	command.AddCommand(
+		NewStart(&startOptions{
+			grafana:                   &grafanaOpts,
+			slackAuthToken:            &slackAuthToken,
+			githubAPIToken:            &githubAPIToken,
+			configRepo:                &configRepoOpts,
+			gitConfigOpts:             &gitConfigOpts,
+			s3storage:                 &s3storageOpts,
+			http:                      &httpOpts,
+			gpgKeyPaths:               &gpgKeyPaths,
+			broker:                    &brokerOpts,
+			slackMutes:                &slackMuteOpts,
+			userMappings:              &userMappings,
+			branchRestrictionPolicies: &branchRestrictions,
+			emailSuffix:               &emailSuffix,
+		}),
+		NewVersion(version),
+	)
 	command.PersistentFlags().IntVar(&httpOpts.Port, "http-port", 8080, "port of the http server")
 	command.PersistentFlags().DurationVar(&httpOpts.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
 	command.PersistentFlags().StringVar(&httpOpts.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")

--- a/cmd/server/command/version.go
+++ b/cmd/server/command/version.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersion(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version number of release-manager",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/server/command"
 	"github.com/lunarway/release-manager/internal/log"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -17,20 +15,11 @@ func main() {
 	var logConfiguration *log.Configuration
 	logConfiguration.ParseFromEnvironmnet()
 	log.Init(logConfiguration)
-	c, err := command.NewCommand()
+	c, err := command.NewRoot(version)
 	if err != nil {
 		log.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
-
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "prints the version number of hamctl",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
-		},
-	}
-	c.AddCommand(versionCmd)
 	err = c.Execute()
 	if err != nil {
 		log.Errorf("Error: %v", err)


### PR DESCRIPTION
Currently the version commands are attached to the root commands unlike any
other of the commands. This is odd and unexpected.

This change moves the version commands into their own files and attaches them to
the root like every other command.

Furhter more the make targets for building the Go binaries are updated to
default to the current head git sha as version. This is mostly for testing but
also ensures that any distribution of a locally built binary is trackable.