### PR TITLE
[Spike] Enable platform env

### DIFF
--- a/cmd/hamctl/command/actions/artifact_id.go
+++ b/cmd/hamctl/command/actions/artifact_id.go
@@ -31,6 +31,8 @@ func ArtifactIDFromEnvironment(client *httpinternal.Client, service, namespace, 
 		return statusResp.Staging.Tag, nil
 	case "prod":
 		return statusResp.Prod.Tag, nil
+	case "platform":
+		return statusResp.Platform.Tag, nil
 	}
 
 	return "", fmt.Errorf("unknown environment %s", environment)

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -54,6 +54,9 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 
 			color.Green("prod:\n")
 			printStatus(resp.Prod)
+
+			color.Green("platform:\n")
+			printStatus(resp.Platform)
 			return nil
 		},
 	}

--- a/cmd/server/http/status.go
+++ b/cmd/server/http/status.go
@@ -70,6 +70,18 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 			LowVulnerabilities:    s.Prod.LowVulnerabilities,
 		}
 
+		platform := httpinternal.Environment{
+			Message:               s.Platform.Message,
+			Author:                s.Platform.Author,
+			Tag:                   s.Platform.Tag,
+			Committer:             s.Platform.Committer,
+			Date:                  convertTimeToEpoch(s.Platform.Date),
+			BuildUrl:              s.Platform.BuildURL,
+			HighVulnerabilities:   s.Platform.HighVulnerabilities,
+			MediumVulnerabilities: s.Platform.MediumVulnerabilities,
+			LowVulnerabilities:    s.Platform.LowVulnerabilities,
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -78,6 +90,7 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 			Dev:               &dev,
 			Staging:           &staging,
 			Prod:              &prod,
+			Platform:          &platform,
 		})
 		if err != nil {
 			logger.Errorf("http: status: service '%s': marshal response failed: %v", service, err)

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -18,6 +18,7 @@ type StatusResponse struct {
 	Dev               *Environment `json:"dev,omitempty"`
 	Staging           *Environment `json:"staging,omitempty"`
 	Prod              *Environment `json:"prod,omitempty"`
+	Platform          *Environment `json:"platform,omitempty"`
 }
 
 type Environment struct {


### PR DESCRIPTION
Spike for enabling a platform environment.

Looks like there is a lot of DRY cases in the code.

Could be awesome to specify environments in configuration to be customized.