### PR TITLE
Add support for multiple env in hamctl release

### DIFF
--- a/cmd/hamctl/command/actions/release.go
+++ b/cmd/hamctl/command/actions/release.go
@@ -8,26 +8,49 @@ import (
 	"github.com/lunarway/release-manager/internal/intent"
 )
 
-func ReleaseArtifactID(client *httpinternal.Client, service, environment, artifactID string, intent intent.Intent) (httpinternal.ReleaseResponse, error) {
-	var resp httpinternal.ReleaseResponse
+type ReleaseResult struct {
+	Response    httpinternal.ReleaseResponse
+	Environment string
+	Error       error
+}
+
+// ReleaseArtifactID issues a release request to a single environment.
+func ReleaseArtifactID(client *httpinternal.Client, service, environment string, artifactID string, intent intent.Intent) (ReleaseResult, error) {
+	resps, err := ReleaseArtifactIDMultipleEnvironments(client, service, []string{environment}, artifactID, intent)
+	if err != nil {
+		return ReleaseResult{}, err
+	}
+	return resps[0], nil
+}
+
+// ReleaseArtifactIDMultipleEnvironments issues a release request to multiple
+// environments.
+func ReleaseArtifactIDMultipleEnvironments(client *httpinternal.Client, service string, environments []string, artifactID string, intent intent.Intent) ([]ReleaseResult, error) {
+	var results []ReleaseResult
 	committerName, committerEmail, err := git.CommitterDetails()
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
 	path, err := client.URL("release")
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	err = client.Do(http.MethodPost, path, httpinternal.ReleaseRequest{
-		Service:        service,
-		Environment:    environment,
-		ArtifactID:     artifactID,
-		CommitterName:  committerName,
-		CommitterEmail: committerEmail,
-		Intent:         intent,
-	}, &resp)
-	if err != nil {
-		return resp, err
+	for _, environment := range environments {
+		var resp httpinternal.ReleaseResponse
+		err = client.Do(http.MethodPost, path, httpinternal.ReleaseRequest{
+			Service:        service,
+			Environment:    environment,
+			ArtifactID:     artifactID,
+			CommitterName:  committerName,
+			CommitterEmail: committerEmail,
+			Intent:         intent,
+		}, &resp)
+
+		results = append(results, ReleaseResult{
+			Response:    resp,
+			Environment: environment,
+			Error:       err,
+		})
 	}
-	return resp, nil
+	return results, nil
 }

--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -44,12 +44,12 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 
 			fmt.Printf("Promote of service: %s\n", *service)
 			resp, err := actions.ReleaseArtifactID(client, *service, toEnvironment, artifactID, intent.NewPromoteEnvironment(fromEnvironment))
-
-			if resp.Status != "" {
-				fmt.Printf("%s\n", resp.Status)
-			} else {
-				fmt.Printf("[✓] Release of %s to %s initialized\n", resp.Tag, resp.ToEnvironment)
+			if err != nil {
+				return err
 			}
+			printReleaseResponse(func(s string, i ...interface{}) {
+				fmt.Printf(s, i...)
+			}, resp)
 			return nil
 		},
 	}
@@ -64,4 +64,15 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 	completion.FlagAnnotation(command, "namespace", "__hamctl_get_namespaces")
 
 	return command
+}
+
+func printReleaseResponse(logger LoggerFunc, resp actions.ReleaseResult) {
+	switch {
+	case resp.Error != nil:
+		logger("[X] %s\n", resp.Error.Error())
+	case resp.Response.Status != "":
+		logger("[✓] %s\n", resp.Response.Status)
+	default:
+		logger("[✓] Release of %s to %s initialized\n", resp.Response.Tag, resp.Response.ToEnvironment)
+	}
 }

--- a/cmd/hamctl/command/release_test.go
+++ b/cmd/hamctl/command/release_test.go
@@ -1,0 +1,201 @@
+package command_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lunarway/release-manager/cmd/hamctl/command"
+	"github.com/lunarway/release-manager/internal/artifact"
+	internalhttp "github.com/lunarway/release-manager/internal/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelease(t *testing.T) {
+	var (
+		serviceName = "service-name"
+		branch      = "master"
+		artifactID  = "master-1-2"
+	)
+
+	// mocked manager server responding as configured in variables below
+	var (
+		foundArtifact   artifact.Spec
+		releaseResponse func(r internalhttp.ReleaseRequest) (internalhttp.ReleaseResponse, *internalhttp.ErrorResponse)
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "describe/latest-artifact"):
+			resp := internalhttp.DescribeArtifactResponse{
+				Artifacts: []artifact.Spec{
+					foundArtifact,
+				},
+			}
+			err := json.NewEncoder(rw).Encode(resp)
+			require.NoError(t, err, "failed to encode test response payload")
+		case strings.Contains(r.URL.Path, "release"):
+			var req internalhttp.ReleaseRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			require.NoError(t, err, "failed to dencode test request payload")
+
+			resp, errorResponse := releaseResponse(req)
+			if errorResponse != nil {
+				internalhttp.Error(rw, errorResponse.Error(), errorResponse.Status)
+				return
+			}
+			err = json.NewEncoder(rw).Encode(resp)
+			require.NoError(t, err, "failed to encode test response payload")
+		default:
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	c := internalhttp.Client{
+		BaseURL: server.URL,
+	}
+
+	runCommand := func(t *testing.T, args ...string) []string {
+		var output []string
+
+		cmd := command.NewRelease(&c, &serviceName, func(f string, args ...interface{}) {
+			output = append(output, fmt.Sprintf(f, args...))
+		})
+
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		require.NoError(t, err, "unexpected execution error")
+
+		// mask GUID to make output assertable
+		output = maskGUID(output)
+
+		return output
+	}
+
+	t.Run("multiple environments", func(t *testing.T) {
+		foundArtifact = artifact.Spec{
+			ID:      artifactID,
+			Service: serviceName,
+		}
+		releaseResponse = func(req internalhttp.ReleaseRequest) (internalhttp.ReleaseResponse, *internalhttp.ErrorResponse) {
+			return internalhttp.ReleaseResponse{
+				Service:       serviceName,
+				ToEnvironment: req.Environment,
+				Tag:           artifactID,
+			}, nil
+		}
+
+		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+
+		assert.Equal(t, []string{
+			"Release of service service-name using branch master\n",
+			"[✓] Release of master-1-2 to dev initialized\n",
+			"[✓] Release of master-1-2 to staging initialized\n",
+		}, output)
+	})
+
+	t.Run("environment up to date", func(t *testing.T) {
+		foundArtifact = artifact.Spec{
+			ID:      artifactID,
+			Service: serviceName,
+		}
+		releaseResponse = func(req internalhttp.ReleaseRequest) (internalhttp.ReleaseResponse, *internalhttp.ErrorResponse) {
+			resp := internalhttp.ReleaseResponse{
+				Service:       serviceName,
+				ToEnvironment: req.Environment,
+				Tag:           artifactID,
+			}
+			if req.Environment == "staging" {
+				resp.Status = "Environment staging is already up-to-date"
+			}
+			return resp, nil
+		}
+
+		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+
+		assert.Equal(t, []string{
+			"Release of service service-name using branch master\n",
+			"[✓] Release of master-1-2 to dev initialized\n",
+			"[✓] Environment staging is already up-to-date\n",
+		}, output)
+	})
+
+	t.Run("unknown environment for single env", func(t *testing.T) {
+		foundArtifact = artifact.Spec{
+			ID:      artifactID,
+			Service: serviceName,
+		}
+		releaseResponse = func(req internalhttp.ReleaseRequest) (internalhttp.ReleaseResponse, *internalhttp.ErrorResponse) {
+			return internalhttp.ReleaseResponse{}, &internalhttp.ErrorResponse{
+				Status:  http.StatusBadRequest,
+				Message: "cannot release master-1-2 to environment dev due to branch restriction policy",
+			}
+		}
+
+		output := runCommand(t, "--branch", branch, "--env", "dev")
+
+		assert.Equal(t, []string{
+			"Release of service service-name using branch master\n",
+			"[X] cannot release master-1-2 to environment dev due to branch restriction policy (reference: GUID)\n",
+		}, output)
+	})
+
+	t.Run("unknown environment", func(t *testing.T) {
+		foundArtifact = artifact.Spec{
+			ID:      artifactID,
+			Service: serviceName,
+		}
+		releaseResponse = func(req internalhttp.ReleaseRequest) (internalhttp.ReleaseResponse, *internalhttp.ErrorResponse) {
+			resp := internalhttp.ReleaseResponse{
+				Service:       serviceName,
+				ToEnvironment: req.Environment,
+				Tag:           artifactID,
+			}
+			if req.Environment == "dev" {
+				return resp, &internalhttp.ErrorResponse{
+					Status:  http.StatusBadRequest,
+					Message: "cannot release master-1-2 to environment dev due to branch restriction policy",
+				}
+			}
+			return resp, nil
+		}
+
+		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+
+		assert.Equal(t, []string{
+			"Release of service service-name using branch master\n",
+			"[X] cannot release master-1-2 to environment dev due to branch restriction policy (reference: GUID)\n",
+			"[✓] Release of master-1-2 to staging initialized\n",
+		}, output)
+	})
+}
+
+// maskGUID masks any guid with the text GUID.
+func maskGUID(output []string) []string {
+	var masked []string
+	r := regexp.MustCompile(".{8}-.{4}-.{4}-.{4}-.{12}")
+	for _, line := range output {
+		m := r.ReplaceAllString(line, "GUID")
+		masked = append(masked, m)
+	}
+	return masked
+}
+
+func TestRelease_emptyEnvValue(t *testing.T) {
+	serviceName := "service-name"
+	c := internalhttp.Client{}
+
+	cmd := command.NewRelease(&c, &serviceName, func(f string, args ...interface{}) {
+		t.Logf(f, args...)
+	})
+
+	cmd.SetArgs([]string{"--env", ""})
+
+	err := cmd.Execute()
+	require.Error(t, err, "unexpected execution error")
+}

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -144,11 +144,10 @@ has no effect.`,
 				fmt.Printf("    %s\n", err)
 				return err
 			}
-			if resp.Status != "" {
-				fmt.Printf("%s\n", resp.Status)
-			} else {
-				fmt.Printf("[✓] Rollback of %s to %s initialized\n", resp.Tag, resp.ToEnvironment)
-			}
+
+			printReleaseResponse(func(s string, i ...interface{}) {
+				fmt.Printf(s, i...)
+			}, resp)
 			return nil
 		},
 	}

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -68,7 +69,9 @@ func NewRoot(version *string) (*cobra.Command, error) {
 		NewDescribe(&client, &service),
 		NewPolicy(&client, &service),
 		NewPromote(&client, &service),
-		NewRelease(&client, &service),
+		NewRelease(&client, &service, func(f string, args ...interface{}) {
+			fmt.Printf(f, args...)
+		}),
 		NewRollback(&client, &service),
 		NewStatus(&client, &service),
 		NewVersion(*version),

--- a/cmd/server/http/release.go
+++ b/cmd/server/http/release.go
@@ -50,7 +50,7 @@ func release(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 				httpinternal.Error(w, fmt.Sprintf("cannot release %s to environment '%s' due to branch restriction policy", req.Intent.AsArtifactWithIntent(req.ArtifactID), req.Environment), http.StatusBadRequest)
 				return
 			case flow.ErrNothingToRelease:
-				statusString = "Environment is already up-to-date"
+				statusString = fmt.Sprintf("Environment '%s' is already up-to-date", req.Environment)
 				logger.Infof("http: release: service '%s' environment '%s' artifact id '%s': release skipped: environment up to date: %v", req.Service, req.Environment, req.ArtifactID, err)
 			case flow.ErrArtifactNotFound:
 				logger.Infof("http: release: service '%s' environment '%s' artifact id '%s': release rejected: %v", req.Service, req.Environment, req.ArtifactID, err)

--- a/internal/http/error.go
+++ b/internal/http/error.go
@@ -19,7 +19,7 @@ var _ error = &ErrorResponse{}
 
 func (e *ErrorResponse) Error() string {
 	if e.ID != "" {
-		return fmt.Sprintf("%s\nReference: %s", e.Message, e.ID)
+		return fmt.Sprintf("%s (reference: %s)", e.Message, e.ID)
 	}
 	return e.Message
 }


### PR DESCRIPTION
Currently the env flag of hamctl release only supports a single environment. It
is a common use case however to release to multiple environments in one go.

This change adds support for a comma separated list of environments. For each
found environment a release action is issued to the manager handling it with no
difference.

A change is necessary on the output of the release command as there can now be
partial failures. Each environment is now outputtet with its result.

    Release of service service-name using branch master
    [✓] Release of master-1-2 to dev initialized
    [✓] Release of master-1-2 to staging initialized

In case of failures it will look like this.

    Release of service service-name using branch master
    [X] cannot release master-1-2 to environment dev due to branch restriction policy (reference: GUID)
    [✓] Release of master-1-2 to staging initialized

As the error output is now line based, the reference ID is printet on the same
line as the error instead of on a new line.