### PR TITLE
Restrict arguments to hamctl

### DIFF
--- a/cmd/hamctl/command/describe.go
+++ b/cmd/hamctl/command/describe.go
@@ -60,6 +60,7 @@ func newDescribeRelease(client *httpinternal.Client, service *string) *cobra.Com
 Format the output with a custom template:
 
 	hamctl describe release --service product --env dev --template '{{ .Service }}'`,
+		Args: cobra.ExactArgs(0),
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
 				return s.Vars.K8S.Namespace
@@ -119,6 +120,7 @@ Get details about the latest 5 artifacts for a service:
 Format the output with a custom template:
 
 	hamctl describe artifact --service product --template '{{ .Service }}'`,
+		Args: cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			var resp httpinternal.DescribeArtifactResponse
 			params := url.Values{}

--- a/cmd/hamctl/command/policy/apply.go
+++ b/cmd/hamctl/command/policy/apply.go
@@ -42,6 +42,7 @@ func autoRelease(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "auto-release",
 		Short: "Auto-release policy for releasing branch artifacts to an environment",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			committerName, committerEmail, err := git.CommitterDetails()
 			if err != nil {
@@ -87,6 +88,7 @@ func branchRestriction(client *httpinternal.Client, service *string) *cobra.Comm
 		Use:   "branch-restriction",
 		Short: "Branch restriction policy for limiting releases by their origin branch",
 		Long:  "Branch restriction policy for limiting releases of artifacts by their origin branch to specific environments",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			committerName, committerEmail, err := git.CommitterDetails()
 			if err != nil {

--- a/cmd/hamctl/command/policy/list.go
+++ b/cmd/hamctl/command/policy/list.go
@@ -14,6 +14,7 @@ func NewList(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "list",
 		Short: "List current policies",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			var resp httpinternal.ListPoliciesResponse
 			params := url.Values{}

--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -15,6 +15,7 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "promote",
 		Short: "Promote a service to a specific environment following promoting conventions.",
+		Args:  cobra.ExactArgs(0),
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
 				return s.Vars.K8S.Namespace

--- a/cmd/hamctl/command/release.go
+++ b/cmd/hamctl/command/release.go
@@ -26,6 +26,7 @@ func NewRelease(client *httpinternal.Client, service *string, logger LoggerFunc)
 Release latest artifact from branch 'master' of service 'product' into environment 'dev':
 
   hamctl release --service product --env dev --branch master`,
+		Args: cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			environments = trimEmptyValues(environments)
 			if len(environments) == 0 {

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -32,6 +32,7 @@ has no effect.`,
 		Example: `Rollback to the previous artifact for service 'product' in environment 'dev':
 
   hamctl rollback --service product --env dev`,
+		Args: cobra.ExactArgs(0),
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
 				return s.Vars.K8S.Namespace

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -17,6 +17,7 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "status",
 		Short: "List the status of the environments",
+		Args:  cobra.ExactArgs(0),
 		PreRun: func(c *cobra.Command, args []string) {
 			defaultShuttleString(shuttleSpecFromFile, &namespace, func(s *shuttleSpec) string {
 				return s.Vars.K8S.Namespace

--- a/cmd/hamctl/command/version.go
+++ b/cmd/hamctl/command/version.go
@@ -10,6 +10,7 @@ func NewVersion(version string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Prints the version number of hamctl",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version)
 		},


### PR DESCRIPTION
Currently it is possible to provide nonsense arguments to hamctl commands
leading to unexpected behaviour. As an example it is possible to run the
following 'release' command even though a 'describe' argument is passed.

    $ hamctl release describe --branch master --env prod
    Release of service fee-statement using branch master
    [✓] Release of master-49f970f6fa-2672319eac to prod initialized

This change adds a guard on all commands that does not use arguents to not allow
any.

    $ hamctl release describe --branch master --env prod
    Error: accepts 0 arg(s), received 1