### PR TITLE
Fix possible insecure path joins

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -225,7 +225,7 @@ func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMs
 
 		policiesPath, err := securejoin.SecureJoin(policiesDir, fmt.Sprintf("%s.json", svc))
 		if err != nil {
-			return true, errors.WithMessage(err, "join policy path")
+			return true, errors.WithMessagef(err, "join policy path '%s'", policiesDir)
 		}
 		logger.Debugf("internal/policy: open policies file '%s'", policiesPath)
 		policiesFile, err := os.OpenFile(policiesPath, os.O_CREATE|os.O_RDWR, os.ModePerm)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -223,7 +223,10 @@ func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMs
 			return true, errors.WithMessagef(err, "make policies directory '%s'", policiesDir)
 		}
 
-		policiesPath := path.Join(policiesDir, fmt.Sprintf("%s.json", svc))
+		policiesPath, err := securejoin.SecureJoin(policiesDir, fmt.Sprintf("%s.json", svc))
+		if err != nil {
+			return true, errors.WithMessage(err, "join policy path")
+		}
 		logger.Debugf("internal/policy: open policies file '%s'", policiesPath)
 		policiesFile, err := os.OpenFile(policiesPath, os.O_CREATE|os.O_RDWR, os.ModePerm)
 		if err != nil {

--- a/internal/s3storage/artifactreadstorage.go
+++ b/internal/s3storage/artifactreadstorage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
@@ -40,7 +41,11 @@ func (f *Service) ArtifactPaths(ctx context.Context, service string, environment
 	if err != nil {
 		return "", "", nil, errors.WithMessagef(err, "download from key '%s'", key)
 	}
-	return path.Join(artifact, "artifact.json"), path.Join(artifact, environment), close, nil
+	resourcesPath, err = securejoin.SecureJoin(artifact, environment)
+	if err != nil {
+		return "", "", nil, errors.WithMessagef(err, "resources path invalid for '%s'", environment)
+	}
+	return path.Join(artifact, "artifact.json"), resourcesPath, close, nil
 }
 
 func (f *Service) LatestArtifactSpecification(ctx context.Context, service string, branch string) (artifact.Spec, error) {
@@ -62,7 +67,11 @@ func (f *Service) LatestArtifactPaths(ctx context.Context, service string, envir
 	if err != nil {
 		return "", "", nil, errors.WithMessagef(err, "download from key '%s'", key)
 	}
-	return path.Join(artifact, "artifact.json"), path.Join(artifact, environment), close, nil
+	resourcesPath, err = securejoin.SecureJoin(artifact, environment)
+	if err != nil {
+		return "", "", nil, errors.WithMessagef(err, "resources path invalid for '%s'", environment)
+	}
+	return path.Join(artifact, "artifact.json"), resourcesPath, close, nil
 }
 
 func (f *Service) ArtifactSpecifications(ctx context.Context, service string, n int) ([]artifact.Spec, error) {


### PR DESCRIPTION
Currently function arguments are passed directly to `path.Join(...)` which might lead to directory traversal attacks due to these arguments not being sanitized for e.g. `../` (see https://play.golang.org/p/qqkltPKjYj3)