### PR TITLE
Fix unmarshaled artifact stage types

### DIFF
--- a/cmd/artifact/command/add.go
+++ b/cmd/artifact/command/add.go
@@ -42,7 +42,7 @@ func appendTestSubCommand(options *Options) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := artifact.Update(path.Join(options.RootPath, options.FileName), func(s artifact.Spec) artifact.Spec {
 				stage.Name = "Test"
-				stage.ID = "test"
+				stage.ID = artifact.StageIDTest
 				stage.Data = testData
 				return setStage(s, stage)
 			})
@@ -81,7 +81,7 @@ func appendBuildSubCommand(options *Options) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := artifact.Update(path.Join(options.RootPath, options.FileName), func(s artifact.Spec) artifact.Spec {
 				stage.Name = "Build"
-				stage.ID = "build"
+				stage.ID = artifact.StageIDBuild
 				stage.Data = buildData
 				return setStage(s, stage)
 			})
@@ -120,7 +120,7 @@ func appendSnykDockerSubCommand(options *Options) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := artifact.Update(path.Join(options.RootPath, options.FileName), func(s artifact.Spec) artifact.Spec {
 				stage.Name = "Security Scan - Docker"
-				stage.ID = "snyk-docker"
+				stage.ID = artifact.StageIDSnykDocker
 				stage.Data = snykDockerData
 				return setStage(s, stage)
 			})
@@ -155,7 +155,7 @@ func appendSnykCodeSubCommand(options *Options) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := artifact.Update(path.Join(options.RootPath, options.FileName), func(s artifact.Spec) artifact.Spec {
 				stage.Name = "Security Scan - Code"
-				stage.ID = "snyk-code"
+				stage.ID = artifact.StageIDSnykCode
 				stage.Data = snykCodeData
 				return setStage(s, stage)
 			})
@@ -190,7 +190,7 @@ func appendPushSubCommand(options *Options) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := artifact.Update(path.Join(options.RootPath, options.FileName), func(s artifact.Spec) artifact.Spec {
 				stage.Name = "Push"
-				stage.ID = "push"
+				stage.ID = artifact.StageIDPush
 				stage.Data = pushData
 				return setStage(s, stage)
 			})

--- a/internal/artifact/spec.go
+++ b/internal/artifact/spec.go
@@ -55,10 +55,65 @@ type CI struct {
 	End    time.Time `json:"end,omitempty"`
 }
 
+type StageID string
+
+const (
+	StageIDBuild      StageID = "build"
+	StageIDTest       StageID = "test"
+	StageIDPush       StageID = "push"
+	StageIDSnykCode   StageID = "snyk-code"
+	StageIDSnykDocker StageID = "snyk-docker"
+)
+
 type Stage struct {
-	ID   string      `json:"id,omitempty"`
+	ID   StageID     `json:"id,omitempty"`
 	Name string      `json:"name,omitempty"`
 	Data interface{} `json:"data,omitempty"`
+}
+
+// UnmarshalJSON implements a custom JSON unmarshal method that sets the
+// concrete Data types for each stage type.
+func (s *Stage) UnmarshalJSON(data []byte) error {
+	type genericStage struct {
+		ID   StageID         `json:"id,omitempty"`
+		Name string          `json:"name,omitempty"`
+		Data json.RawMessage `json:"data,omitempty"`
+	}
+	var gStage genericStage
+	err := json.Unmarshal(data, &gStage)
+	if err != nil {
+		return err
+	}
+
+	s.ID = gStage.ID
+	s.Name = gStage.Name
+
+	switch s.ID {
+	case StageIDBuild:
+		data := BuildData{}
+		err = json.Unmarshal(gStage.Data, &data)
+		s.Data = data
+	case StageIDPush:
+		data := PushData{}
+		err = json.Unmarshal(gStage.Data, &data)
+		s.Data = data
+	case StageIDTest:
+		data := TestData{}
+		err = json.Unmarshal(gStage.Data, &data)
+		s.Data = data
+	case StageIDSnykCode:
+		data := SnykCodeData{}
+		err = json.Unmarshal(gStage.Data, &data)
+		s.Data = data
+	case StageIDSnykDocker:
+		data := SnykDockerData{}
+		err = json.Unmarshal(gStage.Data, &data)
+		s.Data = data
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 type BuildData struct {
@@ -103,16 +158,6 @@ type VulnerabilityResult struct {
 	High   int `json:"high"`
 	Medium int `json:"medium"`
 	Low    int `json:"low"`
-}
-
-// GetStage returns a stage of the spec with provided stage ID.
-func (s *Spec) GetStage(stageID string) (Stage, bool) {
-	for _, stage := range s.Stages {
-		if stage.ID == stageID {
-			return stage, true
-		}
-	}
-	return Stage{}, false
 }
 
 func Get(path string) (Spec, error) {

--- a/internal/artifact/spec_test.go
+++ b/internal/artifact/spec_test.go
@@ -2,11 +2,13 @@ package artifact_test
 
 import (
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {
@@ -51,6 +53,63 @@ func TestGet(t *testing.T) {
 				assert.NoError(t, err, "no output error expected")
 			}
 			assert.Equal(t, tc.spec, spec, "spec not as expected")
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		output artifact.Spec
+	}{
+		{
+			name:  "no stages",
+			input: `{"id": "no-stages"}`,
+			output: artifact.Spec{
+				ID: "no-stages",
+			},
+		},
+		{
+			name: "with stages",
+			input: `
+			{
+				"id": "stages",
+				"stages": [
+					{
+						"id": "build",
+						"name": "name",
+						"data": {
+							"image": "quay.io/lunarway/release-manager",
+							"tag": "v1.2.3",
+							"dockerVersion": "20.10.6"
+						}
+					}
+				]
+			}
+`,
+			output: artifact.Spec{
+				ID: "stages",
+				Stages: []artifact.Stage{
+					{
+						ID:   artifact.StageIDBuild,
+						Name: "name",
+						Data: artifact.BuildData{
+							Image:         "quay.io/lunarway/release-manager",
+							Tag:           "v1.2.3",
+							DockerVersion: "20.10.6",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := artifact.Decode(strings.NewReader(tc.input))
+
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, tc.output, spec)
 		})
 	}
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -175,55 +175,57 @@ func (s *Service) Status(ctx context.Context, namespace, service string) (Status
 
 	return StatusResponse{
 		DefaultNamespaces: defaultNamespaces,
-		Dev: Environment{
-			Tag:                   devSpec.ID,
-			Committer:             devSpec.Application.CommitterName,
-			Author:                devSpec.Application.AuthorName,
-			Message:               devSpec.Application.Message,
-			Date:                  devSpec.CI.End,
-			BuildURL:              devSpec.CI.JobURL,
-			HighVulnerabilities:   calculateTotalVulnerabilties("high", devSpec),
-			MediumVulnerabilities: calculateTotalVulnerabilties("medium", devSpec),
-			LowVulnerabilities:    calculateTotalVulnerabilties("low", devSpec),
-		},
-		Staging: Environment{
-			Tag:                   stagingSpec.ID,
-			Committer:             stagingSpec.Application.CommitterName,
-			Author:                stagingSpec.Application.AuthorName,
-			Message:               stagingSpec.Application.Message,
-			Date:                  stagingSpec.CI.End,
-			BuildURL:              stagingSpec.CI.JobURL,
-			HighVulnerabilities:   calculateTotalVulnerabilties("high", stagingSpec),
-			MediumVulnerabilities: calculateTotalVulnerabilties("medium", stagingSpec),
-			LowVulnerabilities:    calculateTotalVulnerabilties("low", stagingSpec),
-		},
-		Prod: Environment{
-			Tag:                   prodSpec.ID,
-			Committer:             prodSpec.Application.CommitterName,
-			Author:                prodSpec.Application.AuthorName,
-			Message:               prodSpec.Application.Message,
-			Date:                  prodSpec.CI.End,
-			BuildURL:              prodSpec.CI.JobURL,
-			HighVulnerabilities:   calculateTotalVulnerabilties("high", prodSpec),
-			MediumVulnerabilities: calculateTotalVulnerabilties("medium", prodSpec),
-			LowVulnerabilities:    calculateTotalVulnerabilties("low", prodSpec),
-		},
+		Dev:               mapSpec(devSpec),
+		Staging:           mapSpec(stagingSpec),
+		Prod:              mapSpec(prodSpec),
 	}, nil
 }
 
-func calculateTotalVulnerabilties(severity string, s artifact.Spec) int64 {
+func mapSpec(spec artifact.Spec) Environment {
+	return Environment{
+		Tag:                   spec.ID,
+		Committer:             spec.Application.CommitterName,
+		Author:                spec.Application.AuthorName,
+		Message:               spec.Application.Message,
+		Date:                  spec.CI.End,
+		BuildURL:              spec.CI.JobURL,
+		HighVulnerabilities:   calculateHighTotalVulnerabilties(spec),
+		MediumVulnerabilities: calculateMediumTotalVulnerabilties(spec),
+		LowVulnerabilities:    calculateLowTotalVulnerabilties(spec),
+	}
+}
+
+func calculateHighTotalVulnerabilties(s artifact.Spec) int64 {
+	return calculateTotalVulnerabilties(s, func(v artifact.VulnerabilityResult) int {
+		return v.High
+	})
+}
+
+func calculateMediumTotalVulnerabilties(s artifact.Spec) int64 {
+	return calculateTotalVulnerabilties(s, func(v artifact.VulnerabilityResult) int {
+		return v.Medium
+	})
+}
+
+func calculateLowTotalVulnerabilties(s artifact.Spec) int64 {
+	return calculateTotalVulnerabilties(s, func(v artifact.VulnerabilityResult) int {
+		return v.Low
+	})
+}
+
+func calculateTotalVulnerabilties(s artifact.Spec, field func(artifact.VulnerabilityResult) int) int64 {
 	result := float64(0)
 	for _, stage := range s.Stages {
-		if stage.ID == "snyk-code" {
-			data := stage.Data.(map[string]interface{})
-			vulnerabilities := data["vulnerabilities"].(map[string]interface{})
-			result += vulnerabilities[severity].(float64)
+		var vulnerabilities artifact.VulnerabilityResult
+		if stage.ID == artifact.StageIDSnykCode {
+			data := stage.Data.(artifact.SnykCodeData)
+			vulnerabilities = data.Vulnerabilities
 		}
-		if stage.ID == "snyk-docker" {
-			data := stage.Data.(map[string]interface{})
-			vulnerabilities := data["vulnerabilities"].(map[string]interface{})
-			result += vulnerabilities[severity].(float64)
+		if stage.ID == artifact.StageIDSnykDocker {
+			data := stage.Data.(artifact.SnykDockerData)
+			vulnerabilities = data.Vulnerabilities
 		}
+		result += float64(field(vulnerabilities))
 	}
 	return int64(result + 0.5)
 }


### PR DESCRIPTION
Currently when reading an artifact spec from JSON all stage's Data field becomes
a generic map[string]interface{} as they are typed with interface{}. This makes
them hard to work with as we do in the status flow where we sum up
vulnerabilities.

This was discovered in a more challenging way when introducing a new HTTP
transport layer where we have static transport DTOs instead of reusing the
internal artifact.Spec on the transport level. That change will be provided in a
future PR.

This change adds a custom unmarshaling method for the Stage type which detects
the stage variant by its ID and then unmarshals the data into a concrete type.