### PR TITLE
Align hamctl template usage and decople data model

### DIFF
--- a/cmd/hamctl/template/template.go
+++ b/cmd/hamctl/template/template.go
@@ -1,7 +1,6 @@
-package command
+package template
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"text/template"
@@ -9,15 +8,14 @@ import (
 	"github.com/lunarway/release-manager/internal/intent"
 )
 
-// templateOutput parses the template text as a Go template. The empty interface
-// is available as the root object in the template.
+// Output parses the template text as a Go template. The empty interface is
+// available as the root object in the template.
 //
 // Some utility functions are available for data manipulation.
-func templateOutput(destination io.Writer, name, text string, data interface{}) error {
+func Output(destination io.Writer, name, text string, data interface{}) error {
 	t := template.New(name)
 	t.Funcs(template.FuncMap{
-		"rightPad":    tmplRightPad,
-		"printIntent": tmplPrintIntent,
+		"rightPad": tmplRightPad,
 	})
 	t, err := t.Parse(text)
 	if err != nil {
@@ -26,21 +24,12 @@ func templateOutput(destination io.Writer, name, text string, data interface{}) 
 	return t.Execute(destination, data)
 }
 
-func templateToString(name, text string, data interface{}) (string, error) {
-	buf := bytes.NewBuffer(nil)
-	err := templateOutput(buf, name, text, data)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
 func tmplRightPad(s string, padding int) string {
 	template := fmt.Sprintf("%%-%ds", padding)
 	return fmt.Sprintf(template, s)
 }
 
-func tmplPrintIntent(i intent.Intent) string {
+func IntentString(i intent.Intent) string {
 	switch i.Type {
 	case intent.TypeAutoRelease:
 		return "autorelease"


### PR DESCRIPTION
Currently we have three ways of writing output to the screen in hamctl. `1)`
`fmt.Print*()` variants for simple line outputs, `2)` `fmt.Print*()` variants for complex
outputs and `3)` Go templates.

`1)` is ok for the most simple outputs and are left as is. `2)` is hard to read and
modify and are updated to use templates instead.

All the templates are updated to use a dedicated data model to avoid coupling
HTTP DTOs to the outputs which is error prone and hard to catch at compile time.