### PR TITLE
Add tests of hamctl status template

### DIFF
--- a/cmd/hamctl/command/describe.go
+++ b/cmd/hamctl/command/describe.go
@@ -39,9 +39,9 @@ Environment: {{ .Environment }}
    {{ if ne (len .Namespace) 0 -}}
    Namespace:  {{ .Namespace }}
    {{ end -}}
-   Artifact from: {{ .ArtifactFrom.Format "2006-01-02 15:04:03" }}
+   Artifact from: {{ .ArtifactFrom.Format dateFormat }}
    Artifact by: {{ .CommitterName }} ({{ .CommitterEmail }})
-   Released at: {{ .ReleasedAt.Format "2006-01-02 15:04:03" }}
+   Released at: {{ .ReleasedAt.Format dateFormat }}
    Released by: {{ .ReleasedByName }} ({{ .ReleasedByEmail }})
    Commit: {{ .CommitURL }}
    Message: {{ .CommitMessage }}
@@ -151,7 +151,7 @@ var describeArtifactDefaultTemplate = `Latest artifacts for service: {{ .Service
 
 {{ rightPad "Date" 21 }}{{ rightPad "Artifact" 30 }}Message
 {{ range $k, $v := .Artifacts -}}
-{{ rightPad (.ArtifactFrom.Format "2006-01-02 15:04:03") 21 }}{{ rightPad .ArtifactID 30 }}{{ .CommitMessage }}
+{{ rightPad (.ArtifactFrom.Format dateFormat) 21 }}{{ rightPad .ArtifactID 30 }}{{ .CommitMessage }}
 {{ end -}}
 `
 

--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -144,7 +144,7 @@ var (
 		Details: `
      {{ print "Release Details          " | bold | underline }}
      Release Number: {{ .ReleaseIndex }}
-     Released at: {{ .ReleasedAt.Format "2006-01-02 15:04:03" }}
+     Released at: {{ .ReleasedAt.Format dateFormat }}
      Released by: {{ .ReleasedByName }} ({{ .ReleasedByEmail }})
      Intent: {{ .Intent }}
 
@@ -153,7 +153,7 @@ var (
      {{ if ne (len .Namespace) 0 -}}
      Namespace:  {{ .Namespace }}
      {{ end -}}
-     Artifact from: {{ .ArtifactFrom.Format "2006-01-02 15:04:03" }}
+     Artifact from: {{ .ArtifactFrom.Format dateFormat }}
      Artifact by: {{ .CommitterName }} ({{ .CommitterEmail }})
      Commit: {{ .CommitURL }}
      Message: {{ .CommitMessage }}`,

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -65,16 +65,19 @@ func mapToStatusData(resp httpinternal.StatusResponse, service string) statusDat
 	}
 }
 
-var statusTemplate = `
+var statusTemplate = `Status for service {{ .Service }}
 {{- if not .EnvironmentsManaged }}
-{{- if .UsingDefaultNamespaces -}}
-Using default namespaces.
-{{- end }}
-Are you setting the right namespace?
-{{ end -}}
-Status for service {{ .Service }}
 
-{{ range .Environments -}}
+No environments managed by release-manager.
+
+{{ if .UsingDefaultNamespaces -}}
+Using environment specific namespace, ie. dev, staging, prod.
+{{ end -}}
+Are you setting the right namespace?
+{{- end -}}
+
+{{ range .Environments }}
+
 {{ .Environment }}:
 {{- if eq (len .Tag) 0 }}
   Not managed by the release-manager
@@ -83,11 +86,11 @@ Status for service {{ .Service }}
   Author: {{ .Author }}
   Committer: {{ .Committer }}
   Message: {{ .CommitMessage }}
-  Date: {{ .Date }}
+  Date: {{ .Date.Format dateFormat }}
   Link: {{ .BuildURL }}
   Vulnerabilities: {{ .HighVulnerabilities }} high, {{ .MediumVulnerabilities }} medium, {{ .LowVulnerabilities }} low
-{{ end }}
-{{ end -}}
+{{- end -}}
+{{- end }}
 `
 
 type statusData struct {

--- a/cmd/hamctl/command/status_test.go
+++ b/cmd/hamctl/command/status_test.go
@@ -1,0 +1,144 @@
+package command
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateStatus(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		input  statusData
+		output string
+	}{
+		{
+			desc: "non managed",
+			input: statusData{
+				EnvironmentsManaged:    false,
+				UsingDefaultNamespaces: false,
+				Service:                "svc",
+				Environments:           nil,
+			},
+			output: `Status for service svc
+
+No environments managed by release-manager.
+
+Are you setting the right namespace?
+`,
+		},
+		{
+			desc: "non managed with default namespaces",
+			input: statusData{
+				EnvironmentsManaged:    false,
+				UsingDefaultNamespaces: true,
+				Service:                "svc",
+				Environments:           nil,
+			},
+			output: `Status for service svc
+
+No environments managed by release-manager.
+
+Using environment specific namespace, ie. dev, staging, prod.
+Are you setting the right namespace?
+`,
+		},
+		{
+			desc: "single environment",
+			input: statusData{
+				EnvironmentsManaged:    true,
+				UsingDefaultNamespaces: true,
+				Service:                "svc",
+				Environments: []statusDataEnvironment{
+					{
+						Environment:           "dev",
+						Tag:                   "master-1234-5678",
+						Author:                "John Doe",
+						Committer:             "Jane Doe",
+						CommitMessage:         "Useful bits",
+						Date:                  time.Date(2021, time.June, 23, 8, 42, 22, 0, time.UTC),
+						BuildURL:              "https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect",
+						HighVulnerabilities:   1,
+						MediumVulnerabilities: 2,
+						LowVulnerabilities:    3,
+					},
+				},
+			},
+			output: `Status for service svc
+
+dev:
+  Tag: master-1234-5678
+  Author: John Doe
+  Committer: Jane Doe
+  Message: Useful bits
+  Date: 2021-06-23 08:42:22
+  Link: https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect
+  Vulnerabilities: 1 high, 2 medium, 3 low
+`,
+		},
+		{
+			desc: "multiple environments",
+			input: statusData{
+				EnvironmentsManaged:    true,
+				UsingDefaultNamespaces: true,
+				Service:                "svc",
+				Environments: []statusDataEnvironment{
+					{
+						Environment:           "dev",
+						Tag:                   "master-1234-5678",
+						Author:                "John Doe",
+						Committer:             "Jane Doe",
+						CommitMessage:         "Useful bits",
+						Date:                  time.Date(2021, time.June, 23, 8, 42, 22, 0, time.UTC),
+						BuildURL:              "https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect",
+						HighVulnerabilities:   1,
+						MediumVulnerabilities: 2,
+						LowVulnerabilities:    3,
+					},
+					{
+						Environment:           "staging",
+						Tag:                   "master-1234-5678",
+						Author:                "John Doe",
+						Committer:             "Jane Doe",
+						CommitMessage:         "Useful bits",
+						Date:                  time.Date(2021, time.June, 23, 8, 42, 22, 0, time.UTC),
+						BuildURL:              "https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect",
+						HighVulnerabilities:   1,
+						MediumVulnerabilities: 2,
+						LowVulnerabilities:    3,
+					},
+				},
+			},
+			output: `Status for service svc
+
+dev:
+  Tag: master-1234-5678
+  Author: John Doe
+  Committer: Jane Doe
+  Message: Useful bits
+  Date: 2021-06-23 08:42:22
+  Link: https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect
+  Vulnerabilities: 1 high, 2 medium, 3 low
+
+staging:
+  Tag: master-1234-5678
+  Author: John Doe
+  Committer: Jane Doe
+  Message: Useful bits
+  Date: 2021-06-23 08:42:22
+  Link: https://jenkins.dev.lunarway.com/job/github-lunarway/job/svc/job/master/105/display/redirect
+  Vulnerabilities: 1 high, 2 medium, 3 low
+`,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			var output bytes.Buffer
+			err := templateStatus(&output, tC.input)
+			require.NoError(t, err)
+			require.Equal(t, tC.output, output.String())
+		})
+	}
+}

--- a/cmd/hamctl/template/template.go
+++ b/cmd/hamctl/template/template.go
@@ -16,6 +16,9 @@ func Output(destination io.Writer, name, text string, data interface{}) error {
 	t := template.New(name)
 	t.Funcs(template.FuncMap{
 		"rightPad": tmplRightPad,
+		"dateFormat": func() string {
+			return "2006-01-02 15:04:05"
+		},
 	})
 	t, err := t.Parse(text)
 	if err != nil {


### PR DESCRIPTION
Add unit tests of the status template to ensure it renderes correctly. It did
not, so there are several small changes to both the look and layout.

Along the way a bug was found in the commonly used format string so this is
extracted out to a shared template variable to control how dates are presented.

Follow up on #246 