### PR TITLE
Upgrade rbac api objects to v1

### DIFF
--- a/e2e-test/fluxd.yaml
+++ b/e2e-test/fluxd.yaml
@@ -35,7 +35,7 @@ metadata:
   name: flux
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -48,7 +48,7 @@ rules:
   - nonResourceURLs: ["*"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/e2e-test/release-daemon.yaml
+++ b/e2e-test/release-daemon.yaml
@@ -67,7 +67,7 @@ spec:
         - name: lunarway-kubernetes-pull-secret
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -81,7 +81,7 @@ rules:
     verbs: ["*"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Upgrade networking api objects to v1 to be conformant.

[_Created by Sourcegraph batch change `her/update-`._](https://sourcegraph.lunar.tech/users/her/batch-changes/update-)