### PR TITLE
Upgrade alpine to 3.14.2

### DIFF
--- a/Dockerfile-daemon-goreleaser
+++ b/Dockerfile-daemon-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1 as builder
+FROM alpine:3.14.2 as builder
 
 RUN apk update
 RUN apk add ca-certificates

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -13,7 +13,7 @@ COPY cmd/server/ ./cmd/server/
 
 RUN go build -o server cmd/server/main.go
 
-FROM alpine:3.14.1
+FROM alpine:3.14.2
 RUN   apk update && \
       apk add --no-cache \
       openssh-keygen bash openssh-client git ca-certificates gnupg

--- a/Dockerfile-server-goreleaser
+++ b/Dockerfile-server-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.14.2
 RUN   apk update && \
       apk add --no-cache \
       openssh-keygen bash openssh-client git ca-certificates gnupg


### PR DESCRIPTION
Contains fixes for two CVEs in openssl.