### PR TITLE
Rework README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,109 +12,26 @@ We will however, have it public available for reference. This might change over 
 # Design
 
 The release-manager consist of 4 different "microservices" with each having a specific responsibility in the pipeline. The applications are basically utilities for moving files around a Git repository.
-The four applications are:
 
-| Application | Description                                                                                                                                                          |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| artifact    | a simple tool for generating an artifact.json blob with information from the CI pipeline                                                                             |
-| server      | the API-server where clients (hamtcl) connects to, and daemon reports events to. It further implements different flows, e.g., promote a release, release an artifact |
-| hamctl      | a CLI client for interacting with the release-manager server                                                                                                         |
-| daemon      | a daemon reporting events about cluster component status back to the release-manager server                                                                          |
+A simplified overview of all the components involved in the flow can be seen below.
 
-A simplified overview of all the components involved in the flow can be seen below:
 ![](docs/gitops_workflow.png)
 
-The applications are not enough to complete the flow. We utilize jenkins as a CI server and Weaveworks Flux as a release operator running inside each cluster.
+To read more about the what each service is responsible for see [Components](#components).
+In addition to the services we utilize [Jenkins](https://github.com/jenkinsci/jenkins) as a CI server and [flux](https://github.com/fluxcd/flux) as a release operator running inside each cluster.
 
-# Components
+# Interactions
 
-## Artifact
+As seen on the illustration the main interaction point for developers are their service repository, doing code changes and with the `hamctl` CLI.
 
-`artifact` is used to generate, what we refer to as artifacts. These are just a json-blob containing relevant information from the Continuous Integration flow.
-As mentioned we use `shuttle` in our jenkins to minimize the custom "CI" code we have to write, making it portable, if we decide to change CI solution at some point. The id's of the artifacts, are composed of `<Branch>-<Source Repository>-<Plan Repository>`.
+Below are descriptions of the common commands used in day to day activities.
 
-An example of a generated `artifact.json`
-
-```json
-{
-  "id": "dev-0017d995e3-67e9d69164",
-  "application": {
-    "sha": "0017d995e32e3d1998395d971b969bcf682d2085",
-    "authorName": "First Last",
-    "authorEmail": "email@lunarway.com",
-    "committerName": "First Last",
-    "committerEmail": "email@lunarway.com",
-    "message": "reformat something",
-    "name": "lunar-way-example-service",
-    "url": "https://bitbucket.org/LunarWay/lunar-way-example-service/commits/0017d995e32e3d1998395d971b969bcf682d2085",
-    "provider": "BitBucket"
-  },
-  "ci": {
-    "jobUrl": "https://jenkins.example.lunarway.com/job/bitbucket/job/lunar-way-example-service/job/dev/84/display/redirect",
-    "start": "2019-03-29T13:47:15.259380775+01:00",
-    "end": "2019-03-29T13:49:57.686299407+01:00"
-  },
-  "shuttle": {
-    "plan": {
-      "message": "fixes-a-bug-where-database-names-would-not-be-valid-if-services-have-more-than-one-dash-in-their-name",
-      "url": "git://git@bitbucket.org:LunarWay/lw-shuttle-go-plan.git"
-    }
-  },
-  "stages": [
-    {
-      "id": "build",
-      "name": "Build",
-      "data": {
-        "dockerVersion": "18.09.3",
-        "image": "quay.io/lunarway/example",
-        "tag": "dev-0017d995e3-67e9d69164"
-      }
-    },
-    {
-      "id": "snyk-code",
-      "name": "Security Scan - Code",
-      "data": {
-        "url": "https://app.snyk.io/org/squad-example/project/ID/history/ID",
-        "vulnerabilities": {
-          "high": 0,
-          "low": 0,
-          "medium": 0
-        }
-      }
-    },
-    {
-      "id": "test",
-      "name": "Test",
-      "data": {
-        "results": {
-          "failed": 0,
-          "passed": 173,
-          "skipped": 0
-        },
-        "url": "https://jenkins.example.lunarway.com/job/bitbucket/job/lunar-way-example-service/job/dev/84/display/redirect"
-      }
-    },
-    {
-      "id": "push",
-      "name": "Push",
-      "data": {
-        "dockerVersion": "18.09.3",
-        "image": "quay.io/lunarway/example",
-        "tag": "dev-0017d995e3-67e9d69164"
-      }
-    }
-  ]
-}
-```
-
-## Server
-
-### Promote
+## Promote
 
 The promotion flows, is a convetion based release process. It can be invoked by `hamctl` as follows:
 
 ```
-$ hamctl promote --service example --env dev
+hamctl promote --service example --env dev
 ```
 
 The convention follows the following flow: `master -> dev -> staging -> prod`
@@ -123,12 +40,12 @@ As seen in the example above, the `example` service will be promoted from the la
 Another example, is a promotion of an artifact running in, e.g. staging, to the production environment. This can be achieved with the following command:
 
 ```
-$ hamctl promote --service example --env prod
+hamctl promote --service example --env prod
 ```
 
 The above locates what is running in the `staging` environment, and takes the necessary steps to run the same artifact in `prod`.
 
-### Release
+## Release
 
 The release flow, is a more liberal release process. There is no conventions in how artifacts move between environments. This makes it suitable for releasing `hotfix`-branches to production or `feature`-branches to a specific environment for testing before merging into `master`.
 
@@ -137,16 +54,16 @@ The release flow currently consist of two approaches, either the release of the 
 Example of a release of a feature branch to the `dev` environment:
 
 ```
-$ hamctl release --service example --branch "feature/new_feature" --env dev
+hamctl release --service example --branch "feature/new_feature" --env dev
 ```
 
 Example of a release of a specific artifact id to the `staging` environment:
 
 ```
-$ hamctl release --service example --artifact dev-0017d995e3-67e9d69164 --env staging
+hamctl release --service example --artifact dev-0017d995e3-67e9d69164 --env staging
 ```
 
-### Status
+## Status
 
 Status is a convience flow to display currently released artifact to the three different environments; `dev`, `staging`,`prod`.
 
@@ -159,7 +76,7 @@ dev:
   Committer: Peter Petersen
   Message: empty-commit-to-test-flow
   Date: 2019-04-01 11:14:26 +0200 CEST
-  Link: https://jenkins.example.lunarway.com/job/bitbucket/job/lunar-way-example-service/job/master/132/display/redirect
+  Link: https://jenkins.example.lunar.app/job/github/job/example-service/job/master/132/display/redirect
   Vulnerabilities: 0 high, 0 medium, 0 low
 
 staging:
@@ -168,7 +85,7 @@ staging:
   Committer: Peter Petersen
   Message: empty-commit-to-test-flow
   Date: 2019-04-01 11:14:26 +0200 CEST
-  Link: https://jenkins.example.lunarway.com/job/bitbucket/job/lunar-way-example-service/job/master/132/display/redirect
+  Link: https://jenkins.example.lunar.app/job/github/job/example-service/job/master/132/display/redirect
   Vulnerabilities: 0 high, 0 medium, 0 low
 
 prod:
@@ -177,20 +94,20 @@ prod:
   Committer: Hans Hansen
   Message: some-commit
   Date: 2019-04-01 11:14:26 +0200 CEST
-  Link: https://jenkins.example.lunarway.com/job/bitbucket/job/lunar-way-example-service/job/master/132/display/redirect
+  Link: https://jenkins.example.lunar.app/job/github/job/example-service/job/master/132/display/redirect
   Vulnerabilities: 0 high, 0 medium, 0 low
 ```
 
-### Policies
+## Policies
 
 It is possible to configure policies for releases with `hamctl`'s `policy` command and globally with flags on the `server`.
 
 You can `list`, `apply` and `delete` policies for a specific service like below.
 
 ```
-$ hamctl policy --service <service> list
-$ hamctl policy --service <service> apply <policy>
-$ hamctl policy --service <service> delete <policy-id> [<policy-id>]
+hamctl policy --service <service> list
+hamctl policy --service <service> apply <policy>
+hamctl policy --service <service> delete <policy-id> [<policy-id>]
 ```
 
 See below for details on how to apply specific policies.
@@ -199,7 +116,7 @@ Some policies cannot be applied simultaniously as they semantically does not sup
 An example is an `auto-release` policy releasing a branch not compatible with a `branch-restriction` policy.
 These cases are validated when applying either of them.
 
-#### Auto-release artifacts from branches to environments
+### Auto-release artifacts from branches to environments
 
 An `auto-release` policy instructs the release manager to deploy new artifacts from a specific branch into an environment.
 
@@ -208,10 +125,10 @@ Multiple policies can be applied for the same branch to different environments, 
 This is an example of applying an auto-release policy for the product service for the `master` branch and `dev` environment.
 
 ```
-$ hamctl policy --service example apply auto-release --branch master --env dev
+hamctl policy --service example apply auto-release --branch master --env dev
 ```
 
-#### Branch restriction on environments
+### Branch restriction on environments
 
 A `branch-restriction` policy instructs the release manager to only allow artifacts from specific branches to be released to an environment.
 The `--branch-regex` flag defines a regular expression that is matched against the branch name on every release.
@@ -219,13 +136,13 @@ The `--branch-regex` flag defines a regular expression that is matched against t
 As an example, the following command applies a branch-restriction policy for the `example` service that only allows the `master` branch to be released to the `prod` environment.
 
 ```
-$ hamctl policy --service example apply branch-restriction --env prod --branch-regex '^master$'
+hamctl policy --service example apply branch-restriction --env prod --branch-regex '^master$'
 ```
 
 Another example is to allow only `master` or `hostfix/*` branches in `prod` like this.
 
 ```
-$ hamctl policy --service example apply branch-restriction --env prod --branch-regex '^(master|hotfix\/.+)$'
+hamctl policy --service example apply branch-restriction --env prod --branch-regex '^(master|hotfix\/.+)$'
 ```
 
 It is not possible to create an auto-release policy for a non-matching branch to an environment that is protected by a branch-restriction policy.
@@ -237,88 +154,13 @@ The `server` can also enforce branch restrictions on all managed services by set
 It takes a comma seprated list of `<environment>=<branchRegex>` values.
 
 ```
-$ server start --policy-branch-restrictions 'production=^master$,staging=^staging$'
+server start --policy-branch-restrictions 'production=^master$,staging=^staging$'
 ```
 
 They will be visible with `hamctl policy list` but cannot by removed with `hamctl`.
 It is also not possible to overwrite them with custom policies, e.g. changing branch of a globally restricted environment.
 
-### Notifications
-
-When releasing applications the server will notify different upstream services along with outputting an identifiable log useful for log aggregation statistics.
-
-```
-info  command/start.go:145  Release [dev]: verification (master-e8da185c2c-06249f1a78) by Bjørn Sørensen, author Bjørn Sørensen
-```
-
-A Slack message is pushed to a `#releases-<env>` Slack channel.
-
-![](docs/slack_release_message.png)
-
-Grafana is annotated with release metadata and tag `deployment`.
-
-![](docs/grafana_annotation.png)
-
-If the artifact provider is GitHub and a GitHub API token is provided (`--github-api-token`) the application source repository is tagged with `<env>` on the released Git SHA.
-
-![](docs/github_tag.png)
-
-### Tracing support
-
-The server collects [Jaeger](https://www.jaegertracing.io/) spans. This is enabled by default and reported as service `release-manager`.
-The jaeger configuration can be customized with available [environment variables](https://github.com/jaegertracing/jaeger-client-go#environment-variables).
-
-For local development a jaeger all-in-one instance can be created with Docker running `make jaeger`.
-The Jaeger UI will be available on [`localhost:16686`](http://localhost:16686).
-
-To disable collection set `JAEGER_DISABLED=true`.
-
-## hamctl
-
-`hamctl` is a thin CLI for interacting with the release-manager server. The different commands implemented in `hamctl` is visible in the previous section.
-
-`hamctl` uses a token-based authentication model for interacting with the release-manager. This can either be provided as command-line argument `--http-auth-token` og set using a ENV variable: `HAMCTL_AUTH_TOKEN`.
-
-### Completions
-
-Shell completions are available with the command `completion`.
-The following commands will add completions to the current shell in either bash or zsh.
-
-```
-source <(hamctl completion bash)
-source <(hamctl completion zsh)
-```
-
-For a more detailed installation instruction see the help output.
-
-```
-hamctl completion --help
-```
-
-## daemon
-
-`daemon` is a small controller running in each of the environments and reports state changes in the environment back to the release-manager. `daemon` needs access to the kubernetes api server, and can be configured using a `ServiceAccount`.
-
-`daemon` uses a token-based authentication model for interacting with the release-manager. This token can be set using the command-line argument `--auth-token` or the ENV variable: `HAMCTL_AUTH_TOKEN`
-
-# Storage
-
-Multiple entities are stored in different storage layers to allow the release manager to work.
-
-## Artifacts
-
-Artifacts are stored in an AWS S3 bucket.
-They are stored as `zip` files with keys from the service name and artifact id.
-
-```
-.
-├── <service>
-│  └── <artifact-id>
-└── example
-    └── master-sha1234-plan1234
-```
-
-## Releases and policies
+# Releases and policies
 
 Release files are structured as shown below.
 In the root are folders for each environment, e.g. `dev`, `prod`.
@@ -359,13 +201,183 @@ When running `kubectl apply` files are applied to the cluster alphabetically so 
 60-69 ingress
 ```
 
-Resources starting with `00_` will skip resource validation. CustomResourceDefintions does not work with the used resource validation, thus they should always start with `00_`.
+Resources starting with `00_` will skip resource validation in the Lunar shuttle plans.
+`CustomResourceDefintions` requires custom schemas which are usually not available so they should always start with `00_`.
+
+# Components
+
+The release-manager consists of four applications.
+
+| Application | Description                                                                                                                                                          |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| artifact    | a simple tool for generating an artifact.json blob with information from the CI pipeline                                                                             |
+| daemon      | a daemon reporting events about cluster component status back to the release-manager server                                                                          |
+| hamctl      | a CLI client for interacting with the release-manager server                                                                                                         |
+| server      | the API-server where clients (hamtcl) connects to, and daemon reports events to. It further implements different flows, e.g., promote a release, release an artifact |
+
+## Artifact
+
+`artifact` is used to generate, what we refer to as artifacts.
+These are a `json` file containing relevant information from the CI flow.
+The id's of the artifacts, are composed of `<branch-name>-<application-git-sha>-<shuttle-plan-git-sha>`.
+
+We use [shuttle](https://github.com/lunarway/shuttle) plans to centralize our CI pipeline definitions, which is why we include the version of the plan in the artifact id.
+
+Here is a redacted example of a generated artifact specification.
+
+```json
+{
+  "id": "dev-0017d995e3-67e9d69164",
+  "application": {
+    "sha": "0017d995e32e3d1998395d971b969bcf682d2085",
+    "message": "fix something",
+    "name": "example-service",
+    ...
+    "url": "https://github.com/lunarway/example-service/commits/0017d995e32e3d1998395d971b969bcf682d2085",
+    "provider": "GitHub"
+  },
+  "ci": {
+    "jobUrl": "https://jenkins.example.lunar.app/job/github/job/example-service/job/dev/84/display/redirect",
+    "start": "2019-03-29T13:47:15.259380775+01:00",
+    "end": "2019-03-29T13:49:57.686299407+01:00"
+  },
+  "shuttle": {
+    "plan": {
+      "message": "Support-new-feature",
+      "url": "git://git@github.com:lunarway/lw-shuttle-go-plan.git"
+    }
+  },
+  "stages": [
+    {
+      "id": "build",
+      "name": "Build",
+      "data": {
+        "dockerVersion": "18.09.3",
+        "image": "quay.io/lunarway/example",
+        "tag": "dev-0017d995e3-67e9d69164"
+      }
+    }
+  ]
+}
+```
+
+## hamctl
+
+`hamctl` is a CLI for interacting with the release-manager server.
+Examples of commands are `hamctl release` or `hamctl status`.
+
+See [Interactions](#interactions) for more examples.
+
+It uses a token-based authentication model for interacting with the server.
+This can either be provided as a command-line argument `--http-auth-token` or using the environment variable `HAMCTL_AUTH_TOKEN`.
+
+### Completions
+
+Shell completions are available with the command `completion`.
+The following commands will add completions to the current shell in either bash or zsh.
+
+```
+source <(hamctl completion bash)
+source <(hamctl completion zsh)
+```
+
+For a more detailed installation instruction see the help output.
+
+```
+hamctl completion --help
+```
+
+## daemon
+
+The `daemon` is an agent running in each of the kubernetes clusters and reports state changes in the environment back to the release-manager.
+`daemon` needs access to the kubernetes API server, and can be configured using a `ServiceAccount`.
+
+`daemon` uses a token-based authentication model for interacting with the release-manager.
+This token can be set using the command-line argument `--auth-token` or the ENV variable: `DAEMON_AUTH_TOKEN`
+
+## Server
+
+The server is responsible for all the operations related to releasing new versions.
+`hamctl` and `artifact` communicates with it over HTTP to initiate releases, register new artifacts etc.
+
+In its simplest form it is responsible for moving files around a Git repository based on the commands it receives, eg. release artifact.
+
+### Notifications
+
+When releasing applications the server will notify different upstream services along with outputting an identifiable log useful for log aggregation statistics.
+
+```
+info  command/start.go:145  Release [dev]: verification (master-e8da185c2c-06249f1a78) by Bjørn Sørensen, author Bjørn Sørensen
+```
+
+A Slack message is pushed to a `#releases-<env>` Slack channel.
+
+![](docs/slack_release_message.png)
+
+Grafana is annotated with release metadata and tag `deployment` useful for plotting on graphs to see when new releases are rolled out.
+
+![](docs/grafana_annotation.png)
+
+If the artifact provider is GitHub and a GitHub API token is provided (`--github-api-token`) the application source repository is tagged with `<env>` on the released Git SHA.
+
+![](docs/github_tag.png)
+
+### Tracing support
+
+The server collects [Jaeger](https://www.jaegertracing.io/) spans. This is enabled by default and reported as service `release-manager`.
+The jaeger configuration can be customized with available [environment variables](https://github.com/jaegertracing/jaeger-client-go#environment-variables).
+
+For local development a jaeger all-in-one instance can be created with Docker running `make jaeger`.
+The Jaeger UI will be available on [`localhost:16686`](http://localhost:16686).
+
+To disable collection set `JAEGER_DISABLED=true`.
+
+# Storage
+
+Multiple entities are stored in different storage layers to allow the release manager to work.
+
+## Artifacts
+
+Artifacts are stored in an AWS S3 bucket.
+They are stored as `zip` files with keys from the service name and artifact id.
+
+```
+.
+├── <service>
+│  └── <artifact-id>
+└── example
+    └── master-sha1234-plan1234
+```
+
+## Policies
+
+Policies are stored in the Git repository along with all releases.
+Each service policy is a JSON file in the `policies/<service>.json` path.
+
+```json
+{
+  "service": "example",
+  "autoReleases": [
+    {
+      "id": "auto-release-master-dev",
+      "branch": "master",
+      "environment": "dev"
+    }
+  ]
+}
+```
 
 # Installation
 
+All the applications are cross compiled to Linux and MacOS and available in the [Releases](https://github.com/lunarway/release-manager/releases) page.
+The server and daemon are also available as Docker images at [quay.io/lunarway/release-manager](quay.io/lunarway/release-manager) and [quay.io/lunarway/release-daemon](quay.io/lunarway/release-daemon).
+
+Usually you will release the server and daemon with kubernetes `Deployment` resources and distribute the `hamctl` CLI to developers.
+`artifact` should be distributed to the Jenkins CI server and used in the pipelines.
+
 ## Access to the config repository
 
-The release manager needs read/write permissions to the config repo.
+The release manager server needs read/write permissions to the config repo.
 
 To create a secret that the release manager can consume: (expects that the filename is identity)
 
@@ -409,8 +421,6 @@ This setup is based a kubernetes cluster managed by `kind`. The following resour
 | `release-server`  | A locally built binary of the release-daemon, that is running in the same manner as the `release-daemon`                                                                                                                                                                                                     |
 | `rabbitmq`        | A simply setup rabbitmq server for the release-manager                                                                                                                                                                                                                                                       |
 
-### e2e actions
-
 To use the e2e setup there are the following actions supported:
 
 | Action                   | Command                          | Description                                                                                          |
@@ -424,10 +434,7 @@ To use the e2e setup there are the following actions supported:
 | Do another dummy release | `make e2e-do-another-release`    | Do another kind of release in git repo to trigger fluxd change                                       |
 | Stop e2e setup           | `make e2e-teardown`              | Stop and cleanup the e2e setup                                                                       |
 
-# Release
-
-There are multiple applications in this repo.
+## Releasing
 
 This project is configured with `goreleaser` and releases all 4 applications at once.
-
-The release-manager server and the release-daemon is available as docker images, besides raw binaries.
+Push a new tag to the main branch and Travis will publish a new release and create the changelog.


### PR DESCRIPTION
The README is currently pretty rough to read. It jumps straight into JSON
snippets and details instead of bringing usage patterns to the top.

This change moves sections around to make it easier to digest along with
changing some sentences here and there.