### PR TITLE
Remove binaries field from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,15 +45,11 @@ builds:
 
 dockers:
   - dockerfile: Dockerfile-server-goreleaser
-    binaries:
-    - server
     image_templates:
     - "quay.io/lunarway/release-manager:{{ .Tag }}"
     extra_files:
     - ssh_config
   - dockerfile: Dockerfile-daemon-goreleaser
-    binaries:
-    - daemon
     image_templates:
     - "quay.io/lunarway/release-daemon:{{ .Tag }}"
 


### PR DESCRIPTION
The fields are deprecated and now does nothing.

https://github.com/goreleaser/goreleaser/blob/master/www/docs/deprecations.md#dockerbinaries