### PR TITLE
Add dynamic Grafana annotation flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ SERVER_START=./dist/server start \
 		--ssh-private-key ${SSH_PRIVATE_KEY} \
 		--slack-token ${SLACK_TOKEN} \
 		--grafana-api-key-dev ${GRAFANA_API_KEY} \
-		--grafana-dev-url ${GRAFANA_URL} \
+		--grafana-url-dev ${GRAFANA_URL} \
 		--hamctl-auth-token ${AUTH_TOKEN} \
 		--daemon-auth-token ${AUTH_TOKEN} \
 		--artifact-auth-token ${AUTH_TOKEN} \

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,7 @@ S3_BUCKET=release-manager-test
 SERVER_START=./dist/server start \
 		--ssh-private-key ${SSH_PRIVATE_KEY} \
 		--slack-token ${SLACK_TOKEN} \
-		--grafana-api-key-dev ${GRAFANA_API_KEY} \
-		--grafana-url-dev ${GRAFANA_URL} \
+		--grafana-annotations dev=${GRAFANA_API_KEY}=${GRAFANA_URL} \
 		--hamctl-auth-token ${AUTH_TOKEN} \
 		--daemon-auth-token ${AUTH_TOKEN} \
 		--artifact-auth-token ${AUTH_TOKEN} \

--- a/cmd/server/command/flags.go
+++ b/cmd/server/command/flags.go
@@ -4,8 +4,20 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lunarway/release-manager/internal/grafana"
 	"github.com/pkg/errors"
 )
+
+func mapGrafanaOptionsToEnvironment(opts *grafanaOptions) map[string]grafana.Environment {
+	environments := make(map[string]grafana.Environment)
+	for env, config := range *opts {
+		environments[env] = grafana.Environment{
+			APIKey:  config.APIKey,
+			BaseURL: config.URL,
+		}
+	}
+	return environments
+}
 
 type grafanaConfig struct {
 	URL    string

--- a/cmd/server/command/flags.go
+++ b/cmd/server/command/flags.go
@@ -1,0 +1,82 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type grafanaConfig struct {
+	URL    string
+	APIKey string
+}
+
+type grafanaOptions map[string]grafanaConfig
+
+func (opts *grafanaOptions) String() string {
+	values := opts.GetSlice()
+	if len(values) == 0 {
+		return "[]"
+	}
+	return strings.Join(values, ",")
+}
+
+func (opts *grafanaOptions) Type() string {
+	return "<env>=<api-key>=<url>"
+}
+
+func (opts *grafanaOptions) Set(csv string) error {
+	for _, split := range strings.Split(csv, ",") {
+		err := opts.Append(split)
+		if err != nil {
+			return fmt.Errorf("flag value '%s': %w", split, err)
+		}
+	}
+	return nil
+}
+
+// GetSlice returns the flag value list as an array of strings.
+func (opts *grafanaOptions) GetSlice() []string {
+	var values []string
+	for env, value := range *opts {
+		values = append(values, fmt.Sprintf("%s=<redacted>=%s", env, value.URL))
+	}
+	return values
+}
+
+// Append adds the specified value to the end of the flag value list.
+func (opts *grafanaOptions) Append(value string) error {
+	env, config, err := parseGrafanaConfig(value)
+	if err != nil {
+		return err
+	}
+	(*opts)[env] = config
+	return nil
+}
+
+// Replace will fully overwrite any data currently in the flag value list.
+func (opts *grafanaOptions) Replace(values []string) error {
+	newOpts := grafanaOptions{}
+	for _, value := range values {
+		err := newOpts.Append(value)
+		if err != nil {
+			return err
+		}
+	}
+	*opts = newOpts
+	return nil
+}
+
+func parseGrafanaConfig(value string) (string, grafanaConfig, error) {
+	splits := strings.SplitN(value, "=", 3)
+
+	if len(splits) < 3 {
+		return "", grafanaConfig{}, errors.New("value must be formatted as <env>=<api-key>=<url>")
+	}
+
+	return splits[0], grafanaConfig{
+		APIKey: splits[1],
+		URL:    splits[2],
+	}, nil
+}

--- a/cmd/server/command/flags.go
+++ b/cmd/server/command/flags.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lunarway/release-manager/internal/grafana"
@@ -54,6 +55,7 @@ func (opts *grafanaOptions) GetSlice() []string {
 	for env, value := range *opts {
 		values = append(values, fmt.Sprintf("%s=<redacted>=%s", env, value.URL))
 	}
+	sort.Strings(values)
 	return values
 }
 

--- a/cmd/server/command/flags_test.go
+++ b/cmd/server/command/flags_test.go
@@ -4,11 +4,66 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGrafanaOptions(t *testing.T) {
+var _ pflag.SliceValue = &grafanaOptions{}
+var _ pflag.Value = &grafanaOptions{}
+
+func TestGrafanaOptions_String(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  grafanaOptions
+		output string
+	}{
+		{
+			name:   "empty",
+			input:  grafanaOptions{},
+			output: "[]",
+		},
+		{
+			name: "single entry",
+			input: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+			},
+			output: "dev=<redacted>=localhost",
+		},
+		{
+			name: "multiple entries",
+			input: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost1",
+					APIKey: "key",
+				},
+				"staging": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "key",
+				},
+			},
+			output: "dev=<redacted>=localhost1,staging=<redacted>=localhost2",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := tc.input.String()
+
+			assert.Equal(t, tc.output, output)
+		})
+	}
+}
+
+func TestGrafanaOptions_Type(t *testing.T) {
+	options := grafanaOptions{}
+
+	assert.Equal(t, "<env>=<api-key>=<url>", options.Type())
+}
+
+func TestGrafanaOptions_Set(t *testing.T) {
 	tt := []struct {
 		name   string
 		input  string
@@ -78,6 +133,192 @@ func TestGrafanaOptions(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.output, opts)
+		})
+	}
+}
+
+func TestGrafanaOptions_GetSlice(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		input  grafanaOptions
+		output []string
+	}{
+		{
+			desc:   "empty",
+			input:  grafanaOptions{},
+			output: nil,
+		},
+		{
+			desc: "single entry",
+			input: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "a-key",
+				},
+			},
+			output: []string{
+				"dev=<redacted>=localhost",
+			},
+		},
+		{
+			desc: "multiple entries",
+			input: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost1",
+					APIKey: "a-key",
+				},
+				"staging": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "another-key",
+				},
+			},
+			output: []string{
+				"dev=<redacted>=localhost1",
+				"staging=<redacted>=localhost2",
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			output := tC.input.GetSlice()
+			assert.Equal(t, tC.output, output)
+		})
+	}
+}
+
+func TestGrafanaOptions_Append(t *testing.T) {
+	tt := []struct {
+		name    string
+		options grafanaOptions
+		input   string
+		output  grafanaOptions
+		err     error
+	}{
+		{
+			name: "added new entry",
+			options: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+			},
+			input: "staging=key=localhost2",
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+				"staging": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "key",
+				},
+			},
+		},
+		{
+			name: "added existing entry",
+			options: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+			},
+			input: "dev=key=localhost2",
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "key",
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.options.Append(tc.input)
+
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.output, tc.options)
+		})
+	}
+}
+
+func TestGrafanaOptions_Replace(t *testing.T) {
+	tt := []struct {
+		name    string
+		options grafanaOptions
+		input   []string
+		output  grafanaOptions
+		err     error
+	}{
+		{
+			name: "single entry",
+			options: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost1",
+					APIKey: "key",
+				},
+			},
+			input: []string{"staging=key=localhost2"},
+			output: grafanaOptions{
+				"staging": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "key",
+				},
+			},
+		},
+		{
+			name: "equal entry with addition",
+			options: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost1",
+					APIKey: "key",
+				},
+			},
+			input: []string{"dev=key=localhost", "staging=key=localhost2"},
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+				"staging": grafanaConfig{
+					URL:    "localhost2",
+					APIKey: "key",
+				},
+			},
+		},
+		{
+			name: "bad entry",
+			options: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost1",
+					APIKey: "key",
+				},
+			},
+			input: []string{"dev=key"},
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+			},
+			err: errors.New("value must be formatted as <env>=<api-key>=<url>"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.options.Replace(tc.input)
+
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.output, tc.options)
 		})
 	}
 }

--- a/cmd/server/command/flags_test.go
+++ b/cmd/server/command/flags_test.go
@@ -1,0 +1,83 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrafanaOptions(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  string
+		output grafanaOptions
+		err    error
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			output: grafanaOptions{},
+			err:    errors.New("flag value '': value must be formatted as <env>=<api-key>=<url>"),
+		},
+		{
+			name:  "single complete",
+			input: "dev=key=localhost",
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key",
+				},
+			},
+			err: nil,
+		},
+		{
+			name:  "multiple complete",
+			input: "dev=key1=localhost,staging=key2=anotherhost",
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost",
+					APIKey: "key1",
+				},
+				"staging": grafanaConfig{
+					URL:    "anotherhost",
+					APIKey: "key2",
+				},
+			},
+			err: nil,
+		},
+		{
+			name:  "url with =",
+			input: "dev=key1=localhost?query=param",
+			output: grafanaOptions{
+				"dev": grafanaConfig{
+					URL:    "localhost?query=param",
+					APIKey: "key1",
+				},
+			},
+			err: nil,
+		},
+		{
+			name:   "multiple values with one incomplete",
+			input:  "dev=key1=localhost,staging=key2",
+			output: grafanaOptions{},
+			err:    errors.New("flag value 'staging=key2': value must be formatted as <env>=<api-key>=<url>"),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := grafanaOptions{}
+
+			err := opts.Set(tc.input)
+
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.output, opts)
+		})
+	}
+}

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -18,7 +18,7 @@ import (
 func NewRoot(version string) (*cobra.Command, error) {
 	var brokerOpts brokerOptions
 	var httpOpts http.Options
-	var grafanaOpts grafanaOptions
+	grafanaOpts := grafanaOptions{}
 	var slackAuthToken string
 	var githubAPIToken string
 	var configRepoOpts configRepoOptions
@@ -88,17 +88,7 @@ func NewRoot(version string) (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&httpOpts.GithubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
 	command.PersistentFlags().StringVar(&githubAPIToken, "github-api-token", os.Getenv("GITHUB_API_TOKEN"), "github api token for tagging releases")
 	command.PersistentFlags().StringVar(&slackAuthToken, "slack-token", os.Getenv("SLACK_TOKEN"), "token to be used to communicate with the slack api")
-
-	command.PersistentFlags().StringVar(&grafanaOpts.DevAPIKey, "grafana-api-key-dev", os.Getenv("GRAFANA_API_KEY_DEV"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&grafanaOpts.StagingAPIKey, "grafana-api-key-staging", os.Getenv("GRAFANA_API_KEY_STAGING"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&grafanaOpts.ProdAPIKey, "grafana-api-key-prod", os.Getenv("GRAFANA_API_KEY_PROD"), "api key to be used to annotate in prod")
-	command.PersistentFlags().StringVar(&grafanaOpts.PlatformAPIKey, "grafana-api-key-platform", os.Getenv("GRAFANA_API_KEY_PLATFORM"), "api key to be used to annotate in platform")
-
-	command.PersistentFlags().StringVar(&grafanaOpts.DevURL, "grafana-url-dev", os.Getenv("GRAFANA_URL_DEV"), "grafana dev url")
-	command.PersistentFlags().StringVar(&grafanaOpts.StagingURL, "grafana-url-staging", os.Getenv("GRAFANA_URL_STAGING"), "grafana staging url")
-	command.PersistentFlags().StringVar(&grafanaOpts.ProdURL, "grafana-url-prod", os.Getenv("GRAFANA_URL_PROD"), "grafana prod url")
-	command.PersistentFlags().StringVar(&grafanaOpts.PlatformURL, "grafana-url-platform", os.Getenv("GRAFANA_URL_PLATFORM"), "grafana platform url")
-
+	command.PersistentFlags().Var(&grafanaOpts, "grafana-annotations", "configuration of Grafana environments to annotate. Use comma separated list for multiple environments")
 	command.PersistentFlags().StringVar(&emailSuffix, "email-suffix", "", "company email suffix to expect. E.g.: '@example.com'")
 	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
 	command.PersistentFlags().StringSliceVar(&branchRestrictionsList, "policy-branch-restrictions", []string{}, "branch restriction policies applied to all releases, key-value pair: <environment>=<branch-regex>")

--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -88,12 +88,17 @@ func NewRoot(version string) (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&httpOpts.GithubWebhookSecret, "github-webhook-secret", os.Getenv("GITHUB_WEBHOOK_SECRET"), "github webhook secret")
 	command.PersistentFlags().StringVar(&githubAPIToken, "github-api-token", os.Getenv("GITHUB_API_TOKEN"), "github api token for tagging releases")
 	command.PersistentFlags().StringVar(&slackAuthToken, "slack-token", os.Getenv("SLACK_TOKEN"), "token to be used to communicate with the slack api")
-	command.PersistentFlags().StringVar(&grafanaOpts.DevAPIKey, "grafana-api-key-dev", os.Getenv("GRAFANA_DEV_API_KEY"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&grafanaOpts.StagingAPIKey, "grafana-api-key-staging", os.Getenv("GRAFANA_STAGING_API_KEY"), "api key to be used to annotate in dev")
-	command.PersistentFlags().StringVar(&grafanaOpts.ProdAPIKey, "grafana-api-key-prod", os.Getenv("GRAFANA_PROD_API_KEY"), "api key to be used to annotate in prod")
-	command.PersistentFlags().StringVar(&grafanaOpts.DevURL, "grafana-dev-url", os.Getenv("GRAFANA_DEV_URL"), "grafana dev url")
-	command.PersistentFlags().StringVar(&grafanaOpts.StagingURL, "grafana-staging-url", os.Getenv("GRAFANA_STAGING_URL"), "grafana staging url")
-	command.PersistentFlags().StringVar(&grafanaOpts.ProdURL, "grafana-prod-url", os.Getenv("GRAFANA_PROD_URL"), "grafana prod url")
+
+	command.PersistentFlags().StringVar(&grafanaOpts.DevAPIKey, "grafana-api-key-dev", os.Getenv("GRAFANA_API_KEY_DEV"), "api key to be used to annotate in dev")
+	command.PersistentFlags().StringVar(&grafanaOpts.StagingAPIKey, "grafana-api-key-staging", os.Getenv("GRAFANA_API_KEY_STAGING"), "api key to be used to annotate in dev")
+	command.PersistentFlags().StringVar(&grafanaOpts.ProdAPIKey, "grafana-api-key-prod", os.Getenv("GRAFANA_API_KEY_PROD"), "api key to be used to annotate in prod")
+	command.PersistentFlags().StringVar(&grafanaOpts.PlatformAPIKey, "grafana-api-key-platform", os.Getenv("GRAFANA_API_KEY_PLATFORM"), "api key to be used to annotate in platform")
+
+	command.PersistentFlags().StringVar(&grafanaOpts.DevURL, "grafana-url-dev", os.Getenv("GRAFANA_URL_DEV"), "grafana dev url")
+	command.PersistentFlags().StringVar(&grafanaOpts.StagingURL, "grafana-url-staging", os.Getenv("GRAFANA_URL_STAGING"), "grafana staging url")
+	command.PersistentFlags().StringVar(&grafanaOpts.ProdURL, "grafana-url-prod", os.Getenv("GRAFANA_URL_PROD"), "grafana prod url")
+	command.PersistentFlags().StringVar(&grafanaOpts.PlatformURL, "grafana-url-platform", os.Getenv("GRAFANA_URL_PLATFORM"), "grafana platform url")
+
 	command.PersistentFlags().StringVar(&emailSuffix, "email-suffix", "", "company email suffix to expect. E.g.: '@example.com'")
 	command.PersistentFlags().StringSliceVar(&users, "user-mappings", []string{}, "user mappings between emails used by Git and Slack, key-value pair: <email>=<slack-email>")
 	command.PersistentFlags().StringSliceVar(&branchRestrictionsList, "policy-branch-restrictions", []string{}, "branch restriction policies applied to all releases, key-value pair: <environment>=<branch-regex>")

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -33,12 +33,14 @@ import (
 )
 
 type grafanaOptions struct {
-	DevAPIKey     string
-	DevURL        string
-	StagingAPIKey string
-	StagingURL    string
-	ProdAPIKey    string
-	ProdURL       string
+	DevAPIKey      string
+	DevURL         string
+	StagingAPIKey  string
+	StagingURL     string
+	ProdAPIKey     string
+	ProdURL        string
+	PlatformAPIKey string
+	PlatformURL    string
 }
 
 // brokerType represents a configured broker type. It implements pflag.Value to
@@ -144,6 +146,10 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					"prod": {
 						APIKey:  startOptions.grafana.ProdAPIKey,
 						BaseURL: startOptions.grafana.ProdURL,
+					},
+					"platform": {
+						APIKey:  startOptions.grafana.PlatformAPIKey,
+						BaseURL: startOptions.grafana.PlatformURL,
 					},
 				},
 			}

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -32,17 +32,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type grafanaOptions struct {
-	DevAPIKey      string
-	DevURL         string
-	StagingAPIKey  string
-	StagingURL     string
-	ProdAPIKey     string
-	ProdURL        string
-	PlatformAPIKey string
-	PlatformURL    string
-}
-
 // brokerType represents a configured broker type. It implements pflag.Value to
 // support input validation and typesafety.
 type brokerType string
@@ -134,24 +123,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			}
 			defer tracer.Close()
 			grafanaSvc := grafana.Service{
-				Environments: map[string]grafana.Environment{
-					"dev": {
-						APIKey:  startOptions.grafana.DevAPIKey,
-						BaseURL: startOptions.grafana.DevURL,
-					},
-					"staging": {
-						APIKey:  startOptions.grafana.StagingAPIKey,
-						BaseURL: startOptions.grafana.StagingURL,
-					},
-					"prod": {
-						APIKey:  startOptions.grafana.ProdAPIKey,
-						BaseURL: startOptions.grafana.ProdURL,
-					},
-					"platform": {
-						APIKey:  startOptions.grafana.PlatformAPIKey,
-						BaseURL: startOptions.grafana.PlatformURL,
-					},
-				},
+				Environments: mapGrafanaOptionsToEnvironment(startOptions.grafana),
 			}
 			// Import GPG Keys
 			if startOptions.gitConfigOpts.SigningKey != "" {
@@ -461,4 +433,15 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 		// values
 		return nil, errors.New("no broker selected")
 	}
+}
+
+func mapGrafanaOptionsToEnvironment(opts *grafanaOptions) map[string]grafana.Environment {
+	environments := make(map[string]grafana.Environment)
+	for env, config := range *opts {
+		environments[env] = grafana.Environment{
+			APIKey:  config.APIKey,
+			BaseURL: config.URL,
+		}
+	}
+	return environments
 }

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -434,14 +434,3 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 		return nil, errors.New("no broker selected")
 	}
 }
-
-func mapGrafanaOptionsToEnvironment(opts *grafanaOptions) map[string]grafana.Environment {
-	environments := make(map[string]grafana.Environment)
-	for env, config := range *opts {
-		environments[env] = grafana.Environment{
-			APIKey:  config.APIKey,
-			BaseURL: config.URL,
-		}
-	}
-	return environments
-}


### PR DESCRIPTION
Currently Grafana annotations are hard coded with dedicated flags for each
supported environment. This makes the code hard coupled and cumbersome to expand
with new environments.

This change adds a new `grafana-annnotations` flag that accepts a comma
separated list of `<env>=<api-key>=<url>` values. This makes it possible to add
as many environments as needed without making changes to the code base.

The `grafanaOptions` struct impements the `pflag.Value` and `pflag.SliceValue`
interfaces which makes `pflag` handle multiple apperances of the flag correctly.
This means the following flag settings are all valid and will result in 4
configured environments.

```
server start \
  --grafana-annotations dev=${GRAFANA_API_KEY}=${GRAFANA_URL} \
  --grafana-annotations staging=${GRAFANA_API_KEY}=${GRAFANA_URL} \
  --grafana-annotations prod=${GRAFANA_API_KEY}=${GRAFANA_URL},platform=${GRAFANA_API_KEY}=${GRAFANA_URL}
```