### PR TITLE
Do not log unknown grafana environment as errors

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -254,7 +254,11 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					})
 					span.Finish()
 					if err != nil {
-						logger.Errorf("flow.NotifyReleaseHook: failed to annotate Grafana: %v", err)
+						if errors.Is(err, grafana.ErrEnvironmentNotConfigured) {
+							logger.Infof("flow.NotifyReleaseHook: skipped annotation in Grafana: %v", err)
+						} else {
+							logger.Errorf("flow.NotifyReleaseHook: failed to annotate Grafana: %v", err)
+						}
 					}
 
 					if strings.ToLower(opts.Spec.Application.Provider) == "github" && *startOptions.githubAPIToken != "" {

--- a/internal/grafana/grafana.go
+++ b/internal/grafana/grafana.go
@@ -32,6 +32,8 @@ type AnnotateResponse struct {
 	Id      int64  `json:"id,omitempty"`
 }
 
+var ErrEnvironmentNotConfigured = errors.New("environment not configured")
+
 func (s *Service) Annotate(ctx context.Context, env string, body AnnotateRequest) error {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -45,7 +47,7 @@ func (s *Service) Annotate(ctx context.Context, env string, body AnnotateRequest
 
 	e, ok := s.Environments[env]
 	if !ok {
-		return errors.New("unknown environment")
+		return ErrEnvironmentNotConfigured
 	}
 
 	req, err := http.NewRequest(http.MethodPost, e.BaseURL+"/api/annotations/graphite", b)


### PR DESCRIPTION
Currently if the server tries to annotate a release in an environment where
Grafana credentials are not configured it logs an error.

As this is not an error of the server this change changes behaviour to log an
info line in this case. This should be enough for operators to understand why
Grafana annotations are missing and not create error logs if this is
intentional, ie. no Grafana environment available.