### PR TITLE
Ignore synthetic ADDED events in daemon

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -39,7 +39,7 @@ func StartDaemon() *cobra.Command {
 				Environment: environment,
 			}
 
-			kubectl, err := kubernetes.NewClient(kubeConfigPath, moduloCrashReportNotif, exporter)
+			kubectl, err := kubernetes.NewClient(kubeConfigPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -51,12 +51,12 @@ func StartDaemon() *cobra.Command {
 				}
 			}
 
-			kubernetes.RegisterDeploymentInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory)
-			kubernetes.RegisterDaemonSetInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory)
+			kubernetes.RegisterDeploymentInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
+			kubernetes.RegisterDaemonSetInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
 			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
-			kubernetes.RegisterPodInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory, moduloCrashReportNotif)
-			kubernetes.RegisterStatefulSetInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory)
+			kubernetes.RegisterPodInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset, moduloCrashReportNotif)
+			kubernetes.RegisterStatefulSetInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 
 			log.Info("Deamon started")
 

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -52,7 +52,7 @@ func StartDaemon() *cobra.Command {
 				}
 			}
 
-			_ = kubernetes.NewDeploymentInformer(kubectl.Clientset, kubectl.InformerFactory, exporter, handlerFactory)
+			kubernetes.RegisterDeploymentInformer(kubectl.Clientset, kubectl.InformerFactory, exporter, handlerFactory)
 
 			log.Info("Deamon started")
 

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -55,7 +55,7 @@ func StartDaemon() *cobra.Command {
 			kubernetes.RegisterDaemonSetInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory)
 			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
 			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
-			kubernetes.RegisterPodInformer(kubectl.InformerFactory, exporter, handlerFactory, moduloCrashReportNotif)
+			kubernetes.RegisterPodInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory, moduloCrashReportNotif)
 			kubernetes.RegisterStatefulSetInformer(kubectl.InformerFactory, kubectl.Clientset, exporter, handlerFactory)
 
 			log.Info("Deamon started")

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Client) HandleNewDaemonSets(ctx context.Context) error {
-	watcher, err := c.clientset.AppsV1().DaemonSets("").Watch(ctx, metav1.ListOptions{})
+	watcher, err := c.Clientset.AppsV1().DaemonSets("").Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (c *Client) HandleNewDaemonSets(ctx context.Context) error {
 			}
 
 			// Annotate the DaemonSet to be able to skip it next time
-			err = annotateDaemonSet(ctx, c.clientset, ds)
+			err = annotateDaemonSet(ctx, c.Clientset, ds)
 			if err != nil {
 				log.Errorf("Unable to annotate DaemonSet: %v", err)
 				continue

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -7,83 +7,84 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
-func (c *Client) HandleNewDaemonSets(ctx context.Context) error {
-	watcher, err := c.Clientset.AppsV1().DaemonSets("").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+type DaemonSetInformer struct {
+	clientset *kubernetes.Clientset
+	exporter  Exporter
+}
+
+func RegisterDaemonSetInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+	d := DaemonSetInformer{}
+
+	informerFactory.Apps().V1().DaemonSets().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			d.handle(obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			d.handle(newObj)
+		},
+	}))
+}
+
+func (d *DaemonSetInformer) handle(e interface{}) {
+	ds, ok := e.(*appsv1.DaemonSet)
+	if !ok {
+		return
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-		case e, ok := <-watcher.ResultChan():
-			if !ok {
-				return ErrWatcherClosed
-			}
-			if e.Object == nil {
-				continue
-			}
-			if e.Type == watch.Deleted {
-				continue
-			}
-			ds, ok := e.Object.(*appsv1.DaemonSet)
-			if !ok {
-				continue
-			}
 
-			// Check if we have all the annotations we need for the release-daemon
-			if !isCorrectlyAnnotated(ds.Annotations) {
-				continue
-			}
+	// Check if we have all the annotations we need for the release-daemon
+	if !isCorrectlyAnnotated(ds.Annotations) {
+		return
+	}
 
-			// Avoid reporting on pods that has been marked for termination
-			if isDaemonSetMarkedForTermination(ds) {
-				continue
-			}
+	// Avoid reporting on pods that has been marked for termination
+	if isDaemonSetMarkedForTermination(ds) {
+		return
+	}
 
-			// Verify if the DaemonSet fulfills the criterias for a succesful release
-			if !isDaemonSetSuccessful(ds) {
-				continue
-			}
+	// Verify if the DaemonSet fulfills the criterias for a succesful release
+	if !isDaemonSetSuccessful(ds) {
+		return
+	}
 
-			// In-order to minimize messages and only return events when new releases is detected, we add
-			// a new annotation to the DaemonSet.
-			// When we initially apply a DaemonSet the lunarway.com/artifact-id annotations SHOULD be set.
-			// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
-			// In this state we annotate the DaemonSet with the current artifact-id as the observed.
-			// When we update a DaemonSet we also update the artifact-id, e.g. now observed and actual artifact id
-			// is different. In this case we want to notify, and update the observed with the current artifact id.
-			// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
-			if ds.Annotations["lunarway.com/observed-artifact-id"] == ds.Annotations["lunarway.com/artifact-id"] {
-				continue
-			}
+	// In-order to minimize messages and only return events when new releases is detected, we add
+	// a new annotation to the DaemonSet.
+	// When we initially apply a DaemonSet the lunarway.com/artifact-id annotations SHOULD be set.
+	// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
+	// In this state we annotate the DaemonSet with the current artifact-id as the observed.
+	// When we update a DaemonSet we also update the artifact-id, e.g. now observed and actual artifact id
+	// is different. In this case we want to notify, and update the observed with the current artifact id.
+	// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
+	if ds.Annotations["lunarway.com/observed-artifact-id"] == ds.Annotations["lunarway.com/artifact-id"] {
+		return
+	}
 
-			// Notify the release-manager with the successful deployment event.
-			err = c.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
-				Name:          ds.Name,
-				Namespace:     ds.Namespace,
-				ResourceType:  "DaemonSet",
-				ArtifactID:    ds.Annotations["lunarway.com/artifact-id"],
-				AuthorEmail:   ds.Annotations["lunarway.com/author"],
-				AvailablePods: ds.Status.NumberAvailable,
-				DesiredPods:   ds.Status.DesiredNumberScheduled,
-			})
-			if err != nil {
-				log.Errorf("Failed to send successful daemonset event: %v", err)
-				continue
-			}
+	ctx := context.Background()
 
-			// Annotate the DaemonSet to be able to skip it next time
-			err = annotateDaemonSet(ctx, c.Clientset, ds)
-			if err != nil {
-				log.Errorf("Unable to annotate DaemonSet: %v", err)
-				continue
-			}
-		}
+	// Notify the release-manager with the successful deployment event.
+	err := d.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
+		Name:          ds.Name,
+		Namespace:     ds.Namespace,
+		ResourceType:  "DaemonSet",
+		ArtifactID:    ds.Annotations["lunarway.com/artifact-id"],
+		AuthorEmail:   ds.Annotations["lunarway.com/author"],
+		AvailablePods: ds.Status.NumberAvailable,
+		DesiredPods:   ds.Status.DesiredNumberScheduled,
+	})
+	if err != nil {
+		log.Errorf("Failed to send successful daemonset event: %v", err)
+		return
+	}
+
+	// Annotate the DaemonSet to be able to skip it next time
+	err = annotateDaemonSet(ctx, d.clientset, ds)
+	if err != nil {
+		log.Errorf("Unable to annotate DaemonSet: %v", err)
+		return
 	}
 }
 

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -18,16 +18,24 @@ type DaemonSetInformer struct {
 }
 
 func RegisterDaemonSetInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
-	d := DaemonSetInformer{}
+	d := DaemonSetInformer{
+		clientset: clientset,
+		exporter:  exporter,
+	}
 
-	informerFactory.Apps().V1().DaemonSets().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			d.handle(obj)
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			d.handle(newObj)
-		},
-	}))
+	informerFactory.
+		Apps().
+		V1().
+		DaemonSets().
+		Informer().
+		AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				d.handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				d.handle(newObj)
+			},
+		}))
 }
 
 func (d *DaemonSetInformer) handle(e interface{}) {

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -17,7 +17,7 @@ type DaemonSetInformer struct {
 	exporter  Exporter
 }
 
-func RegisterDaemonSetInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+func RegisterDaemonSetInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, clientset *kubernetes.Clientset) {
 	d := DaemonSetInformer{
 		clientset: clientset,
 		exporter:  exporter,

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -18,7 +18,7 @@ type DeploymentInformer struct {
 	exporter  Exporter
 }
 
-func RegisterDeploymentInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+func RegisterDeploymentInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, clientset *kubernetes.Clientset) {
 	d := DeploymentInformer{
 		clientset: clientset,
 		exporter:  exporter,

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -18,7 +18,7 @@ type DeploymentInformer struct {
 	exporter  Exporter
 }
 
-func NewDeploymentInformer(clientset *kubernetes.Clientset, informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory) *DeploymentInformer {
+func RegisterDeploymentInformer(clientset *kubernetes.Clientset, informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
 	d := &DeploymentInformer{
 		clientset: clientset,
 		exporter:  exporter,
@@ -42,8 +42,6 @@ func NewDeploymentInformer(clientset *kubernetes.Clientset, informerFactory info
 				log.Infof("Got Delete: doing nothing: %+v", obj)
 			},
 		}))
-
-	return d
 }
 
 func (d *DeploymentInformer) handleDeployment(e interface{}) {

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -2,89 +2,126 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 )
 
 func (c *Client) HandleNewDeployments(ctx context.Context) error {
-	watcher, err := c.clientset.AppsV1().Deployments("").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+	log.Info("Watching deployments")
+	factory := informers.NewSharedInformerFactory(c.clientset, 0)
+	deploymentInformer := factory.Apps().V1().Deployments()
+
+	readyToProcess := make(chan struct{})
+
+	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if !hasSynced(readyToProcess) {
+				return
+			}
+			log.Infof("Got Add: %+v", obj)
+			c.handleDeployment(obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if !hasSynced(readyToProcess) {
+				return
+			}
+			log.Infof("Got Update: %+v", newObj)
+			c.handleDeployment(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if !hasSynced(readyToProcess) {
+				return
+			}
+			log.Infof("Got Delete: doing nothing: %+v", obj)
+		},
+	})
+
+	stopCh := make(chan struct{})
+	factory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, deploymentInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to sync deployment informer")
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-		case e, ok := <-watcher.ResultChan():
-			if !ok {
-				return ErrWatcherClosed
-			}
-			if e.Object == nil {
-				continue
-			}
-			if e.Type == watch.Deleted {
-				continue
-			}
-			deploy, ok := e.Object.(*appsv1.Deployment)
-			if !ok {
-				continue
-			}
 
-			// Check if we have all the annotations we need for the release-daemon
-			if !isCorrectlyAnnotated(deploy.Annotations) {
-				continue
-			}
+	log.Infof("Last synced: %s", deploymentInformer.Informer().LastSyncResourceVersion())
+	close(readyToProcess)
+	<-ctx.Done()
+	close(stopCh)
 
-			// Avoid reporting on pods that has been marked for termination
-			if isDeploymentMarkedForTermination(deploy) {
-				continue
-			}
+	return nil
+}
 
-			// Check the received event, and determine whether or not this was a successful deployment.
-			if !isDeploymentSuccessful(deploy) {
-				continue
-			}
+func hasSynced(readyToProcess chan struct{}) bool {
+	select {
+	case <-readyToProcess:
+		return true
+	default:
+		return false
+	}
+}
 
-			// In-order to minimize messages and only return events when new releases is detected, we add
-			// a new annotation to the Deployment.
-			// When we initially apply a Deployment the lunarway.com/artifact-id annotations SHOULD be set.
-			// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
-			// In this state we annotate the Deployment with the current artifact-id as the observed.
-			// When we update a Deployment we also update the artifact-id, e.g. now observed and actual artifact id
-			// is different. In this case we want to notify, and update the observed with the current artifact id.
-			// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
-			if deploy.Annotations["lunarway.com/observed-artifact-id"] == deploy.Annotations["lunarway.com/artifact-id"] {
-				continue
-			}
+func (c *Client) handleDeployment(e interface{}) {
+	deploy, ok := e.(*appsv1.Deployment)
+	if !ok {
+		return
+	}
 
-			// Notify the release-manager with the successful deployment event.
-			err = c.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
-				Name:          deploy.Name,
-				Namespace:     deploy.Namespace,
-				ResourceType:  "Deployment",
-				ArtifactID:    deploy.Annotations["lunarway.com/artifact-id"],
-				AuthorEmail:   deploy.Annotations["lunarway.com/author"],
-				AvailablePods: deploy.Status.AvailableReplicas,
-				DesiredPods:   *deploy.Spec.Replicas,
-			})
-			if err != nil {
-				log.Errorf("Failed to send successful deployment event: %v", err)
-				continue
-			}
+	ctx := context.Background()
 
-			// Annotate the Deployment to be able to skip it next time
-			err = annotateDeployment(ctx, c.clientset, deploy)
-			if err != nil {
-				log.Errorf("Unable to annotate Deployment: %v", err)
-				continue
-			}
-		}
+	// Check if we have all the annotations we need for the release-daemon
+	if !isCorrectlyAnnotated(deploy.Annotations) {
+		return
+	}
+
+	// Avoid reporting on pods that has been marked for termination
+	if isDeploymentMarkedForTermination(deploy) {
+		return
+	}
+
+	// Check the received event, and determine whether or not this was a successful deployment.
+	if !isDeploymentSuccessful(deploy) {
+		return
+	}
+
+	// In-order to minimize messages and only return events when new releases is detected, we add
+	// a new annotation to the Deployment.
+	// When we initially apply a Deployment the lunarway.com/artifact-id annotations SHOULD be set.
+	// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
+	// In this state we annotate the Deployment with the current artifact-id as the observed.
+	// When we update a Deployment we also update the artifact-id, e.g. now observed and actual artifact id
+	// is different. In this case we want to notify, and update the observed with the current artifact id.
+	// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
+	if deploy.Annotations["lunarway.com/observed-artifact-id"] == deploy.Annotations["lunarway.com/artifact-id"] {
+		return
+	}
+
+	// Notify the release-manager with the successful deployment event.
+	err := c.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
+		Name:          deploy.Name,
+		Namespace:     deploy.Namespace,
+		ResourceType:  "Deployment",
+		ArtifactID:    deploy.Annotations["lunarway.com/artifact-id"],
+		AuthorEmail:   deploy.Annotations["lunarway.com/author"],
+		AvailablePods: deploy.Status.AvailableReplicas,
+		DesiredPods:   *deploy.Spec.Replicas,
+	})
+	if err != nil {
+		log.Errorf("Failed to send successful deployment event: %v", err)
+		return
+	}
+
+	// Annotate the Deployment to be able to skip it next time
+	err = annotateDeployment(ctx, c.clientset, deploy)
+	if err != nil {
+		log.Errorf("Unable to annotate Deployment: %v", err)
+		return
 	}
 }
 

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -18,7 +18,7 @@ type DeploymentInformer struct {
 	exporter  Exporter
 }
 
-func RegisterDeploymentInformer(clientset *kubernetes.Clientset, informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+func RegisterDeploymentInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
 	d := &DeploymentInformer{
 		clientset: clientset,
 		exporter:  exporter,
@@ -31,15 +31,10 @@ func RegisterDeploymentInformer(clientset *kubernetes.Clientset, informerFactory
 		Informer().
 		AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				log.Infof("Got Add: %+v", obj)
 				d.handleDeployment(obj)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				log.Infof("Got Update: %+v", newObj)
 				d.handleDeployment(newObj)
-			},
-			DeleteFunc: func(obj interface{}) {
-				log.Infof("Got Delete: doing nothing: %+v", obj)
 			},
 		}))
 }

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -19,7 +19,7 @@ type DeploymentInformer struct {
 }
 
 func RegisterDeploymentInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
-	d := &DeploymentInformer{
+	d := DeploymentInformer{
 		clientset: clientset,
 		exporter:  exporter,
 	}

--- a/cmd/daemon/kubernetes/jobs.go
+++ b/cmd/daemon/kubernetes/jobs.go
@@ -7,53 +7,54 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 )
 
-func (c *Client) HandleJobErrors(ctx context.Context) error {
-	watcher, err := c.Clientset.BatchV1().Jobs("").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+type JobInformer struct {
+	exporter Exporter
+}
+
+func RegisterJobInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+	j := JobInformer{
+		exporter: exporter,
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-		case e, ok := <-watcher.ResultChan():
-			if !ok {
-				return ErrWatcherClosed
-			}
-			if e.Object == nil {
-				continue
-			}
-			if e.Type == watch.Deleted {
-				continue
-			}
-			job, ok := e.Object.(*batchv1.Job)
-			if !ok {
-				continue
-			}
 
-			// Check if we have all the annotations we need for the release-daemon
-			if !isCorrectlyAnnotated(job.Annotations) {
-				continue
-			}
+	informerFactory.Batch().V1().Jobs().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			j.handle(obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			j.handle(newObj)
+		},
+	}))
+}
 
-			if isJobFailed(job) {
-				// Notify the release-manager with the job error event.
-				err = c.exporter.SendJobErrorEvent(ctx, http.JobErrorEvent{
-					JobName:     job.Name,
-					Namespace:   job.Namespace,
-					Errors:      jobErrorMessages(job),
-					ArtifactID:  job.Annotations["lunarway.com/artifact-id"],
-					AuthorEmail: job.Annotations["lunarway.com/author"],
-				})
-				if err != nil {
-					log.Errorf("Failed to send job error event: %v", err)
-					continue
-				}
-			}
+func (j JobInformer) handle(e interface{}) {
+	job, ok := e.(*batchv1.Job)
+	if !ok {
+		return
+	}
+
+	// Check if we have all the annotations we need for the release-daemon
+	if !isCorrectlyAnnotated(job.Annotations) {
+		return
+	}
+
+	ctx := context.Background()
+
+	if isJobFailed(job) {
+		// Notify the release-manager with the job error event.
+		err := j.exporter.SendJobErrorEvent(ctx, http.JobErrorEvent{
+			JobName:     job.Name,
+			Namespace:   job.Namespace,
+			Errors:      jobErrorMessages(job),
+			ArtifactID:  job.Annotations["lunarway.com/artifact-id"],
+			AuthorEmail: job.Annotations["lunarway.com/author"],
+		})
+		if err != nil {
+			log.Errorf("Failed to send job error event: %v", err)
+			return
 		}
 	}
 }

--- a/cmd/daemon/kubernetes/jobs.go
+++ b/cmd/daemon/kubernetes/jobs.go
@@ -2,16 +2,17 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
 func (c *Client) HandleJobErrors(ctx context.Context) error {
-	watcher, err := c.clientset.BatchV1().Jobs("").Watch(ctx, metav1.ListOptions{})
+	watcher, err := c.Clientset.BatchV1().Jobs("").Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func jobErrorMessages(job *batchv1.Job) []http.JobConditionError {
 
 	for _, condition := range job.Status.Conditions {
 		if condition.Status == corev1.ConditionTrue && condition.Type == batchv1.JobFailed {
-			errors = append(errors, http.JobConditionError {
+			errors = append(errors, http.JobConditionError{
 				Reason:  condition.Reason,
 				Message: condition.Message,
 			})

--- a/cmd/daemon/kubernetes/jobs.go
+++ b/cmd/daemon/kubernetes/jobs.go
@@ -20,14 +20,19 @@ func RegisterJobInformer(informerFactory informers.SharedInformerFactory, export
 		exporter: exporter,
 	}
 
-	informerFactory.Batch().V1().Jobs().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			j.handle(obj)
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			j.handle(newObj)
-		},
-	}))
+	informerFactory.
+		Batch().
+		V1().
+		Jobs().
+		Informer().
+		AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				j.handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				j.handle(newObj)
+			},
+		}))
 }
 
 func (j JobInformer) handle(e interface{}) {

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -11,10 +11,8 @@ import (
 )
 
 type Client struct {
-	Clientset              *kubernetes.Clientset
-	exporter               Exporter
-	moduloCrashReportNotif float64
-	InformerFactory        informers.SharedInformerFactory
+	Clientset       *kubernetes.Clientset
+	InformerFactory informers.SharedInformerFactory
 
 	hasSynced chan struct{}
 }
@@ -23,22 +21,22 @@ var (
 	ErrWatcherClosed = errors.New("channel closed")
 )
 
-func NewClient(kubeConfigPath string, moduloCrashReportNotif float64, e Exporter) (*Client, error) {
+func NewClient(kubeConfigPath string) (*Client, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
 		return nil, err
 	}
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
+
 	factory := informers.NewSharedInformerFactory(clientset, 0)
 
 	return &Client{
-		Clientset:              clientset,
-		InformerFactory:        factory,
-		exporter:               e,
-		moduloCrashReportNotif: moduloCrashReportNotif,
+		Clientset:       clientset,
+		InformerFactory: factory,
 
 		hasSynced: make(chan struct{}),
 	}, nil

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -19,7 +19,7 @@ import (
 
 func (c *Client) HandlePodErrors(ctx context.Context) error {
 	// TODO; See if it's possible to use FieldSelector to limit events received.
-	watcher, err := c.clientset.CoreV1().Pods("").Watch(ctx, metav1.ListOptions{})
+	watcher, err := c.Clientset.CoreV1().Pods("").Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (c *Client) HandlePodErrors(ctx context.Context) error {
 				for _, cst := range pod.Status.ContainerStatuses {
 					if cst.State.Waiting != nil && cst.State.Waiting.Reason == "CrashLoopBackOff" {
 
-						logs, err := getLogs(ctx, c.clientset, pod.Name, cst.Name, pod.Namespace)
+						logs, err := getLogs(ctx, c.Clientset, pod.Name, cst.Name, pod.Namespace)
 						if err != nil {
 							log.Errorf("Error retrieving logs from pod: %s, container: %s, namespace: %s: %v", pod.Name, cst.Name, pod.Namespace, err)
 						}

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -13,103 +13,113 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
-func (c *Client) HandlePodErrors(ctx context.Context) error {
-	// TODO; See if it's possible to use FieldSelector to limit events received.
-	watcher, err := c.Clientset.CoreV1().Pods("").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+type PodInformer struct {
+	clientset              *kubernetes.Clientset
+	exporter               Exporter
+	moduloCrashReportNotif float64
+}
+
+func RegisterPodInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, moduloCrashReportNotif float64) {
+	p := PodInformer{
+		exporter:               exporter,
+		moduloCrashReportNotif: moduloCrashReportNotif,
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-		case e, ok := <-watcher.ResultChan():
-			if !ok {
-				return ErrWatcherClosed
-			}
-			if e.Object == nil {
-				continue
-			}
-			pod, ok := e.Object.(*corev1.Pod)
-			if !ok {
-				continue
-			}
-			// Is this a pod managed by the release manager - and does it contain the information needed?
-			if !isCorrectlyAnnotated(pod.Annotations) {
-				continue
-			}
-			// Avoid reporting on pods that has been marked for termination
-			if isPodMarkedForTermination(pod) {
-				continue
-			}
+	informerFactory.
+		Core().
+		V1().
+		Pods().
+		Informer().
+		AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				p.handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				p.handle(newObj)
+			},
+		}))
+}
 
-			if isPodInCrashLoopBackOff(pod) {
-				log.Infof("Pod: %s is in CrashLoopBackOff", pod.Name)
-				restartCount := pod.Status.ContainerStatuses[0].RestartCount
-				if math.Mod(float64(restartCount), c.moduloCrashReportNotif) != 1 {
-					continue
-				}
-				var errorContainers []http.ContainerError
-				for _, cst := range pod.Status.ContainerStatuses {
-					if cst.State.Waiting != nil && cst.State.Waiting.Reason == "CrashLoopBackOff" {
+func (p *PodInformer) handle(e interface{}) {
+	pod, ok := e.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	// Is this a pod managed by the release manager - and does it contain the information needed?
+	if !isCorrectlyAnnotated(pod.Annotations) {
+		return
+	}
+	// Avoid reporting on pods that has been marked for termination
+	if isPodMarkedForTermination(pod) {
+		return
+	}
 
-						logs, err := getLogs(ctx, c.Clientset, pod.Name, cst.Name, pod.Namespace)
-						if err != nil {
-							log.Errorf("Error retrieving logs from pod: %s, container: %s, namespace: %s: %v", pod.Name, cst.Name, pod.Namespace, err)
-						}
+	ctx := context.Background()
 
-						errorContainers = append(errorContainers, http.ContainerError{
-							Name:         cst.Name,
-							ErrorMessage: logs,
-							Type:         "CrashLoopBackOff",
-						})
-					}
-				}
+	if isPodInCrashLoopBackOff(pod) {
+		log.Infof("Pod: %s is in CrashLoopBackOff", pod.Name)
+		restartCount := pod.Status.ContainerStatuses[0].RestartCount
+		if math.Mod(float64(restartCount), p.moduloCrashReportNotif) != 1 {
+			return
+		}
+		var errorContainers []http.ContainerError
+		for _, cst := range pod.Status.ContainerStatuses {
+			if cst.State.Waiting != nil && cst.State.Waiting.Reason == "CrashLoopBackOff" {
 
-				err = c.exporter.SendPodErrorEvent(ctx, http.PodErrorEvent{
-					PodName:     pod.Name,
-					Namespace:   pod.Namespace,
-					Errors:      errorContainers,
-					ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
-					AuthorEmail: pod.Annotations["lunarway.com/author"],
-				})
+				logs, err := getLogs(ctx, p.clientset, pod.Name, cst.Name, pod.Namespace)
 				if err != nil {
-					log.Errorf("Failed to send crash loop backoff event: %v", err)
-				}
-				continue
-			}
-
-			if isPodInCreateContainerConfigError(pod) {
-				log.Infof("Pod: %s is in CreateContainerConfigError", pod.Name)
-				// Determine which container of the deployment has CreateContainerConfigError
-				var errorContainers []http.ContainerError
-				for _, cst := range pod.Status.ContainerStatuses {
-					if cst.State.Waiting != nil && cst.State.Waiting.Reason == "CreateContainerConfigError" {
-						errorContainers = append(errorContainers, http.ContainerError{
-							Name:         cst.Name,
-							ErrorMessage: cst.State.Waiting.Message,
-							Type:         "CreateContainerConfigError",
-						})
-					}
+					log.Errorf("Error retrieving logs from pod: %s, container: %s, namespace: %s: %v", pod.Name, cst.Name, pod.Namespace, err)
 				}
 
-				err = c.exporter.SendPodErrorEvent(ctx, http.PodErrorEvent{
-					PodName:     pod.Name,
-					Namespace:   pod.Namespace,
-					Errors:      errorContainers,
-					ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
-					AuthorEmail: pod.Annotations["lunarway.com/author"],
+				errorContainers = append(errorContainers, http.ContainerError{
+					Name:         cst.Name,
+					ErrorMessage: logs,
+					Type:         "CrashLoopBackOff",
 				})
-				if err != nil {
-					log.Errorf("Failed to send create container config error: %v", err)
-				}
-				continue
 			}
+		}
+
+		err := p.exporter.SendPodErrorEvent(ctx, http.PodErrorEvent{
+			PodName:     pod.Name,
+			Namespace:   pod.Namespace,
+			Errors:      errorContainers,
+			ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
+			AuthorEmail: pod.Annotations["lunarway.com/author"],
+		})
+		if err != nil {
+			log.Errorf("Failed to send crash loop backoff event: %v", err)
+		}
+		return
+	}
+
+	if isPodInCreateContainerConfigError(pod) {
+		log.Infof("Pod: %s is in CreateContainerConfigError", pod.Name)
+		// Determine which container of the deployment has CreateContainerConfigError
+		var errorContainers []http.ContainerError
+		for _, cst := range pod.Status.ContainerStatuses {
+			if cst.State.Waiting != nil && cst.State.Waiting.Reason == "CreateContainerConfigError" {
+				errorContainers = append(errorContainers, http.ContainerError{
+					Name:         cst.Name,
+					ErrorMessage: cst.State.Waiting.Message,
+					Type:         "CreateContainerConfigError",
+				})
+			}
+		}
+
+		err := p.exporter.SendPodErrorEvent(ctx, http.PodErrorEvent{
+			PodName:     pod.Name,
+			Namespace:   pod.Namespace,
+			Errors:      errorContainers,
+			ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
+			AuthorEmail: pod.Annotations["lunarway.com/author"],
+		})
+		if err != nil {
+			log.Errorf("Failed to send create container config error: %v", err)
 		}
 	}
 }

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -24,8 +24,9 @@ type PodInformer struct {
 	moduloCrashReportNotif float64
 }
 
-func RegisterPodInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, moduloCrashReportNotif float64) {
+func RegisterPodInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory, moduloCrashReportNotif float64) {
 	p := PodInformer{
+		clientset:              clientset,
 		exporter:               exporter,
 		moduloCrashReportNotif: moduloCrashReportNotif,
 	}

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -24,7 +24,7 @@ type PodInformer struct {
 	moduloCrashReportNotif float64
 }
 
-func RegisterPodInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory, moduloCrashReportNotif float64) {
+func RegisterPodInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, clientset *kubernetes.Clientset, moduloCrashReportNotif float64) {
 	p := PodInformer{
 		clientset:              clientset,
 		exporter:               exporter,

--- a/cmd/daemon/kubernetes/resource_event_handler.go
+++ b/cmd/daemon/kubernetes/resource_event_handler.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import "k8s.io/client-go/tools/cache"
+
+type ResourceEventHandlerFactory func(cache.ResourceEventHandlerFuncs) cache.ResourceEventHandler
+
+// ResourceEventHandlerFuncs is a cache.ResourceEventHandler that can be
+// configured to skip event handlers based on a ShouldProcess func.
+type ResourceEventHandlerFuncs struct {
+	ShouldProcess func() bool
+	cache.ResourceEventHandlerFuncs
+}
+
+// OnAdd calls AddFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnAdd(obj interface{}) {
+	if r.AddFunc != nil && r.ShouldProcess() {
+		r.AddFunc(obj)
+	}
+}
+
+// OnUpdate calls UpdateFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
+	if r.UpdateFunc != nil && r.ShouldProcess() {
+		r.UpdateFunc(oldObj, newObj)
+	}
+}
+
+// OnDelete calls DeleteFunc if it's not nil.
+func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
+	if r.DeleteFunc != nil && r.ShouldProcess() {
+		r.DeleteFunc(obj)
+	}
+}

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -17,7 +17,7 @@ type StatefulSetInformer struct {
 	exporter  Exporter
 }
 
-func RegisterStatefulSetInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+func RegisterStatefulSetInformer(informerFactory informers.SharedInformerFactory, exporter Exporter, handlerFactory ResourceEventHandlerFactory, clientset *kubernetes.Clientset) {
 	s := StatefulSetInformer{
 		clientset: clientset,
 		exporter:  exporter,

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Client) HandleNewStatefulSets(ctx context.Context) error {
-	watcher, err := c.clientset.AppsV1().StatefulSets("").Watch(ctx, metav1.ListOptions{})
+	watcher, err := c.Clientset.AppsV1().StatefulSets("").Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (c *Client) HandleNewStatefulSets(ctx context.Context) error {
 			}
 
 			// Annotate the StatefulSet to be able to skip it next time
-			err = annotateStatefulSet(ctx, c.clientset, ss)
+			err = annotateStatefulSet(ctx, c.Clientset, ss)
 			if err != nil {
 				log.Errorf("Unable to annotate StatefulSet: %v", err)
 				continue

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -7,83 +7,84 @@ import (
 	"github.com/lunarway/release-manager/internal/log"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
-func (c *Client) HandleNewStatefulSets(ctx context.Context) error {
-	watcher, err := c.Clientset.AppsV1().StatefulSets("").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+type StatefulSetInformer struct {
+	clientset *kubernetes.Clientset
+	exporter  Exporter
+}
+
+func RegisterStatefulSetInformer(informerFactory informers.SharedInformerFactory, clientset *kubernetes.Clientset, exporter Exporter, handlerFactory ResourceEventHandlerFactory) {
+	s := StatefulSetInformer{
+		clientset: clientset,
+		exporter:  exporter,
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-		case e, ok := <-watcher.ResultChan():
-			if !ok {
-				return ErrWatcherClosed
-			}
-			if e.Object == nil {
-				continue
-			}
-			if e.Type == watch.Deleted {
-				continue
-			}
-			ss, ok := e.Object.(*appsv1.StatefulSet)
-			if !ok {
-				continue
-			}
 
-			// Check if we have all the annotations we need for the release-daemon
-			if !isCorrectlyAnnotated(ss.Annotations) {
-				continue
-			}
+	informerFactory.Apps().V1().StatefulSets().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			s.handle(obj)
+		},
+	}))
+}
 
-			// Avoid reporting on pods that has been marked for termination
-			if isStefulSetMarkedForTermination(ss) {
-				continue
-			}
+func (s *StatefulSetInformer) handle(e interface{}) {
+	ss, ok := e.(*appsv1.StatefulSet)
+	if !ok {
+		return
+	}
 
-			// Verify if the StatefulSet fulfills the criterias for a succesful release
-			if !isStatefulSetSuccessful(ss) {
-				continue
-			}
+	// Check if we have all the annotations we need for the release-daemon
+	if !isCorrectlyAnnotated(ss.Annotations) {
+		return
+	}
 
-			// In-order to minimize messages and only return events when new releases is detected, we add
-			// a new annotation to the StatefulSet.
-			// When we initially apply a StatefulSet the lunarway.com/artifact-id annotations SHOULD be set.
-			// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
-			// In this state we annotate the StatefulSet with the current artifact-id as the observed.
-			// When we update a StatefulSet we also update the artifact-id, e.g. now observed and actual artifact id
-			// is different. In this case we want to notify, and update the observed with the current artifact id.
-			// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
-			if ss.Annotations["lunarway.com/observed-artifact-id"] == ss.Annotations["lunarway.com/artifact-id"] {
-				continue
-			}
+	// Avoid reporting on pods that has been marked for termination
+	if isStefulSetMarkedForTermination(ss) {
+		return
+	}
 
-			// Notify the release-manager with the successful deployment event.
-			err = c.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
-				Name:          ss.Name,
-				Namespace:     ss.Namespace,
-				ResourceType:  "StatefulSet",
-				ArtifactID:    ss.Annotations["lunarway.com/artifact-id"],
-				AuthorEmail:   ss.Annotations["lunarway.com/author"],
-				AvailablePods: ss.Status.ReadyReplicas,
-				DesiredPods:   ss.Status.Replicas,
-			})
-			if err != nil {
-				log.Errorf("Failed to send successful statefulset event: %v", err)
-				continue
-			}
+	// Verify if the StatefulSet fulfills the criterias for a succesful release
+	if !isStatefulSetSuccessful(ss) {
+		return
+	}
 
-			// Annotate the StatefulSet to be able to skip it next time
-			err = annotateStatefulSet(ctx, c.Clientset, ss)
-			if err != nil {
-				log.Errorf("Unable to annotate StatefulSet: %v", err)
-				continue
-			}
-		}
+	// In-order to minimize messages and only return events when new releases is detected, we add
+	// a new annotation to the StatefulSet.
+	// When we initially apply a StatefulSet the lunarway.com/artifact-id annotations SHOULD be set.
+	// Further the observed-artifact-id is an annotation managed by the daemon and will initially be "".
+	// In this state we annotate the StatefulSet with the current artifact-id as the observed.
+	// When we update a StatefulSet we also update the artifact-id, e.g. now observed and actual artifact id
+	// is different. In this case we want to notify, and update the observed with the current artifact id.
+	// This also eliminates messages when a pod is deleted. As the two annotations will be equal.
+	if ss.Annotations["lunarway.com/observed-artifact-id"] == ss.Annotations["lunarway.com/artifact-id"] {
+		return
+	}
+
+	ctx := context.Background()
+
+	// Notify the release-manager with the successful deployment event.
+	err := s.exporter.SendSuccessfulReleaseEvent(ctx, http.ReleaseEvent{
+		Name:          ss.Name,
+		Namespace:     ss.Namespace,
+		ResourceType:  "StatefulSet",
+		ArtifactID:    ss.Annotations["lunarway.com/artifact-id"],
+		AuthorEmail:   ss.Annotations["lunarway.com/author"],
+		AvailablePods: ss.Status.ReadyReplicas,
+		DesiredPods:   ss.Status.Replicas,
+	})
+	if err != nil {
+		log.Errorf("Failed to send successful statefulset event: %v", err)
+		return
+	}
+
+	// Annotate the StatefulSet to be able to skip it next time
+	err = annotateStatefulSet(ctx, s.clientset, ss)
+	if err != nil {
+		log.Errorf("Unable to annotate StatefulSet: %v", err)
+		return
 	}
 }
 

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -23,11 +23,19 @@ func RegisterStatefulSetInformer(informerFactory informers.SharedInformerFactory
 		exporter:  exporter,
 	}
 
-	informerFactory.Apps().V1().StatefulSets().Informer().AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			s.handle(obj)
-		},
-	}))
+	informerFactory.
+		Apps().
+		V1().
+		StatefulSets().
+		Informer().
+		AddEventHandler(handlerFactory(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				s.handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				s.handle(newObj)
+			},
+		}))
 }
 
 func (s *StatefulSetInformer) handle(e interface{}) {


### PR DESCRIPTION
Currently the daemon will process the [synthetic `ADDED` events](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-watch) that are emitted
from a watch intended to create the intial state. This results in the daemon
notifying on every pod, deployment job etc. that are in a cluster when it starts
up the first time. If slack messages are enabled in the release-manager this
results in a whole lot of messages hitting developers.

This is especially painful when releasing the daemon into a new cluster that
hasn't been observed before. For Lunar this is often failover clusters where the
daemon is disabled until a failover cluster has settled its state.

This change disables these events by replacing the low level watch primitive on
`kubernetes.Clientset` to use the higher level abstraction `informers`.
Informers can tell when they have synced the inital state and with this we have
a hook as to when we should start forwarding events to the release-manager. This
also has the benifit of providing a simpler implementation without excessive use
of channels and Go routines as informers just register callbacks on specific
resources.

The diff is quite large but no functionality is changed in the handlers but they
are instead moved to be separate structs instead of methods on the
`kubernetes.Client` struct.