### PR TITLE
Upgrade to Go 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.17"
+- 1.17.3
 script:
 - go build ./...
 - make integration-test VERBOSE=yes

--- a/Dockerfile-daemon
+++ b/Dockerfile-daemon
@@ -1,4 +1,4 @@
-FROM golang:1.17.0 as builder
+FROM golang:1.17.3 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.17.0 as builder
+FROM golang:1.17.3 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
This upgrade contains a fix to CVE-2021-41772 which impacts the use of
zip.OpenReader().