### PR TITLE
Annotate Jobs when observing them

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -53,8 +53,7 @@ func StartDaemon() *cobra.Command {
 
 			kubernetes.RegisterDeploymentInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 			kubernetes.RegisterDaemonSetInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
-			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
-			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory)
+			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 			kubernetes.RegisterPodInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset, moduloCrashReportNotif)
 			kubernetes.RegisterStatefulSetInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -69,9 +69,22 @@ func (c *Client) HasSynced() bool {
 
 func isCorrectlyAnnotated(annotations map[string]string) bool {
 	if (annotations["lunarway.com/controlled-by-release-manager"] == "true") &&
-		annotations["lunarway.com/artifact-id"] != "" &&
+		annotations[artifactIDAnnotationKey] != "" &&
 		annotations["lunarway.com/author"] != "" {
 		return true
 	}
 	return false
+}
+
+const (
+	observedAnnotationKey   = "lunarway.com/observed-artifact-id"
+	artifactIDAnnotationKey = "lunarway.com/artifact-id"
+)
+
+func observe(annotations map[string]string) {
+	annotations[observedAnnotationKey] = annotations[artifactIDAnnotationKey]
+}
+
+func isObserved(annotations map[string]string) bool {
+	return annotations[observedAnnotationKey] == annotations[artifactIDAnnotationKey]
 }

--- a/cmd/daemon/kubernetes/kubernetes_test.go
+++ b/cmd/daemon/kubernetes/kubernetes_test.go
@@ -1,8 +1,9 @@
 package kubernetes
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsCorrectlyAnnotated(t *testing.T) {
@@ -32,7 +33,7 @@ func TestIsCorrectlyAnnotated(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			correct := isCorrectlyAnnotated(map[string]string{
 				"lunarway.com/controlled-by-release-manager": tc.controlled,
-				"lunarway.com/artifact-id":                    tc.artifactID,
+				artifactIDAnnotationKey:                      tc.artifactID,
 				"lunarway.com/author":                        tc.author,
 			})
 
@@ -40,4 +41,3 @@ func TestIsCorrectlyAnnotated(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -89,7 +89,7 @@ func (p *PodInformer) handle(e interface{}) {
 			PodName:     pod.Name,
 			Namespace:   pod.Namespace,
 			Errors:      errorContainers,
-			ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
+			ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
 			AuthorEmail: pod.Annotations["lunarway.com/author"],
 		})
 		if err != nil {
@@ -116,7 +116,7 @@ func (p *PodInformer) handle(e interface{}) {
 			PodName:     pod.Name,
 			Namespace:   pod.Namespace,
 			Errors:      errorContainers,
-			ArtifactID:  pod.Annotations["lunarway.com/artifact-id"],
+			ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
 			AuthorEmail: pod.Annotations["lunarway.com/author"],
 		})
 		if err != nil {


### PR DESCRIPTION
Currently if a job gets into a Failed state and the is a fail history we will
keep sending JobError events to the server over and over.

This change adds the observed annotation to Jobs when we handle them to only
ever send a single even for a failed Job.

This is the same as done doe DaemonSets and Deployments so the code is
refactored to be more shareable and to avoid duplicating the annotation keys all
over.