### PR TITLE
Extract annotation keys into consts

### DIFF
--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -79,7 +79,7 @@ func (d *DaemonSetInformer) handle(e interface{}) {
 		Namespace:     ds.Namespace,
 		ResourceType:  "DaemonSet",
 		ArtifactID:    ds.Annotations[artifactIDAnnotationKey],
-		AuthorEmail:   ds.Annotations["lunarway.com/author"],
+		AuthorEmail:   ds.Annotations[authorAnnotationKey],
 		AvailablePods: ds.Status.NumberAvailable,
 		DesiredPods:   ds.Status.DesiredNumberScheduled,
 	})

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -79,7 +79,7 @@ func (d *DeploymentInformer) handleDeployment(e interface{}) {
 		Namespace:     deploy.Namespace,
 		ResourceType:  "Deployment",
 		ArtifactID:    deploy.Annotations[artifactIDAnnotationKey],
-		AuthorEmail:   deploy.Annotations["lunarway.com/author"],
+		AuthorEmail:   deploy.Annotations[authorAnnotationKey],
 		AvailablePods: deploy.Status.AvailableReplicas,
 		DesiredPods:   *deploy.Spec.Replicas,
 	})

--- a/cmd/daemon/kubernetes/jobs.go
+++ b/cmd/daemon/kubernetes/jobs.go
@@ -63,7 +63,7 @@ func (j JobInformer) handle(e interface{}) {
 			Namespace:   job.Namespace,
 			Errors:      jobErrorMessages(job),
 			ArtifactID:  job.Annotations[artifactIDAnnotationKey],
-			AuthorEmail: job.Annotations["lunarway.com/author"],
+			AuthorEmail: job.Annotations[authorAnnotationKey],
 		})
 		if err != nil {
 			log.Errorf("Failed to send job error event: %v", err)

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -68,9 +68,9 @@ func (c *Client) HasSynced() bool {
 }
 
 func isCorrectlyAnnotated(annotations map[string]string) bool {
-	if (annotations["lunarway.com/controlled-by-release-manager"] == "true") &&
+	if (annotations[controlledAnnotationKey] == "true") &&
 		annotations[artifactIDAnnotationKey] != "" &&
-		annotations["lunarway.com/author"] != "" {
+		annotations[authorAnnotationKey] != "" {
 		return true
 	}
 	return false
@@ -79,6 +79,8 @@ func isCorrectlyAnnotated(annotations map[string]string) bool {
 const (
 	observedAnnotationKey   = "lunarway.com/observed-artifact-id"
 	artifactIDAnnotationKey = "lunarway.com/artifact-id"
+	authorAnnotationKey     = "lunarway.com/author"
+	controlledAnnotationKey = "lunarway.com/controlled-by-release-manager"
 )
 
 func observe(annotations map[string]string) {

--- a/cmd/daemon/kubernetes/kubernetes_test.go
+++ b/cmd/daemon/kubernetes/kubernetes_test.go
@@ -32,9 +32,9 @@ func TestIsCorrectlyAnnotated(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			correct := isCorrectlyAnnotated(map[string]string{
-				"lunarway.com/controlled-by-release-manager": tc.controlled,
-				artifactIDAnnotationKey:                      tc.artifactID,
-				"lunarway.com/author":                        tc.author,
+				controlledAnnotationKey: tc.controlled,
+				artifactIDAnnotationKey: tc.artifactID,
+				authorAnnotationKey:     tc.author,
 			})
 
 			assert.Equal(t, tc.correct, correct)

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -90,7 +90,7 @@ func (p *PodInformer) handle(e interface{}) {
 			Namespace:   pod.Namespace,
 			Errors:      errorContainers,
 			ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
-			AuthorEmail: pod.Annotations["lunarway.com/author"],
+			AuthorEmail: pod.Annotations[authorAnnotationKey],
 		})
 		if err != nil {
 			log.Errorf("Failed to send crash loop backoff event: %v", err)
@@ -117,7 +117,7 @@ func (p *PodInformer) handle(e interface{}) {
 			Namespace:   pod.Namespace,
 			Errors:      errorContainers,
 			ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
-			AuthorEmail: pod.Annotations["lunarway.com/author"],
+			AuthorEmail: pod.Annotations[authorAnnotationKey],
 		})
 		if err != nil {
 			log.Errorf("Failed to send create container config error: %v", err)

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -79,7 +79,7 @@ func (s *StatefulSetInformer) handle(e interface{}) {
 		Namespace:     ss.Namespace,
 		ResourceType:  "StatefulSet",
 		ArtifactID:    ss.Annotations[artifactIDAnnotationKey],
-		AuthorEmail:   ss.Annotations["lunarway.com/author"],
+		AuthorEmail:   ss.Annotations[authorAnnotationKey],
 		AvailablePods: ss.Status.ReadyReplicas,
 		DesiredPods:   ss.Status.Replicas,
 	})


### PR DESCRIPTION
Currently we duplicate the annotations inspected by the daemon several places.

This change introduces const strings and reference these instead to make the
code more maintainable.