### PR TITLE
Remove unnecessary fmt.Sprintf

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -301,7 +301,7 @@ func PushArtifactToReleaseManager(ctx context.Context, releaseManagerClient *htt
 
 	log.WithFields("artifactID", artifactSpec.ID, "artifactFiles", files).Infof("calculated zip md5: %x", zipMD5s)
 
-	path, err := releaseManagerClient.URL(fmt.Sprintf("artifacts/create"))
+	path, err := releaseManagerClient.URL("artifacts/create")
 	if err != nil {
 		return "", errors.WithMessage(err, "push artifact URL generation failed")
 	}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -187,7 +187,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		}
 		sourceSpec, err := artifact.Get(artifactSourcePath)
 		if err != nil {
-			return true, errors.WithMessage(err, fmt.Sprintf("locate source spec"))
+			return true, errors.WithMessage(err, "locate source spec")
 		}
 		artifactAuthor := commitinfo.NewPersonInfo(sourceSpec.Application.AuthorName, sourceSpec.Application.AuthorEmail)
 		releaseAuthor := commitinfo.NewPersonInfo(actor.Name, actor.Email)


### PR DESCRIPTION
Remove unnecessary fmt.Sprintf calls as detected by go-staticcheck.