### PR TITLE
Fixed an issue where a .yaml file were completely empty

### DIFF
--- a/internal/flow/kustomization.go
+++ b/internal/flow/kustomization.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -45,7 +46,9 @@ func kustomizationExists(directory string) (string, error) {
 		// no need to handle non-YAML files as the decoder does the right thing
 		err = yaml.NewDecoder(file).Decode(&spec)
 		if err != nil {
-			return err
+			if errors.Cause(err) != io.EOF {
+				return err
+			}
 		}
 		if strings.HasPrefix(spec.APIVersion, "kustomize.toolkit.fluxcd.io/") && spec.Kind == "Kustomization" {
 			filePath = path

--- a/internal/flow/kustomization_test.go
+++ b/internal/flow/kustomization_test.go
@@ -34,14 +34,18 @@ func TestKustomizationExists(t *testing.T) {
 			testDir: "no-kustomization",
 			path:    "",
 		},
+		{
+			name:    "empty-file",
+			testDir: "empty-file",
+			path:    "",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			exists, err := kustomizationExists(path.Join("testdata", tc.testDir))
-
+			actual, err := kustomizationExists(path.Join("testdata", tc.testDir))
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.path, exists)
+			assert.Equal(t, tc.path, actual)
 		})
 	}
 }


### PR DESCRIPTION
Currently, a release would fail if it encountered an empty file as the `yaml.Decoder` fails parsing it.

This change fixes the issue by inspecting the error and ignoring the file.