### PR TITLE
Add template functions to rollback templates

### DIFF
--- a/cmd/hamctl/command/rollback.go
+++ b/cmd/hamctl/command/rollback.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/lunarway/release-manager/cmd/hamctl/command/actions"
 	"github.com/lunarway/release-manager/cmd/hamctl/command/completion"
 	"github.com/lunarway/release-manager/cmd/hamctl/template"
@@ -54,8 +53,8 @@ has no effect.`,
 				}
 
 				funcMap := promptui.FuncMap
-				funcMap["humanizeTime"] = func(input time.Time) string {
-					return humanize.Time(input)
+				for name, f := range template.FuncMap() {
+					funcMap[name] = f
 				}
 				rollbackInteractiveTemplates.FuncMap = funcMap
 

--- a/cmd/hamctl/template/template.go
+++ b/cmd/hamctl/template/template.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"text/template"
+	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/lunarway/release-manager/internal/intent"
 )
 
@@ -14,12 +16,7 @@ import (
 // Some utility functions are available for data manipulation.
 func Output(destination io.Writer, name, text string, data interface{}) error {
 	t := template.New(name)
-	t.Funcs(template.FuncMap{
-		"rightPad": tmplRightPad,
-		"dateFormat": func() string {
-			return "2006-01-02 15:04:05"
-		},
-	})
+	t.Funcs(FuncMap())
 	t, err := t.Parse(text)
 	if err != nil {
 		return fmt.Errorf("invalid template: %v", err)
@@ -30,6 +27,18 @@ func Output(destination io.Writer, name, text string, data interface{}) error {
 func tmplRightPad(s string, padding int) string {
 	template := fmt.Sprintf("%%-%ds", padding)
 	return fmt.Sprintf(template, s)
+}
+
+func FuncMap() template.FuncMap {
+	return template.FuncMap{
+		"rightPad": tmplRightPad,
+		"dateFormat": func() string {
+			return "2006-01-02 15:04:05"
+		},
+		"humanizeTime": func(input time.Time) string {
+			return humanize.Time(input)
+		},
+	}
 }
 
 func IntentString(i intent.Intent) string {


### PR DESCRIPTION
Currently the hamctl rollback command relies on a `dateFormat` function that is
not available. This is a bug introduced in
9354fb3854be6fa1c85e756f82cff6e04f39f06c (#247) where the `dateFormat` function
was introduced. It was not however ensured that it was available in the
interactive templates.

This change fixes the issue by creating a new `FuncMap` function that returns all
the functions used in templates and add them to both the `template.Output`
function and the interactive templates.