### PR TITLE
Fix policy list template

### DIFF
--- a/cmd/hamctl/command/policy/list.go
+++ b/cmd/hamctl/command/policy/list.go
@@ -17,7 +17,7 @@ var listPoliciesTemplate = `Policies for service {{ .Service }}
 
 {{ if ne (len .AutoReleases) 0 -}}
 Auto-releases:
-{{ $columnFormat := printf "%%-%ds     %%-%ds     %%-%ds" .AutoReleaseBranchMaxLen .AutoReleaseEnvMaxLen .AutoReleaseIDMaxLen }}
+{{ $columnFormat := printf "%%-%ds     %%-%ds     %%-%ds" .AutoReleaseEnvMaxLen .AutoReleaseBranchMaxLen .AutoReleaseIDMaxLen }}
 {{ printf $columnFormat "ENV" "BRANCH" "ID" }}
 {{ range $k, $v := .AutoReleases -}}
 {{ printf $columnFormat .Environment .Branch .ID }}
@@ -99,7 +99,7 @@ func mapListResponseToTemplate(resp httpinternal.ListPoliciesResponse) listPolic
 		autoReleases = append(autoReleases, listPoliciesDataAutoRelease{
 			ID:          r.ID,
 			Environment: r.Environment,
-			Branch:      r.Environment,
+			Branch:      r.Branch,
 		})
 	}
 


### PR DESCRIPTION
Currently the policy list command outputs the environment in both the ENV and BRANCH columns.

    $ hamctl policy list
    Policies for service product

    Auto-releases:

    ENV         BRANCH      ID
    dev         dev         auto-release-master-dev
    staging     staging     auto-release-master-staging
    prod        prod        auto-release-master-prod

    Branch restrictions:

    ENV            REGEX        ID

This change fixes the bug by setting branch correctly in the template DTO mapper and also fixes a bug the column width configuration.

    $ hamctl policy list
    Policies for service product

    Auto-releases:

    ENV         BRANCH     ID
    dev         master     auto-release-master-dev
    staging     master     auto-release-master-staging
    prod        master     auto-release-master-prod

    Branch restrictions:

    ENV            REGEX        ID