### PR TITLE
Upgrade Go to 1.17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.17.3
+- 1.17.5
 script:
 - go build ./...
 - make integration-test VERBOSE=yes

--- a/Dockerfile-daemon
+++ b/Dockerfile-daemon
@@ -1,4 +1,4 @@
-FROM golang:1.17.3 as builder
+FROM golang:1.17.5 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM golang:1.17.3 as builder
+FROM golang:1.17.5 as builder
 WORKDIR /app
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
Contains a fix to the HTTP server implementation that could cause an unbounded
memory CVE.