### PR TITLE
Remove staging in promote flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 GitOps release manager for kubernetes configuration repositories.
 
-This project is used as an internal project at Lunar and it therefore contains some assumptions on our setup. This includes environment naming (dev, staging, prod). Further it is build around assumptions made by our OSS project `shuttle`, and id's for releases are a combination of branch name, git-sha from source repo, and git-sha from shuttle plan repo. Our initial intent is not to support this as an open source project.
+This project is used as an internal project at Lunar and it therefore contains some assumptions on our setup. This includes environment naming (dev, prod). Further it is build around assumptions made by our OSS project `shuttle`, and id's for releases are a combination of branch name, git-sha from source repo, and git-sha from shuttle plan repo. Our initial intent is not to support this as an open source project.
 
 We will however, have it public available for reference. This might change over time.
 
@@ -34,16 +34,16 @@ The promotion flows, is a convetion based release process. It can be invoked by 
 hamctl promote --service example --env dev
 ```
 
-The convention follows the following flow: `master -> dev -> staging -> prod`
+The convention follows the following flow: `master -> dev -> prod`
 As seen in the example above, the `example` service will be promoted from the lastest available artifact from `master` to the `dev` environment.
 
-Another example, is a promotion of an artifact running in, e.g. staging, to the production environment. This can be achieved with the following command:
+Another example, is a promotion of an artifact running in, e.g. dev, to the production environment. This can be achieved with the following command:
 
 ```
 hamctl promote --service example --env prod
 ```
 
-The above locates what is running in the `staging` environment, and takes the necessary steps to run the same artifact in `prod`.
+The above locates what is running in the `dev` environment, and takes the necessary steps to run the same artifact in `prod`.
 
 ## Release
 
@@ -57,29 +57,20 @@ Example of a release of a feature branch to the `dev` environment:
 hamctl release --service example --branch "feature/new_feature" --env dev
 ```
 
-Example of a release of a specific artifact id to the `staging` environment:
+Example of a release of a specific artifact id to the `prod` environment:
 
 ```
-hamctl release --service example --artifact dev-0017d995e3-67e9d69164 --env staging
+hamctl release --service example --artifact main-0017d995e3-67e9d69164 --env prod
 ```
 
 ## Status
 
-Status is a convience flow to display currently released artifact to the three different environments; `dev`, `staging`,`prod`.
+Status is a convience flow to display currently released artifact to the three different environments; `dev`,`prod`.
 
 ```
 $ hamctl status --service example
 
 dev:
-  Tag: master-1c1508405e-67e9d69164
-  Author: Kasper Nissen
-  Committer: Peter Petersen
-  Message: empty-commit-to-test-flow
-  Date: 2019-04-01 11:14:26 +0200 CEST
-  Link: https://jenkins.example.lunar.app/job/github/job/example-service/job/master/132/display/redirect
-  Vulnerabilities: 0 high, 0 medium, 0 low
-
-staging:
   Tag: master-1c1508405e-67e9d69164
   Author: Kasper Nissen
   Committer: Peter Petersen
@@ -120,7 +111,7 @@ These cases are validated when applying either of them.
 
 An `auto-release` policy instructs the release manager to deploy new artifacts from a specific branch into an environment.
 
-Multiple policies can be applied for the same branch to different environments, e.g. release `master` artifacts to `dev` and `staging`.
+Multiple policies can be applied for the same branch to different environments, e.g. release `master` artifacts to `dev` and `prod`.
 
 This is an example of applying an auto-release policy for the product service for the `master` branch and `dev` environment.
 
@@ -154,7 +145,7 @@ The `server` can also enforce branch restrictions on all managed services by set
 It takes a comma seprated list of `<environment>=<branchRegex>` values.
 
 ```
-server start --policy-branch-restrictions 'production=^master$,staging=^staging$'
+server start --policy-branch-restrictions 'production=^master$,dev=^development$'
 ```
 
 They will be visible with `hamctl policy list` but cannot by removed with `hamctl`.

--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -96,12 +96,10 @@ endef
 export FLUX_KUSTOMIZATION
 
 example_resources:
-	mkdir -p examples/{dev,staging,prod}
+	mkdir -p examples/{dev,prod}
 	echo "$$CONFIG_MAP" > examples/dev/configmap.yaml
-	echo "$$CONFIG_MAP" > examples/staging/configmap.yaml
 	echo "$$CONFIG_MAP" > examples/prod/configmap.yaml
 	echo "$$FLUX_KUSTOMIZATION" > examples/dev/kustomization.yaml
-	echo "$$FLUX_KUSTOMIZATION" > examples/staging/kustomization.yaml
 	echo "$$FLUX_KUSTOMIZATION" > examples/prod/kustomization.yaml
 
 RELEASE_MANAGER_URL=http://localhost:8080

--- a/cmd/hamctl/command/actions/artifact_id.go
+++ b/cmd/hamctl/command/actions/artifact_id.go
@@ -27,8 +27,6 @@ func ArtifactIDFromEnvironment(client *httpinternal.Client, service, namespace, 
 	switch environment {
 	case "dev":
 		return statusResp.Dev.Tag, nil
-	case "staging":
-		return statusResp.Staging.Tag, nil
 	case "prod":
 		return statusResp.Prod.Tag, nil
 	}

--- a/cmd/hamctl/command/promote.go
+++ b/cmd/hamctl/command/promote.go
@@ -26,10 +26,8 @@ func NewPromote(client *httpinternal.Client, service *string) *cobra.Command {
 				switch toEnvironment {
 				case "dev":
 					fromEnvironment = "master"
-				case "staging":
-					fromEnvironment = "dev"
 				case "prod":
-					fromEnvironment = "staging"
+					fromEnvironment = "dev"
 				}
 			}
 			var artifactID string

--- a/cmd/hamctl/command/release_test.go
+++ b/cmd/hamctl/command/release_test.go
@@ -90,12 +90,12 @@ func TestRelease(t *testing.T) {
 			}, nil
 		}
 
-		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+		output := runCommand(t, "--branch", branch, "--env", "dev,prod")
 
 		assert.Equal(t, []string{
 			"Release of service service-name using branch master\n",
 			"[✓] Release of master-1-2 to dev initialized\n",
-			"[✓] Release of master-1-2 to staging initialized\n",
+			"[✓] Release of master-1-2 to prod initialized\n",
 		}, output)
 	})
 
@@ -110,18 +110,18 @@ func TestRelease(t *testing.T) {
 				ToEnvironment: req.Environment,
 				Tag:           artifactID,
 			}
-			if req.Environment == "staging" {
-				resp.Status = "Environment staging is already up-to-date"
+			if req.Environment == "prod" {
+				resp.Status = "Environment prod is already up-to-date"
 			}
 			return resp, nil
 		}
 
-		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+		output := runCommand(t, "--branch", branch, "--env", "dev,prod")
 
 		assert.Equal(t, []string{
 			"Release of service service-name using branch master\n",
 			"[✓] Release of master-1-2 to dev initialized\n",
-			"[✓] Environment staging is already up-to-date\n",
+			"[✓] Environment prod is already up-to-date\n",
 		}, output)
 	})
 
@@ -165,12 +165,12 @@ func TestRelease(t *testing.T) {
 			return resp, nil
 		}
 
-		output := runCommand(t, "--branch", branch, "--env", "dev,staging")
+		output := runCommand(t, "--branch", branch, "--env", "dev,prod")
 
 		assert.Equal(t, []string{
 			"Release of service service-name using branch master\n",
 			"[X] cannot release master-1-2 to environment dev due to branch restriction policy (reference: GUID)\n",
-			"[✓] Release of master-1-2 to staging initialized\n",
+			"[✓] Release of master-1-2 to prod initialized\n",
 		}, output)
 	})
 }

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -54,12 +54,11 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 
 func mapToStatusData(resp httpinternal.StatusResponse, service string) statusData {
 	return statusData{
-		EnvironmentsManaged:    someManaged(resp.Dev, resp.Staging, resp.Prod),
+		EnvironmentsManaged:    someManaged(resp.Dev, resp.Prod),
 		UsingDefaultNamespaces: resp.DefaultNamespaces,
 		Service:                service,
 		Environments: []statusDataEnvironment{
 			mapEnvironment(resp.Dev, "dev"),
-			mapEnvironment(resp.Staging, "staging"),
 			mapEnvironment(resp.Prod, "prod"),
 		},
 	}
@@ -71,7 +70,7 @@ var statusTemplate = `Status for service {{ .Service }}
 No environments managed by release-manager.
 
 {{ if .UsingDefaultNamespaces -}}
-Using environment specific namespace, ie. dev, staging, prod.
+Using environment specific namespace, ie. dev, prod.
 {{ end -}}
 Are you setting the right namespace?
 {{- end -}}

--- a/cmd/hamctl/command/status_test.go
+++ b/cmd/hamctl/command/status_test.go
@@ -41,7 +41,7 @@ Are you setting the right namespace?
 
 No environments managed by release-manager.
 
-Using environment specific namespace, ie. dev, staging, prod.
+Using environment specific namespace, ie. dev, prod.
 Are you setting the right namespace?
 `,
 		},
@@ -97,32 +97,11 @@ dev:
 						MediumVulnerabilities: 2,
 						LowVulnerabilities:    3,
 					},
-					{
-						Environment:           "staging",
-						Tag:                   "master-1234-5678",
-						Author:                "John Doe",
-						Committer:             "Jane Doe",
-						CommitMessage:         "Useful bits",
-						Date:                  time.Date(2021, time.June, 23, 8, 42, 22, 0, time.UTC),
-						BuildURL:              "https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect",
-						HighVulnerabilities:   1,
-						MediumVulnerabilities: 2,
-						LowVulnerabilities:    3,
-					},
 				},
 			},
 			output: `Status for service svc
 
 dev:
-  Tag: master-1234-5678
-  Author: John Doe
-  Committer: Jane Doe
-  Message: Useful bits
-  Date: 2021-06-23 08:42:22
-  Link: https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect
-  Vulnerabilities: 1 high, 2 medium, 3 low
-
-staging:
   Tag: master-1234-5678
   Author: John Doe
   Committer: Jane Doe

--- a/cmd/server/command/flags_test.go
+++ b/cmd/server/command/flags_test.go
@@ -40,12 +40,12 @@ func TestGrafanaOptions_String(t *testing.T) {
 					URL:    "localhost1",
 					APIKey: "key",
 				},
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "localhost2",
 					APIKey: "key",
 				},
 			},
-			output: "dev=<redacted>=localhost1,staging=<redacted>=localhost2",
+			output: "dev=<redacted>=localhost1,prod=<redacted>=localhost2",
 		},
 	}
 	for _, tc := range tt {
@@ -89,13 +89,13 @@ func TestGrafanaOptions_Set(t *testing.T) {
 		},
 		{
 			name:  "multiple complete",
-			input: "dev=key1=localhost,staging=key2=anotherhost",
+			input: "dev=key1=localhost,prod=key2=anotherhost",
 			output: grafanaOptions{
 				"dev": grafanaConfig{
 					URL:    "localhost",
 					APIKey: "key1",
 				},
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "anotherhost",
 					APIKey: "key2",
 				},
@@ -115,9 +115,9 @@ func TestGrafanaOptions_Set(t *testing.T) {
 		},
 		{
 			name:   "multiple values with one incomplete",
-			input:  "dev=key1=localhost,staging=key2",
+			input:  "dev=key1=localhost,prod=key2",
 			output: grafanaOptions{},
-			err:    errors.New("flag value 'staging=key2': value must be formatted as <env>=<api-key>=<url>"),
+			err:    errors.New("flag value 'prod=key2': value must be formatted as <env>=<api-key>=<url>"),
 		},
 	}
 	for _, tc := range tt {
@@ -167,14 +167,14 @@ func TestGrafanaOptions_GetSlice(t *testing.T) {
 					URL:    "localhost1",
 					APIKey: "a-key",
 				},
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "localhost2",
 					APIKey: "another-key",
 				},
 			},
 			output: []string{
 				"dev=<redacted>=localhost1",
-				"staging=<redacted>=localhost2",
+				"prod=<redacted>=localhost2",
 			},
 		},
 	}
@@ -202,13 +202,13 @@ func TestGrafanaOptions_Append(t *testing.T) {
 					APIKey: "key",
 				},
 			},
-			input: "staging=key=localhost2",
+			input: "prod=key=localhost2",
 			output: grafanaOptions{
 				"dev": grafanaConfig{
 					URL:    "localhost",
 					APIKey: "key",
 				},
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "localhost2",
 					APIKey: "key",
 				},
@@ -262,9 +262,9 @@ func TestGrafanaOptions_Replace(t *testing.T) {
 					APIKey: "key",
 				},
 			},
-			input: []string{"staging=key=localhost2"},
+			input: []string{"prod=key=localhost2"},
 			output: grafanaOptions{
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "localhost2",
 					APIKey: "key",
 				},
@@ -278,13 +278,13 @@ func TestGrafanaOptions_Replace(t *testing.T) {
 					APIKey: "key",
 				},
 			},
-			input: []string{"dev=key=localhost", "staging=key=localhost2"},
+			input: []string{"dev=key=localhost", "prod=key=localhost2"},
 			output: grafanaOptions{
 				"dev": grafanaConfig{
 					URL:    "localhost",
 					APIKey: "key",
 				},
-				"staging": grafanaConfig{
+				"prod": grafanaConfig{
 					URL:    "localhost2",
 					APIKey: "key",
 				},

--- a/cmd/server/http/status.go
+++ b/cmd/server/http/status.go
@@ -46,18 +46,6 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 			LowVulnerabilities:    s.Dev.LowVulnerabilities,
 		}
 
-		staging := httpinternal.Environment{
-			Message:               s.Staging.Message,
-			Author:                s.Staging.Author,
-			Tag:                   s.Staging.Tag,
-			Committer:             s.Staging.Committer,
-			Date:                  convertTimeToEpoch(s.Staging.Date),
-			BuildUrl:              s.Staging.BuildURL,
-			HighVulnerabilities:   s.Staging.HighVulnerabilities,
-			MediumVulnerabilities: s.Staging.MediumVulnerabilities,
-			LowVulnerabilities:    s.Staging.LowVulnerabilities,
-		}
-
 		prod := httpinternal.Environment{
 			Message:               s.Prod.Message,
 			Author:                s.Prod.Author,
@@ -76,7 +64,6 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 		err = payload.encodeResponse(ctx, w, httpinternal.StatusResponse{
 			DefaultNamespaces: s.DefaultNamespaces,
 			Dev:               &dev,
-			Staging:           &staging,
 			Prod:              &prod,
 		})
 		if err != nil {

--- a/e2e-test/release-manager.yaml
+++ b/e2e-test/release-manager.yaml
@@ -83,7 +83,6 @@ spec:
           # - name: GITHUB_API_TOKEN
           # - name: SLACK_TOKEN
           # - name: GRAFANA_DEV_API_KEY
-          # - name: GRAFANA_STAGING_API_KEY
           # - name: GRAFANA_PROD_API_KEY
           livenessProbe:
             httpGet:

--- a/internal/commitinfo/commitinfo_test.go
+++ b/internal/commitinfo/commitinfo_test.go
@@ -28,7 +28,7 @@ func TestParseCommitInfo(t *testing.T) {
 		{
 			name: "release commit with no spacing should match",
 			commitMessage: []string{
-				"[staging/test-service] release master-1234ds13g3-12s46g356g by hest@lunar.app",
+				"[prod/test-service] release master-1234ds13g3-12s46g356g by hest@lunar.app",
 				"Artifact-created-by: Foo Bar <test@lunar.app>",
 			},
 			commitInfo: CommitInfo{
@@ -36,14 +36,14 @@ func TestParseCommitInfo(t *testing.T) {
 				ArtifactCreatedBy: NewPersonInfo("Foo Bar", "test@lunar.app"),
 				ReleasedBy:        NewPersonInfo("", "hest@lunar.app"),
 				Service:           "test-service",
-				Environment:       "staging",
+				Environment:       "prod",
 				Intent:            intent.NewReleaseArtifact(),
 			},
 			correctCommitMessage: []string{
-				"[staging/test-service] release master-1234ds13g3-12s46g356g by hest@lunar.app",
+				"[prod/test-service] release master-1234ds13g3-12s46g356g by hest@lunar.app",
 				"",
 				"Service: test-service",
-				"Environment: staging",
+				"Environment: prod",
 				"Artifact-ID: master-1234ds13g3-12s46g356g",
 				"Artifact-released-by:  <hest@lunar.app>",
 				"Artifact-created-by: Foo Bar <test@lunar.app>",

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -15,7 +15,6 @@ type StatusRequest struct {
 type StatusResponse struct {
 	DefaultNamespaces bool         `json:"defaultNamespaces,omitempty"`
 	Dev               *Environment `json:"dev,omitempty"`
-	Staging           *Environment `json:"staging,omitempty"`
 	Prod              *Environment `json:"prod,omitempty"`
 }
 

--- a/internal/policy/branch_restriction_test.go
+++ b/internal/policy/branch_restriction_test.go
@@ -51,7 +51,7 @@ func TestCanRelease(t *testing.T) {
 					BranchRegex: "master",
 				},
 				{
-					Environment: "staging",
+					Environment: "preprod",
 					BranchRegex: "master",
 				},
 			},

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -141,14 +141,14 @@ func TestPolicies_SetAutoRelease(t *testing.T) {
 			input: input{
 				policies: policy("master", "dev"),
 				branch:   "feature",
-				env:      "staging",
+				env:      "prod",
 			},
 			output: output{
 				policies: policy(
 					"master", "dev",
-					"feature", "staging",
+					"feature", "prod",
 				),
-				id: "auto-release-feature-staging",
+				id: "auto-release-feature-prod",
 			},
 		},
 	}
@@ -463,7 +463,7 @@ func TestMergeBranchRestrictions(t *testing.T) {
 				{
 					ID:          "global-2",
 					BranchRegex: "^master$",
-					Environment: "staging",
+					Environment: "preprod",
 				},
 			},
 			local: []BranchRestriction{
@@ -487,7 +487,7 @@ func TestMergeBranchRestrictions(t *testing.T) {
 				{
 					ID:          "global-2",
 					BranchRegex: "^master$",
-					Environment: "staging",
+					Environment: "preprod",
 				},
 				{
 					ID:          "local-1",


### PR DESCRIPTION
As we have discontinued the concept of a staging environment the hardcoded
promotion flow of master -> dev -> staging -> prod no longer makes sense. A long
term change on how promotes are done is in the pipeline but until that is done
this change short circuits the promotion flow to skip staging.

This change also removes any mention of staging in the code base to avoid
confusion. Any code currently presenting something around the staging name is
also updated like the hamctl status command.