### PR TITLE
Remove dependency on host git in tests

### DIFF
--- a/cmd/hamctl/command/release_test.go
+++ b/cmd/hamctl/command/release_test.go
@@ -22,6 +22,8 @@ func TestRelease(t *testing.T) {
 		branch      = "master"
 		artifactID  = "master-1-2"
 	)
+	t.Setenv("HAMCTL_USER_NAME", "test")
+	t.Setenv("HAMCTL_USER_EMAIL", "test@example.com")
 
 	// mocked manager server responding as configured in variables below
 	var (

--- a/internal/flow/describe_release_test.go
+++ b/internal/flow/describe_release_test.go
@@ -63,7 +63,12 @@ func TestService_DescribeRelease_basicFlow(t *testing.T) {
 		},
 	}
 	for i := range commits {
-		hash, err := wt.Commit(commits[i].message, &git.CommitOptions{})
+		hash, err := wt.Commit(commits[i].message, &git.CommitOptions{
+			Author: &object.Signature{
+				Name:  "test",
+				Email: "test@example.com",
+			},
+		})
 		if err != nil {
 			t.Fatalf("failed to commit to worktree: %v", err)
 		}


### PR DESCRIPTION
Currently some of the tests rely on valid git configuration being pressent when
running. With the migration to GitHub actions in #281 this became clear as the
config was not pressent.

This change adds two new non-documented environment variables that can be used
to "fake" the user name and email for use in tests. This is not a great solution
but in generel the git config lookup isn't a great solution so I figure this is
OK for now. Another test case that makes some initial commits have also been
updated to set the commit author to again remove the dependency on the host
config.

The build in #281 is green with these changes is so we should be good in that
nothing else depends on git in this way.