### PR TITLE
Disable changelog in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,8 +75,4 @@ release:
   prerelease: auto
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
+  skip: true


### PR DESCRIPTION
The changelog is now created by release-drafter instead.