### PR TITLE
Run release workflow on release publish events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
When publishing a drafted release in GitHub we do not see a push tag event. This
change sets the workflow to run explicitly on release publishing instead making
it trigger correctly.