### PR TITLE
Fix release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     # only allow tags on the master branch
-    if: github.event.base_ref == 'refs/heads/master'
+    if: github.event.target_commitish == 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently the release job is not run on publish of releases as the if condition
does not use the correct field for filtering.

This change fixes the condition based on the "release" event payload.