### PR TITLE
Fix relase action confition again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # only allow tags on the master branch
-    if: github.event.target_commitish == 'master'
+    if: github.event.release.target_commitish == 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Use the nested release object of the release webhook payload to set the
condition of the release job.