### PR TITLE
Only run codeql on default branch or PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
   schedule:
     - cron: "0 19 * * 2"


### PR DESCRIPTION
Currently, dependabot PRs fail as `CodeQL` is run on the branch which has insufficient permissions. We already run it on Pull Requests (which succeeds).

This change changes the codeql workflow to only trigger on push events on the default branch