### PR TITLE
Show status of all environments in hamctl

### DIFF
--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -53,14 +53,15 @@ func NewStatus(client *httpinternal.Client, service *string) *cobra.Command {
 }
 
 func mapToStatusData(resp httpinternal.StatusResponse, service string) statusData {
+	var envs []statusDataEnvironment
+	for _, e := range resp.Environments {
+		envs = append(envs, mapEnvironment(&e, e.Name))
+	}
 	return statusData{
 		EnvironmentsManaged:    someManaged(resp.Dev, resp.Prod),
 		UsingDefaultNamespaces: resp.DefaultNamespaces,
 		Service:                service,
-		Environments: []statusDataEnvironment{
-			mapEnvironment(resp.Dev, "dev"),
-			mapEnvironment(resp.Prod, "prod"),
-		},
+		Environments:           envs,
 	}
 }
 

--- a/cmd/server/http/status.go
+++ b/cmd/server/http/status.go
@@ -63,6 +63,7 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 
 		err = payload.encodeResponse(ctx, w, httpinternal.StatusResponse{
 			DefaultNamespaces: s.DefaultNamespaces,
+			Environments:      mapEnvironments(s.Environments),
 			Dev:               &dev,
 			Prod:              &prod,
 		})
@@ -70,6 +71,26 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 			logger.Errorf("http: status: service '%s': marshal response failed: %v", service, err)
 		}
 	}
+}
+
+func mapEnvironments(envs []flow.Environment) []httpinternal.Environment {
+	var mapped []httpinternal.Environment
+	for _, env := range envs {
+		mapped = append(mapped, httpinternal.Environment{
+			Name:                  env.Name,
+			Message:               env.Message,
+			Author:                env.Author,
+			Tag:                   env.Tag,
+			Committer:             env.Committer,
+			Date:                  convertTimeToEpoch(env.Date),
+			BuildUrl:              env.BuildURL,
+			HighVulnerabilities:   env.HighVulnerabilities,
+			MediumVulnerabilities: env.MediumVulnerabilities,
+			LowVulnerabilities:    env.LowVulnerabilities,
+		})
+	}
+
+	return mapped
 }
 
 func convertTimeToEpoch(t time.Time) int64 {

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -24,7 +24,7 @@ func TestReleaseSpecification(t *testing.T) {
 				Service:     "a",
 			},
 			spec: artifact.Spec{
-				ID: "master-1234-5678",
+				ID: "master-default-5678",
 			},
 		},
 		{
@@ -65,22 +65,28 @@ func TestReleaseSpecifications(t *testing.T) {
 		name      string
 		namespace string
 		service   string
-		spec      artifact.Spec
+		release   ReleaseSpec
 	}{
 		{
 			name:      "default namespace",
 			namespace: "",
 			service:   "a",
-			spec: artifact.Spec{
-				ID: "master-default-5678",
+			release: ReleaseSpec{
+				Environment: "dev",
+				Spec: artifact.Spec{
+					ID: "master-default-5678",
+				},
 			},
 		},
 		{
 			name:      "specified namespace",
 			namespace: "other",
 			service:   "a",
-			spec: artifact.Spec{
-				ID: "master-other-5678",
+			release: ReleaseSpec{
+				Environment: "dev",
+				Spec: artifact.Spec{
+					ID: "master-other-5678",
+				},
 			},
 		},
 	}
@@ -95,10 +101,10 @@ func TestReleaseSpecifications(t *testing.T) {
 				ArtifactFileName: "artifact.json",
 			}
 
-			specs, err := s.releaseSpecifications(context.Background(), tc.namespace, tc.service)
+			releases, err := s.releaseSpecifications(context.Background(), tc.namespace, tc.service)
 
 			assert.NoError(t, err, "unexpected error")
-			assert.Equal(t, tc.spec, specs, "artifact spec not as expected")
+			assert.Equal(t, []ReleaseSpec{tc.release}, releases, "release specs not as expected")
 		})
 	}
 }

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -59,3 +59,46 @@ func TestReleaseSpecification(t *testing.T) {
 		})
 	}
 }
+
+func TestReleaseSpecifications(t *testing.T) {
+	tt := []struct {
+		name      string
+		namespace string
+		service   string
+		spec      artifact.Spec
+	}{
+		{
+			name:      "default namespace",
+			namespace: "",
+			service:   "a",
+			spec: artifact.Spec{
+				ID: "master-default-5678",
+			},
+		},
+		{
+			name:      "specified namespace",
+			namespace: "other",
+			service:   "a",
+			spec: artifact.Spec{
+				ID: "master-other-5678",
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			gitService := MockGitService{}
+			gitService.Test(t)
+			gitService.On("MasterPath").Return("testdata")
+
+			s := Service{
+				Git:              &gitService,
+				ArtifactFileName: "artifact.json",
+			}
+
+			specs, err := s.releaseSpecifications(context.Background(), tc.namespace, tc.service)
+
+			assert.NoError(t, err, "unexpected error")
+			assert.Equal(t, tc.spec, specs, "artifact spec not as expected")
+		})
+	}
+}

--- a/internal/flow/testdata/dev/releases/dev/a/artifact.json
+++ b/internal/flow/testdata/dev/releases/dev/a/artifact.json
@@ -1,3 +1,3 @@
 {
-  "id": "master-1234-5678"
+  "id": "master-default-5678"
 }

--- a/internal/flow/testdata/dev/releases/other/a/artifact.json
+++ b/internal/flow/testdata/dev/releases/other/a/artifact.json
@@ -1,0 +1,3 @@
+{
+  "id": "master-other-5678"
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -89,8 +89,9 @@ func (s *Service) clone(ctx context.Context, destination string) (*git.Repositor
 
 	span, _ = s.Tracer.FromCtx(ctx, "plain clone")
 	r, err := git.PlainCloneContext(ctx, destination, false, &git.CloneOptions{
-		URL:  s.ConfigRepoURL,
-		Auth: authSSH,
+		URL:   s.ConfigRepoURL,
+		Auth:  authSSH,
+		Depth: 1,
 	})
 	span.Finish()
 	if err != nil {

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -13,12 +13,17 @@ type StatusRequest struct {
 }
 
 type StatusResponse struct {
-	DefaultNamespaces bool         `json:"defaultNamespaces,omitempty"`
-	Dev               *Environment `json:"dev,omitempty"`
-	Prod              *Environment `json:"prod,omitempty"`
+	DefaultNamespaces bool          `json:"defaultNamespaces,omitempty"`
+	Environments      []Environment `json:"environments,omitempty"`
+
+	// Deprecated: Use environments instead.
+	Dev *Environment `json:"dev,omitempty"`
+	// Deprecated: Use environments instead.
+	Prod *Environment `json:"prod,omitempty"`
 }
 
 type Environment struct {
+	Name                  string `json:"name,omitempty"`
 	Tag                   string `json:"tag,omitempty"`
 	Committer             string `json:"committer,omitempty"`
 	Author                string `json:"author,omitempty"`


### PR DESCRIPTION
Currently hamctl status only shows the status of hardcoded dev and prod
environments. This makes the command close to useless when used with multiple
environments of other names.

This change adds a new environments array to the server API which contains all
identified environments where a service is released to. These are then written
by hamctl to the user along with the hard coded ones.

For backwards compatibality the dev and prod fields are kept around to allow a
rolling upgrade of the server and hamctl versions to developers.