### PR TITLE
Remove step conditional from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # only allow tags on the master branch
-    if: github.event.release.target_commitish == 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
It seems the check disables our release workflow at the moment.

This change removes the conditional to figure out if it will unlock releases.