### PR TITLE
Remove depth 1 on git clone

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -89,9 +89,8 @@ func (s *Service) clone(ctx context.Context, destination string) (*git.Repositor
 
 	span, _ = s.Tracer.FromCtx(ctx, "plain clone")
 	r, err := git.PlainCloneContext(ctx, destination, false, &git.CloneOptions{
-		URL:   s.ConfigRepoURL,
-		Auth:  authSSH,
-		Depth: 1,
+		URL:  s.ConfigRepoURL,
+		Auth: authSSH,
 	})
 	span.Finish()
 	if err != nil {


### PR DESCRIPTION
In 73795640e87746d02ca24336044360d4ef2f72c9 (#328) we mistakenly added a test
line which speeds up local development. But this effectively disables our
ability to do rollbacks.

This change removes the line fixing the issues.