### PR TITLE
Make hamctl status output a list

### DIFF
--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -75,21 +75,12 @@ Using environment specific namespace, ie. dev, prod.
 {{ end -}}
 Are you setting the right namespace?
 {{- end -}}
-
-{{ range .Environments }}
-
-{{ .Environment }}:
-{{- if eq (len .Tag) 0 }}
-  Not managed by the release-manager
-{{- else }}
-  Tag: {{ .Tag }}
-  Author: {{ .Author }}
-  Committer: {{ .Committer }}
-  Message: {{ .CommitMessage }}
-  Date: {{ .Date.Format dateFormat }}
-  Link: {{ .BuildURL }}
-  Vulnerabilities: {{ .HighVulnerabilities }} high, {{ .MediumVulnerabilities }} medium, {{ .LowVulnerabilities }} low
-{{- end -}}
+{{- if not (eq (len .Environments) 0) }}
+{{/* add 2 as we have ": " added to the environment column */ -}}
+{{ $columnWidth := add (maxLength .Environments "Environment") 2 -}}
+{{- range .Environments }}
+{{ rightPad (printf "%s:" .Environment) $columnWidth }}{{ .Date.Format dateFormat }} {{ .Tag }} by {{ .Committer }}: {{ .CommitMessage }}
+{{- end }}
 {{- end }}
 `
 

--- a/cmd/hamctl/command/status_test.go
+++ b/cmd/hamctl/command/status_test.go
@@ -68,14 +68,7 @@ Are you setting the right namespace?
 			},
 			output: `Status for service svc
 
-dev:
-  Tag: master-1234-5678
-  Author: John Doe
-  Committer: Jane Doe
-  Message: Useful bits
-  Date: 2021-06-23 08:42:22
-  Link: https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect
-  Vulnerabilities: 1 high, 2 medium, 3 low
+dev: 2021-06-23 08:42:22 master-1234-5678 by Jane Doe: Useful bits
 `,
 		},
 		{
@@ -97,18 +90,24 @@ dev:
 						MediumVulnerabilities: 2,
 						LowVulnerabilities:    3,
 					},
+					{
+						Environment:           "prod",
+						Tag:                   "master-5678-1234",
+						Author:                "John Doe",
+						Committer:             "Jane Doe",
+						CommitMessage:         "More useful bits",
+						Date:                  time.Date(2021, time.June, 23, 8, 42, 22, 0, time.UTC),
+						BuildURL:              "https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect",
+						HighVulnerabilities:   1,
+						MediumVulnerabilities: 2,
+						LowVulnerabilities:    3,
+					},
 				},
 			},
 			output: `Status for service svc
 
-dev:
-  Tag: master-1234-5678
-  Author: John Doe
-  Committer: Jane Doe
-  Message: Useful bits
-  Date: 2021-06-23 08:42:22
-  Link: https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect
-  Vulnerabilities: 1 high, 2 medium, 3 low
+dev:  2021-06-23 08:42:22 master-1234-5678 by Jane Doe: Useful bits
+prod: 2021-06-23 08:42:22 master-5678-1234 by Jane Doe: More useful bits
 `,
 		},
 	}

--- a/cmd/hamctl/template/template_test.go
+++ b/cmd/hamctl/template/template_test.go
@@ -1,0 +1,63 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTmplMaxLength(t *testing.T) {
+	type item struct {
+		Field string
+	}
+	tt := []struct {
+		name   string
+		list   interface{}
+		key    string
+		output int
+	}{
+		{
+			name:   "empty list",
+			list:   nil,
+			key:    "Field",
+			output: 0,
+		},
+		{
+			name:   "empty value",
+			list:   nil,
+			key:    "Field",
+			output: 0,
+		},
+		{
+			name: "single item",
+			list: []item{
+				{
+					Field: "hello",
+				},
+			},
+			key:    "Field",
+			output: 5,
+		},
+		{
+			name: "multiple items",
+			list: []item{
+				{
+					Field: "hello",
+				},
+				{
+					Field: "largeField",
+				},
+			},
+			key:    "Field",
+			output: 10,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := tmplMaxLength(tc.list, tc.key)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.output, output, "output not as expected")
+		})
+	}
+}


### PR DESCRIPTION
This change updates the output of hamctl status to be more concise and remove
unneeded information. As the link to Jenkins and the vulnerability count is a
point in time datapoint it is likely to be outdated whenever something is
released.

This change makes the output a one line status of each environment.

    $ hamctl status
    Status for service svc

    dev:  2021-06-23 08:42:22 master-1234-5678 by Jane Doe: Useful bits
    prod: 2021-06-23 08:42:22 master-5678-1234 by Jane Doe: More useful bits

The output was before.

```
$ hamctl status
Status for service svc

dev:
  Tag: master-1234-5678
  Author: John Doe
  Committer: Jane Doe
  Message: Useful bits
  Date: 2021-06-23 08:42:22
  Link: https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect
  Vulnerabilities: 1 high, 2 medium, 3 low

prod:
  Tag: master-5678-1234
  Author: John Doe
  Committer: Jane Doe
  Message: More useful bits
  Date: 2021-06-23 08:42:22
  Link: https://jenkins.corp.com/job/github-lunarway/job/svc/job/master/105/display/redirect
  Vulnerabilities: 1 high, 2 medium, 3 low
```