### PR TITLE
Remove deprecated hardcoded env in status response

### DIFF
--- a/cmd/hamctl/command/actions/artifact_id.go
+++ b/cmd/hamctl/command/actions/artifact_id.go
@@ -24,11 +24,10 @@ func ArtifactIDFromEnvironment(client *httpinternal.Client, service, namespace, 
 		return "", err
 	}
 
-	switch environment {
-	case "dev":
-		return statusResp.Dev.Tag, nil
-	case "prod":
-		return statusResp.Prod.Tag, nil
+	for _, env := range statusResp.Environments {
+		if environment == env.Name {
+			return env.Tag, nil
+		}
 	}
 
 	return "", fmt.Errorf("unknown environment %s", environment)

--- a/cmd/hamctl/command/status.go
+++ b/cmd/hamctl/command/status.go
@@ -58,7 +58,7 @@ func mapToStatusData(resp httpinternal.StatusResponse, service string) statusDat
 		envs = append(envs, mapEnvironment(&e, e.Name))
 	}
 	return statusData{
-		EnvironmentsManaged:    someManaged(resp.Dev, resp.Prod),
+		EnvironmentsManaged:    someManaged(resp.Environments...),
 		UsingDefaultNamespaces: resp.DefaultNamespaces,
 		Service:                service,
 		Environments:           envs,
@@ -124,9 +124,9 @@ func mapEnvironment(env *httpinternal.Environment, name string) statusDataEnviro
 }
 
 // someManaged returns true if any of provided environments are managed.
-func someManaged(envs ...*httpinternal.Environment) bool {
+func someManaged(envs ...httpinternal.Environment) bool {
 	for _, e := range envs {
-		if e != nil && e.Tag != "" {
+		if e.Tag != "" {
 			return true
 		}
 	}

--- a/cmd/server/http/status.go
+++ b/cmd/server/http/status.go
@@ -34,38 +34,12 @@ func status(payload *payload, flowSvc *flow.Service) http.HandlerFunc {
 			return
 		}
 
-		dev := httpinternal.Environment{
-			Message:               s.Dev.Message,
-			Author:                s.Dev.Author,
-			Tag:                   s.Dev.Tag,
-			Committer:             s.Dev.Committer,
-			Date:                  convertTimeToEpoch(s.Dev.Date),
-			BuildUrl:              s.Dev.BuildURL,
-			HighVulnerabilities:   s.Dev.HighVulnerabilities,
-			MediumVulnerabilities: s.Dev.MediumVulnerabilities,
-			LowVulnerabilities:    s.Dev.LowVulnerabilities,
-		}
-
-		prod := httpinternal.Environment{
-			Message:               s.Prod.Message,
-			Author:                s.Prod.Author,
-			Tag:                   s.Prod.Tag,
-			Committer:             s.Prod.Committer,
-			Date:                  convertTimeToEpoch(s.Prod.Date),
-			BuildUrl:              s.Prod.BuildURL,
-			HighVulnerabilities:   s.Prod.HighVulnerabilities,
-			MediumVulnerabilities: s.Prod.MediumVulnerabilities,
-			LowVulnerabilities:    s.Prod.LowVulnerabilities,
-		}
-
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		err = payload.encodeResponse(ctx, w, httpinternal.StatusResponse{
 			DefaultNamespaces: s.DefaultNamespaces,
 			Environments:      mapEnvironments(s.Environments),
-			Dev:               &dev,
-			Prod:              &prod,
 		})
 		if err != nil {
 			logger.Errorf("http: status: service '%s': marshal response failed: %v", service, err)

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -15,11 +15,6 @@ type StatusRequest struct {
 type StatusResponse struct {
 	DefaultNamespaces bool          `json:"defaultNamespaces,omitempty"`
 	Environments      []Environment `json:"environments,omitempty"`
-
-	// Deprecated: Use environments instead.
-	Dev *Environment `json:"dev,omitempty"`
-	// Deprecated: Use environments instead.
-	Prod *Environment `json:"prod,omitempty"`
 }
 
 type Environment struct {


### PR DESCRIPTION
This change removes the hardcoded dev and prod environments from the status
endpoint and flows. A new environments slice was introduced in
73795640e87746d02ca24336044360d4ef2f72c9 (#328) which contains the same
information and more and is what hamctl uses when writing output to developers.