### PR TITLE
Fix issue where the k8s observers 

### DIFF
--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -61,8 +61,7 @@ func StartDaemon() *cobra.Command {
 			go func() {
 				err := server.ListenAndServe()
 				if err != nil {
-					log.Errorf("Failed to start the notification server: %s", err)
-					os.Exit(1)
+					done <- errors.WithMessage(err, "start notification server")
 				}
 			}()
 

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -57,7 +57,14 @@ func StartDaemon() *cobra.Command {
 			kubernetes.RegisterJobInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
 			kubernetes.RegisterPodInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset, moduloCrashReportNotif)
 			kubernetes.RegisterStatefulSetInformer(kubectl.InformerFactory, exporter, handlerFactory, kubectl.Clientset)
-			flux_notification_controller.StartHttpServer()
+			server := flux_notification_controller.NewHttpServer()
+			go func() {
+				err := server.ListenAndServe()
+				if err != nil {
+					log.Errorf("Failed to start the notification server: %s", err)
+					os.Exit(1)
+				}
+			}()
 
 			log.Info("Deamon started")
 
@@ -80,6 +87,13 @@ func StartDaemon() *cobra.Command {
 				log.Errorf("Exited unknown error: %v", err)
 				os.Exit(1)
 			}
+
+			err = server.Close()
+			if err != nil {
+				log.Errorf("Failed to close the notification server: %s", err)
+				os.Exit(1)
+			}
+
 			log.Infof("Program ended")
 			return nil
 		},

--- a/cmd/daemon/flux2notifications/server.go
+++ b/cmd/daemon/flux2notifications/server.go
@@ -4,14 +4,16 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/lunarway/release-manager/internal/log"
 )
 
-func StartHttpServer() {
+func NewHttpServer() *http.Server {
 	router := mux.NewRouter()
 	router.HandleFunc("/webhook/flux2-alerts", HandleEventFromFlux2).Methods(http.MethodPost)
-	err := http.ListenAndServe(":3001", router)
-	if err != nil {
-		log.Errorf("Failed to start daemon's HTTP server: %v", err)
+
+	server := &http.Server{
+		Addr:    ":3001",
+		Handler: router,
 	}
+
+	return server
 }


### PR DESCRIPTION
Currently, the Kubernetes observers are not running in the `release-daemon` as the new HTTP server is blocking the rest of the components from starting.

This change starts the HTTP server in a go routine instead.  