### PR TITLE
OOMKills are only shown on running pods last termination state

### DIFF
--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -192,10 +192,6 @@ func isPodInCreateContainerConfigError(pod *corev1.Pod) bool {
 }
 
 func isPodOOMKilled(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodFailed {
-		return false
-	}
-
 	for _, cst := range pod.Status.ContainerStatuses {
 		return isContainerOOMKilled(cst)
 	}

--- a/cmd/daemon/kubernetes/pods_test.go
+++ b/cmd/daemon/kubernetes/pods_test.go
@@ -201,7 +201,7 @@ func TestIsPodOOMKilled(t *testing.T) {
 			desc: "container status is OOMKilled",
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
-					Phase: corev1.PodFailed,
+					Phase: corev1.PodRunning,
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
 							State: corev1.ContainerState{


### PR DESCRIPTION
Currently, OOMKills are not reported as the pod phase assumption was wrong. After investigating an OOMKilled pod, we saws that the pod phase was running.

This change removes the pod phase check from the `isPodOOMKilled` function to enable reporting of OOMKIlled pods.