### PR TITLE
Use quorum queues instead of classic queues

### DIFF
--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -121,13 +121,16 @@ func (w *Worker) initializeConsumer(c ConsumerConfig) error {
 	}
 
 	w.logger.Infof("[amqp] Declaring queue '%s'", prefixedQueue)
+	queueArgs := amqp.Table{
+		"x-queue-type": "quorum",
+	}
 	_, err = channel.QueueDeclare(
 		prefixedQueue,   // name
 		c.DurableQueue,  // durable
 		!c.DurableQueue, // delete when unused. We set this to the negation of DurableQueue: either our queues are durable or they live and die with the service creating them
 		false,           // exclusive
 		false,           // no-wait
-		nil,             // arguments
+		queueArgs,       // arguments
 	)
 	if err != nil {
 		return errors.WithMessagef(err, "declare queue '%s'", prefixedQueue)


### PR DESCRIPTION
This change is part of an effort to make it possible to deploy the server component in HA. 

Currently, the AMQP integration uses classic queue which is not HA by default, unless that is configured.

This change moves the queue declaration to use quorum queues instead which will configure multiple replicas out of the box. It is also better for data-safety.

**THIS IS A BREAKING CHANGE**

A queue declaration will fail if a queue already exists so the queue would have to be manually removed before using this version.