### PR TITLE
Feature/amqp single consumers

### DIFF
--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -121,13 +121,16 @@ func (w *Worker) initializeConsumer(c ConsumerConfig) error {
 	}
 
 	w.logger.Infof("[amqp] Declaring queue '%s'", prefixedQueue)
+	queueArgs := amqp.Table{
+		"x-queue-type": "quorum",
+	}
 	_, err = channel.QueueDeclare(
 		prefixedQueue,   // name
 		c.DurableQueue,  // durable
 		!c.DurableQueue, // delete when unused. We set this to the negation of DurableQueue: either our queues are durable or they live and die with the service creating them
 		false,           // exclusive
 		false,           // no-wait
-		nil,             // arguments
+		queueArgs,       // arguments
 	)
 	if err != nil {
 		return errors.WithMessagef(err, "declare queue '%s'", prefixedQueue)

--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -122,7 +122,8 @@ func (w *Worker) initializeConsumer(c ConsumerConfig) error {
 
 	w.logger.Infof("[amqp] Declaring queue '%s'", prefixedQueue)
 	queueArgs := amqp.Table{
-		"x-queue-type": "quorum",
+		"x-queue-type":             "quorum",
+		"x-single-active-consumer": true,
 	}
 	_, err = channel.QueueDeclare(
 		prefixedQueue,   // name


### PR DESCRIPTION
This change is part of an effort to make it possible to deploytthe server component in HA.

Currently, the AMQP integration uses a round-robin approach when multiple consumers are active.

This change adds the `x-single-active-comsumer` arg so that only one consumer is active at a given point. Failovers is handled by the `AMQP` server. 

THIS IS A BREAKING CHANGE

A queue declaration will fail if a queue already exists so the queue would have to be manually removed before using this version.

This PR is dependent on #372 