### PR TITLE
Removes ticks when error message is empty

### DIFF
--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -208,7 +208,7 @@ func (c *Client) NotifySlackPolicyFailed(ctx context.Context, email, title, erro
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
 		Title:      title,
 		Color:      MsgColorRed,
-		Text:       FormatErrorMessage(errorMessage),
+		Text:       formatErrorMessage(errorMessage),
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
@@ -298,7 +298,7 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	for _, container := range event.Errors {
 		fields = append(fields, slack.AttachmentField{
 			Title: fmt.Sprintf("Container: %s (%s)", container.Name, container.Type),
-			Value: fmt.Sprintf("```%s```", container.ErrorMessage),
+			Value: formatErrorMessage(container.ErrorMessage),
 			Short: false,
 		})
 	}
@@ -329,7 +329,7 @@ func (c *Client) NotifyK8SJobErrorEvent(ctx context.Context, event *http.JobErro
 	for _, condition := range event.Errors {
 		fields = append(fields, slack.AttachmentField{
 			Title: fmt.Sprintf("Reason: %s", condition.Reason),
-			Value: fmt.Sprintf("```%s```", condition.Message),
+			Value: formatErrorMessage(condition.Message),
 			Short: false,
 		})
 	}
@@ -383,7 +383,7 @@ func generateSlackMessage(msgType, service, environment, branch, namespace strin
 	}
 }
 
-func FormatErrorMessage(errorMessage string) string {
+func formatErrorMessage(errorMessage string) string {
 	if errorMessage == "" { //error message is only formatted if there is one
 		return errorMessage
 	}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -208,10 +208,11 @@ func (c *Client) NotifySlackPolicyFailed(ctx context.Context, email, title, erro
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
 		Title:      title,
 		Color:      MsgColorRed,
-		Text:       fmt.Sprintf("```%s```", errorMessage),
+		Text:       FormatErrorMessage(errorMessage),
 		MarkdownIn: []string{"text", "fields"},
 	})
-
+	log.Infof("errormsg = %s", FormatErrorMessage(errorMessage))
+	fmt.Println(FormatErrorMessage(errorMessage))
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	if err != nil {
 		return err
@@ -382,4 +383,11 @@ func generateSlackMessage(msgType, service, environment, branch, namespace strin
 	default:
 		return fmt.Sprintf("Failed handling event in release manager for:\nEvent: %s\nService: %s\nEnvironment: %s\nBranch: %s\nNamespace: %s\nError: %s", msgType, service, environment, branch, namespace, err)
 	}
+}
+
+func FormatErrorMessage(errorMessage string) string {
+	if errorMessage == "" { //error message is only formatted if there is one
+		return errorMessage
+	}
+	return fmt.Sprintf("```%s```", errorMessage)
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -211,8 +211,6 @@ func (c *Client) NotifySlackPolicyFailed(ctx context.Context, email, title, erro
 		Text:       FormatErrorMessage(errorMessage),
 		MarkdownIn: []string{"text", "fields"},
 	})
-	log.Infof("errormsg = %s", FormatErrorMessage(errorMessage))
-	fmt.Println(FormatErrorMessage(errorMessage))
 	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	if err != nil {
 		return err

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -36,21 +36,23 @@ func TestNewMutableClient_mapping(t *testing.T) {
 		}
 	)
 
-	slackClient := intslack.MockSlackClient{}
-	slackClient.Test(t)
-	slackClient.On("PostMessage", slackUser.ID, mock.Anything, mock.Anything).Return("", "", nil)
-	// return error when looking up non-corp email
-	slackClient.On("GetUserByEmailContext", mock.Anything, email).Return(&slack.User{}, errors.New("users_not_found"))
-	// return slack user on anything else
-	slackClient.On("GetUserByEmailContext", mock.Anything, mock.Anything).Return(slackUser, nil)
+	t.Run("domain verification", func(t *testing.T) {
+		slackClient := intslack.MockSlackClient{}
+		slackClient.Test(t)
+		slackClient.On("PostMessage", slackUser.ID, mock.Anything, mock.Anything).Return("", "", nil)
+		// return error when looking up non-corp email
+		slackClient.On("GetUserByEmailContext", mock.Anything, email).Return(&slack.User{}, errors.New("users_not_found"))
+		// return slack user on anything else
+		slackClient.On("GetUserByEmailContext", mock.Anything, mock.Anything).Return(slackUser, nil)
 
-	client, err := intslack.NewMuteableClient(&slackClient, mapping, emailDomain, intslack.MuteOptions{})
-	if !assert.NoError(t, err, "unexpected instantiation error") {
-		return
-	}
+		client, err := intslack.NewMuteableClient(&slackClient, mapping, emailDomain, intslack.MuteOptions{})
+		if !assert.NoError(t, err, "unexpected instantiation error") {
+			return
+		}
 
-	_, _, err = client.PostSlackBuildStarted(email, "title", "titleLink", "text", "color")
-	if !assert.NoError(t, err, "unexpected instantiation error") {
-		return
-	}
+		_, _, err = client.PostSlackBuildStarted(email, "title", "titleLink", "text", "color")
+		if !assert.NoError(t, err, "unexpected instantiation error") {
+			return
+		}
+	})
 }


### PR DESCRIPTION
An OOMKIlled error seems to have an empty error msg. Therefore, it looks a bit weird in Slack:
![image](https://user-images.githubusercontent.com/56017845/177116061-a254ca7f-07d2-4a9f-9e26-5d586335749c.png)

When @mahlunar made the task, he also needed a reference to the pods.go -> [release-manager/pods.go at master · lunarway/release-manager](https://github.com/lunarway/release-manager/blob/master/cmd/daemon/kubernetes/pods.go#L143). I can't really figure out why this is relevant for the Slack message.

I am also unsure of how to test it. Any guidance would be helpful 🙏 It seems like the rest of the methods were tested through mock but this method is not part of the interface and it would be a mistake to it purely for testing purposes.