### PR TITLE
Alert squads on PodErrorEvents

### DIFF
--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -81,7 +81,7 @@ const (
 	artifactIDAnnotationKey    = "lunarway.com/artifact-id"
 	authorAnnotationKey        = "lunarway.com/author"
 	controlledAnnotationKey    = "lunarway.com/controlled-by-release-manager"
-	runtimeAlertsAnnotationKey = "lunarway.com/runtimeAlerts"
+	runtimeAlertsAnnotationKey = "lunarway.com/runtime-alerts"
 	squadLabelKey              = "squad"
 )
 

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -77,11 +77,12 @@ func isCorrectlyAnnotated(annotations map[string]string) bool {
 }
 
 const (
-	observedAnnotationKey   = "lunarway.com/observed-artifact-id"
-	artifactIDAnnotationKey = "lunarway.com/artifact-id"
-	authorAnnotationKey     = "lunarway.com/author"
-	controlledAnnotationKey = "lunarway.com/controlled-by-release-manager"
-	squadLabelKey           = "squad"
+	observedAnnotationKey      = "lunarway.com/observed-artifact-id"
+	artifactIDAnnotationKey    = "lunarway.com/artifact-id"
+	authorAnnotationKey        = "lunarway.com/author"
+	controlledAnnotationKey    = "lunarway.com/controlled-by-release-manager"
+	runtimeAlertsAnnotationKey = "lunarway.com/runtimeAlerts"
+	squadLabelKey              = "squad"
 )
 
 func observe(annotations map[string]string) {

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -262,6 +262,9 @@ func getCodeOwnerSquad(labels map[string]string) string {
 
 func alertSquad(squad string, annotations map[string]string) (alertChannel string) {
 	if value, ok := annotations[runtimeAlertsAnnotationKey]; ok {
+		if value == "false" {
+			return ""
+		}
 		return value
 	}
 	return fmt.Sprintf("#squad-%s-alerts", squad)

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -97,6 +97,7 @@ type PodErrorEvent struct {
 	Environment string           `json:"environment,omitempty"`
 	ArtifactID  string           `json:"artifactId,omitempty"`
 	Squad       string           `json:"squad,omitempty"`
+	AlertSquad  string           `json:"alertSquad,omitempty"`
 }
 
 type JobConditionError struct {

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -316,9 +316,6 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	if event.AlertSquad != "false" {
 		_, _, err = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
 	}
-	if event.Squad == "aura" || event.Squad == "odyssey" { //check if you opted in
-		_, _, err = c.client.PostMessageContext(ctx, fmt.Sprintf("#squad-%s-alerts", event.Squad), asUser, attachments)
-	}
 	return err
 }
 

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -313,7 +313,7 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	if err != nil {
 		return err
 	}
-	if event.AlertSquad != "false" {
+	if event.AlertSquad != "" {
 		_, _, err = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
 	}
 	return err

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -313,6 +313,9 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	if err != nil {
 		return err
 	}
+	if event.AlertSquad != "false" {
+		_, _, err = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
+	}
 	if event.Squad == "aura" || event.Squad == "odyssey" { //check if you opted in
 		_, _, err = c.client.PostMessageContext(ctx, fmt.Sprintf("#squad-%s-alerts", event.Squad), asUser, attachments)
 	}


### PR DESCRIPTION
Adds functionality for alerting the squad as well as the author on PodErrorEvents. When the author misses, overlooks or forgets a pod failure, it can be a problem as said pod is failing until noticed or a new version is released.
It is the assumption that this leads to more - and silently - failing pods in our environments than necessary.
This change would make failing pods a collective squad responsibility instead of the individual developer.