### PR TITLE
Replace home made mux with gorilla/mux

### DIFF
--- a/cmd/server/http/http_test.go
+++ b/cmd/server/http/http_test.go
@@ -60,13 +60,13 @@ func TestAuthenticate(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := func(w http.ResponseWriter, r *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-			}
+			})
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set("Authorization", tc.authorization)
 			w := httptest.NewRecorder()
-			authenticate(tc.serverToken, handler)(w, req)
+			authenticate(tc.serverToken)(handler).ServeHTTP(w, req)
 
 			assert.Equal(t, tc.status, w.Result().StatusCode, "status code not as expected")
 		})

--- a/cmd/server/http/policy_test.go
+++ b/cmd/server/http/policy_test.go
@@ -1,8 +1,6 @@
 package http
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,13 +31,13 @@ func TestFilterEmptyStrings(t *testing.T) {
 			output: nil,
 		},
 		{
-			name: "multiple whitespace strings",
-			input: strings("  ", "	"),
+			name:   "multiple whitespace strings",
+			input:  strings("  ", "	"),
 			output: nil,
 		},
 		{
-			name: "mixed whitespace and non-whitespace strings",
-			input: strings("  ", "hello", "	", "world"),
+			name:   "mixed whitespace and non-whitespace strings",
+			input:  strings("  ", "hello", "	", "world"),
 			output: strings("hello", "world"),
 		},
 		{
@@ -57,46 +55,6 @@ func TestFilterEmptyStrings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			output := filterEmptyStrings(tc.input)
 			assert.Equal(t, tc.output, output, "output not as expected")
-		})
-	}
-}
-
-func TestPolicyPatchPath(t *testing.T) {
-	tt := []struct {
-		name       string
-		path       string
-		valid      bool
-		policyType string
-	}{
-		{
-			name:       "empty",
-			path:       "http://localhost",
-			valid:      false,
-			policyType: "",
-		},
-		{
-			name:       "no type",
-			path:       "http://localhost/policies",
-			valid:      false,
-			policyType: "",
-		},
-		{
-			name:       "with type",
-			path:       "http://localhost/policies/auto-release",
-			valid:      true,
-			policyType: "auto-release",
-		},
-	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodPatch, tc.path, nil)
-			p, ok := newPolicyPatchPath(r)
-			assert.Equal(t, tc.valid, ok, "path not valid")
-			if !ok {
-				return
-			}
-			policyType := p.PolicyType()
-			assert.Equal(t, tc.policyType, policyType, "policy type not as expected")
 		})
 	}
 }


### PR DESCRIPTION
Currently the server runs a complicated set of mux operations to register
handlers and middlewares. Further more parsing of query parameters are done with
complicated  string parsing. All of this makes it hard to understand the API but
also hard to maintain.

This change migrates to the gorilla/mux module which makes path parsing
redundant and also allows for sub routed grouping of middlewares which makes for
a simpler registration flow.

Another motivation for the change is to allow the introduction of a prometheus
metrics middleware which works nicely with parameterized path segments. This
will be introduced at a later point.