### PR TITLE
Add HTTP prometheus metrics middleware

### DIFF
--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -81,7 +81,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	m.HandleFunc("/webhook/github", githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
 
 	s := http.Server{
-		Addr:              fmt.Sprintf("localhost:%d", opts.Port),
+		Addr:              fmt.Sprintf(":%d", opts.Port),
 		Handler:           m,
 		ReadTimeout:       opts.Timeout,
 		WriteTimeout:      opts.Timeout,

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -40,6 +40,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	})
 
 	m.Use(trace(tracer))
+	m.Use(prometheusMiddleware())
 	m.Use(reqrespLogger)
 
 	hamctlMux := m.NewRoute().Subrouter()
@@ -80,7 +81,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	m.HandleFunc("/webhook/github", githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
 
 	s := http.Server{
-		Addr:              fmt.Sprintf(":%d", opts.Port),
+		Addr:              fmt.Sprintf("localhost:%d", opts.Port),
 		Handler:           m,
 		ReadTimeout:       opts.Timeout,
 		WriteTimeout:      opts.Timeout,

--- a/cmd/server/http/metrics.go
+++ b/cmd/server/http/metrics.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+func prometheusMiddleware() func(next http.Handler) http.Handler {
+	durationHistorgram := promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "request_duration_seconds",
+		Help: "Duration of HTTP requests.",
+	}, []string{"path", "method", "status_code"})
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			lrw := &statusCodeKeepingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+			route := mux.CurrentRoute(r)
+			path, _ := route.GetPathTemplate()
+			start := time.Now()
+
+			next.ServeHTTP(lrw, r)
+
+			duration := time.Since(start).Seconds()
+			durationHistorgram.
+				WithLabelValues(path, r.Method, strconv.Itoa(lrw.StatusCode())).
+				Observe(duration)
+		})
+	}
+}
+
+// statusCodeKeepingResponseWriter is an http.ResponseWriter which stores the
+// HTTP status code for later inspection.
+type statusCodeKeepingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (s *statusCodeKeepingResponseWriter) StatusCode() int {
+	return s.statusCode
+}
+
+func (s *statusCodeKeepingResponseWriter) WriteHeader(code int) {
+	s.statusCode = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusCodeKeepingResponseWriter) Write(content []byte) (int, error) {
+	return s.ResponseWriter.Write(content)
+}


### PR DESCRIPTION
This change adds a HTTP middleware for tracking request and response latencies.
This will give us better insights into how the service performs over time.