### PR TITLE
Use Go 1.19.0 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.1
+          go-version: 1.19.0
       - name: Cache Go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.1
+          go-version: 1.19.0
       - name: Cache Go modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Go was only upgraded in our build images for local usage. This change patches Go
to latest in our build pipeline and thus also in our releases.