### PR TITLE
Add release prometheus counter

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lunarway/release-manager/internal/copy"
 	internalgit "github.com/lunarway/release-manager/internal/git"
 	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/lunarway/release-manager/internal/intent"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/policy"
 	"github.com/lunarway/release-manager/internal/slack"
@@ -63,6 +64,7 @@ type NotifyReleaseOptions struct {
 	Service     string
 	Releaser    string
 	Spec        artifact.Spec
+	Intent      intent.Intent
 }
 
 type GitService interface {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Observer struct {
+	releaseCounter *prometheus.CounterVec
+}
+
+func NewObserver() *Observer {
+	return &Observer{
+		releaseCounter: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "release_manager_releases_total",
+			Help: "Total number of releases",
+		}, []string{
+			"environment",
+			"service",
+			"releaser",
+			"intent",
+		}),
+	}
+}
+
+type Release struct {
+	Environment string
+	Service     string
+	Releaser    string
+	Intent      string
+}
+
+func (o *Observer) ObserveRelease(release Release) {
+	o.releaseCounter.WithLabelValues(
+		release.Environment,
+		release.Service,
+		release.Releaser,
+		release.Intent,
+	).Inc()
+}


### PR DESCRIPTION
This change registers a new release notifier which tracks a prometheus counter
for each release. The release notifier option is also expanded to include the
intent which contains relevant information on the behaviour backing the release,
eg. was it a rollback.

```
# HELP release_manager_releases_total Total number of releases
# TYPE release_manager_releases_total counter
release_manager_releases_total{environment="dev",intent="ReleaseArtifact",releaser="Bjørn Sørensen",service="test-service"} 1
```