### PR TITLE
Replace ioutil.ReadAll with io.ReadAll

### DIFF
--- a/cmd/daemon/flux2notifications/api.go
+++ b/cmd/daemon/flux2notifications/api.go
@@ -2,7 +2,7 @@ package flux2notifications
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -28,7 +28,7 @@ type Event struct {
 
 func HandleEventFromFlux2(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body) //TODO: log something
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("Failed to unmarshal alert from flux2-notification-controller: %v", err)
 		http.Error(w, "unknown error", http.StatusInternalServerError)

--- a/cmd/daemon/flux2notifications/api_test.go
+++ b/cmd/daemon/flux2notifications/api_test.go
@@ -1,7 +1,7 @@
 package flux2notifications
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,7 +26,7 @@ func TestWebhookForAlerts(t *testing.T) {
 	HandleEventFromFlux2(w, request)
 	response := w.Result()
 	defer response.Body.Close()
-	_, err := ioutil.ReadAll(response.Body)
+	_, err := io.ReadAll(response.Body)
 
 	//assert
 	assert.NoError(t, err, "HandleEventFromFlux2 could not handle request")

--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -3,7 +3,7 @@ package copy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -47,11 +47,11 @@ func execCommand(ctx context.Context, rootPath string, cmdName string, args ...s
 		return errors.WithMessage(err, "start command")
 	}
 
-	stdoutData, err := ioutil.ReadAll(stdout)
+	stdoutData, err := io.ReadAll(stdout)
 	if err != nil {
 		return errors.WithMessage(err, "read stdout data of command")
 	}
-	stderrData, err := ioutil.ReadAll(stderr)
+	stderrData, err := io.ReadAll(stderr)
 	if err != nil {
 		return errors.WithMessage(err, "read stderr data of command")
 	}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -452,7 +453,7 @@ func uploadFile(url string, fileContent []byte, md5 string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed upload file to %s with status code %v and request id %v and and also got an error reading body %w", url, resp.StatusCode, resp.Header["X-Amz-Request-Id"], err)
 		}

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -1,7 +1,7 @@
 package git
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -49,7 +49,7 @@ func getGitConfig(field string) (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "start command")
 	}
-	stdoutData, err := ioutil.ReadAll(stdout)
+	stdoutData, err := io.ReadAll(stdout)
 	if err != nil {
 		return "", errors.WithMessage(err, "read stdout data of command")
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -390,11 +389,11 @@ func execCommand(ctx context.Context, rootPath string, cmdName string, args ...s
 		return errors.WithMessage(err, "start command")
 	}
 
-	stdoutData, err := ioutil.ReadAll(stdout)
+	stdoutData, err := io.ReadAll(stdout)
 	if err != nil {
 		return errors.WithMessage(err, "read stdout data of command")
 	}
-	stderrData, err := ioutil.ReadAll(stderr)
+	stderrData, err := io.ReadAll(stderr)
 	if err != nil {
 		return errors.WithMessage(err, "read stderr data of command")
 	}
@@ -454,11 +453,11 @@ func checkStatus(ctx context.Context, rootPath string) error {
 		return errors.WithMessage(err, "start command")
 	}
 
-	stdoutData, err := ioutil.ReadAll(stdout)
+	stdoutData, err := io.ReadAll(stdout)
 	if err != nil {
 		return errors.WithMessage(err, "read stdout data of command")
 	}
-	stderrData, err := ioutil.ReadAll(stderr)
+	stderrData, err := io.ReadAll(stderr)
 	if err != nil {
 		return errors.WithMessage(err, "read stderr data of command")
 	}
@@ -495,11 +494,11 @@ func gitPush(ctx context.Context, rootPath string) error {
 		return errors.WithMessage(err, "start command")
 	}
 
-	stdoutData, err := ioutil.ReadAll(stdout)
+	stdoutData, err := io.ReadAll(stdout)
 	if err != nil {
 		return errors.WithMessage(err, "read stdout data of command")
 	}
-	stderrData, err := ioutil.ReadAll(stderr)
+	stderrData, err := io.ReadAll(stderr)
 	if err != nil {
 		return errors.WithMessage(err, "read stderr data of command")
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -57,7 +56,7 @@ func (s *Service) TagRepo(ctx context.Context, repository, tag, sha string) erro
 	case http.StatusCreated:
 		return nil
 	case http.StatusUnprocessableEntity:
-		errorBody, err := ioutil.ReadAll(resp.Body)
+		errorBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logger.Errorf("internal/github: failed too read error body of request")
 		}
@@ -68,7 +67,7 @@ func (s *Service) TagRepo(ctx context.Context, repository, tag, sha string) erro
 		}
 		return nil
 	default:
-		errorBody, err := ioutil.ReadAll(resp.Body)
+		errorBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logger.Errorf("internal/github: failed too read error body of request")
 		}
@@ -95,7 +94,7 @@ func (s *Service) updateTag(ctx context.Context, repository, tag, sha string) er
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		errorBody, err := ioutil.ReadAll(resp.Body)
+		errorBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.WithContext(ctx).Errorf("internal/github: failed to read error body of request")
 		}

--- a/internal/grafana/grafana.go
+++ b/internal/grafana/grafana.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -63,7 +63,7 @@ func (s *Service) Annotate(ctx context.Context, env string, body AnnotateRequest
 
 	logger := log.WithContext(ctx)
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		logger.Infof("grafana: response body: %s", body)
 		return errors.New("grafana: status code not ok")
 	}


### PR DESCRIPTION
The ioutil package function has been deprecated and replaced by io.ReadAll.

This change updates all references to the deprecated function.