### PR TITLE
Fix HTTP bug in ArtifactIDFromBranch lookup

### DIFF
--- a/cmd/hamctl/command/actions/artifact_id.go
+++ b/cmd/hamctl/command/actions/artifact_id.go
@@ -37,7 +37,7 @@ func ArtifactIDFromBranch(client *httpinternal.Client, service string, branch st
 	var describeResp httpinternal.DescribeArtifactResponse
 	params := url.Values{}
 	params.Add("branch", branch)
-	path, err := client.URLWithQuery(fmt.Sprintf("describe/latest-artifact/%s/%s", service, branch), params)
+	path, err := client.URLWithQuery(fmt.Sprintf("describe/latest-artifact/%s", service), params)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -36,6 +36,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 	}
 	m := mux.NewRouter()
 	m.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.WithContext(r.Context()).Infof("Unknown HTTP endpoint called: %s", r.URL.String())
 		notFound(w)
 	})
 


### PR DESCRIPTION
Currently hamctl will use the ArtifactIDFromBranch action to look up what to
release when using the branch flag.

    hamctl release --service foo --branch bar --env baz

The action has a bug in the endpoint construction where it adds the branch name
twice. Once as a path segment and later as a query parameter. The server expects
only a query parameter. The bug was introduced way back in
1482e499a5f3fada4434e183fc0743145bb62019 (#195) but as the old HTTP server mux
was not that strict the bug wasn't discovered. With the change to using
gorilla/mux in bea4c3f975e07d6a129194137cedcdb3ce26f717 (#407) where paths needs
to match strictly things stopped working.