### PR TITLE
Remove unneeded fmt.Sprintf calls

### DIFF
--- a/cmd/server/http/policy.go
+++ b/cmd/server/http/policy.go
@@ -109,11 +109,11 @@ func applyBranchRestrictionPolicy(payload *payload, policySvc *policyinternal.Se
 			switch errorCause(err) {
 			case policyinternal.ErrConflict:
 				logger.Infof("http: policy: apply: service '%s' branch regex '%s' environment '%s': apply branch-restriction rejected: conflicts with another policy: %v", req.Service, req.BranchRegex, req.Environment, err)
-				httpinternal.Error(w, fmt.Sprintf("policy conflicts with another policy"), http.StatusBadRequest)
+				httpinternal.Error(w, "policy conflicts with another policy", http.StatusBadRequest)
 				return
 			case git.ErrBranchBehindOrigin:
 				logger.Infof("http: policy: apply: service '%s' branch regex '%s' environment '%s': apply branch-restriction: %v", req.Service, req.BranchRegex, req.Environment, err)
-				httpinternal.Error(w, fmt.Sprintf("could not apply policy right now. Please try again in a moment."), http.StatusServiceUnavailable)
+				httpinternal.Error(w, "could not apply policy right now. Please try again in a moment.", http.StatusServiceUnavailable)
 				return
 			default:
 				logger.Errorf("http: policy: apply: service '%s' branch regex '%s' environment '%s': apply branch-restriction failed: %v", req.Service, req.BranchRegex, req.Environment, err)
@@ -235,7 +235,7 @@ func deletePolicies(payload *payload, policySvc *policyinternal.Service) http.Ha
 				return
 			case git.ErrBranchBehindOrigin:
 				logger.Infof("http: policy: delete: service '%s' ids %v: %v", req.Service, ids, err)
-				httpinternal.Error(w, fmt.Sprintf("could not delete policy right now. Please try again in a moment."), http.StatusServiceUnavailable)
+				httpinternal.Error(w, "could not delete policy right now. Please try again in a moment.", http.StatusServiceUnavailable)
 				return
 			default:
 				logger.Errorf("http: policy: delete: service '%s' ids %v: delete failed: %v", req.Service, ids, err)

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -263,7 +263,7 @@ func (c *Client) notifyAuthorEventProcessed(ctx context.Context, options Release
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":rocket: Release Manager :white_check_mark:"),
+		Title:      ":rocket: Release Manager :white_check_mark:",
 		Color:      MsgColorGreen,
 		Text:       fmt.Sprintf("Release for *%s* in %s processed\nArtifact: <%s|*%s*>", options.Service, options.Environment, options.CommitLink, options.ArtifactID),
 		MarkdownIn: []string{"text", "fields"},
@@ -375,7 +375,7 @@ func (c *Client) NotifyReleaseManagerError(ctx context.Context, msgType, service
 
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
-		Title:      fmt.Sprintf(":boom: Release Manager failed :x:"),
+		Title:      ":boom: Release Manager failed :x:",
 		Color:      MsgColorRed,
 		Text:       generateSlackMessage(msgType, service, environment, branch, namespace, inputErr),
 		MarkdownIn: []string{"text", "fields"},


### PR DESCRIPTION
staticcheck detected several places where fmt.Sprintf is used without arguments.

	$ staticcheck ./...
	...
	cmd/server/http/policy.go:112:27: unnecessary use of fmt.Sprintf (S1039)
	cmd/server/http/policy.go:116:27: unnecessary use of fmt.Sprintf (S1039)
	cmd/server/http/policy.go:238:27: unnecessary use of fmt.Sprintf (S1039)
	internal/slack/slack.go:266:15: unnecessary use of fmt.Sprintf (S1039)
	internal/slack/slack.go:378:15: unnecessary use of fmt.Sprintf (S1039)

This change removes invokations of the function.