### PR TITLE
Remove usage of deprecated io/ioutil package

### DIFF
--- a/cmd/server/gpg/gpg.go
+++ b/cmd/server/gpg/gpg.go
@@ -6,7 +6,6 @@ package gpg
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,16 +24,17 @@ func ImportKeys(src string, trustImportedKeys bool) ([]string, error) {
 	case err != nil:
 		return nil, err
 	case info.IsDir():
-		infos, err := ioutil.ReadDir(src)
+		dirEntries, err := os.ReadDir(src)
 		if err != nil {
 			return nil, err
 		}
-		for _, f := range infos {
-			filepath := filepath.Join(src, f.Name())
-			if f, err = os.Stat(filepath); err != nil {
+		for _, dirEntry := range dirEntries {
+			filepath := filepath.Join(src, dirEntry.Name())
+			stat, err := os.Stat(filepath)
+			if err != nil {
 				continue
 			}
-			if f.Mode().IsRegular() {
+			if stat.Mode().IsRegular() {
 				files = append(files, filepath)
 			}
 		}

--- a/internal/flow/describe_release_test.go
+++ b/internal/flow/describe_release_test.go
@@ -2,7 +2,6 @@ package flow_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,7 +22,7 @@ import (
 // reported in the results due to how the flow was handling checkouts.
 func TestService_DescribeRelease_basicFlow(t *testing.T) {
 	// setup temporary repository
-	tmpDir, err := ioutil.TempDir("", "release-manager-test")
+	tmpDir, err := os.MkdirTemp("", "release-manager-test")
 	if err != nil {
 		t.Fatalf("failed to get temp dir: %v", err)
 	}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -422,7 +421,7 @@ func zipFiles(files []fileInfo) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		fileContent, err := ioutil.ReadFile(file.fullPath)
+		fileContent, err := os.ReadFile(file.fullPath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/git/temp_dir.go
+++ b/internal/git/temp_dir.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/lunarway/release-manager/internal/log"
@@ -16,7 +15,7 @@ func TempDir(ctx context.Context, tracer tracing.Tracer, prefix string) (string,
 	span, _ := tracer.FromCtxf(ctx, "create temp dir")
 	span.SetTag("path_prefix", prefix)
 	defer span.Finish()
-	path, err := ioutil.TempDir("", prefix)
+	path, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", func(context.Context) {}, err
 	}

--- a/internal/s3storage/artifactreadstorage.go
+++ b/internal/s3storage/artifactreadstorage.go
@@ -3,7 +3,7 @@ package s3storage
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"sort"
 
@@ -136,7 +136,7 @@ func (f *Service) getArtifactSpecFromObjectKey(ctx context.Context, objectKey st
 
 	subSpan, _ := f.tracer.FromCtx(ctx, "read json file")
 	defer subSpan.Finish()
-	jsonSpec, err := ioutil.ReadFile(path.Join(artifactPath, "artifact.json"))
+	jsonSpec, err := os.ReadFile(path.Join(artifactPath, "artifact.json"))
 	if err != nil {
 		return artifact.Spec{}, errors.WithMessage(err, "read artifact.json file")
 	}

--- a/internal/s3storage/s3.go
+++ b/internal/s3storage/s3.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -26,7 +25,7 @@ func (f *Service) downloadArtifact(ctx context.Context, key string) (string, fun
 
 	logger := log.WithContext(ctx)
 	logger.WithFields("key", key).Infof("Downloading artifact from S3 key '%s'", key)
-	zipDest, err := ioutil.TempFile("", "s3-artifact-zip")
+	zipDest, err := os.CreateTemp("", "s3-artifact-zip")
 	if err != nil {
 		return "", nil, errors.WithMessage(err, "create temp file for zip")
 	}
@@ -77,7 +76,7 @@ func (f *Service) downloadArtifact(ctx context.Context, key string) (string, fun
 }
 
 func tempDir(prefix string) (string, func(context.Context), error) {
-	path, err := ioutil.TempDir("", prefix)
+	path, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", func(context.Context) {}, err
 	}


### PR DESCRIPTION
This change removes any usage of the deprecated io/ioutil package. The places for change was detected by staticcheck.

	$ staticcheck ./...
	cmd/server/gpg/gpg.go:9:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
	internal/flow/describe_release_test.go:5:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
	internal/flow/flow.go:11:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
	internal/git/temp_dir.go:5:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
	internal/s3storage/artifactreadstorage.go:6:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
	internal/s3storage/s3.go:7:2: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)