### PR TITLE
Remove unused variables

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -16,9 +16,6 @@ import (
 func pushCommand(options *Options) *cobra.Command {
 	releaseManagerClient := httpinternal.Client{}
 
-	// retries for comitting changes into config repo
-	// can be required for racing writes
-	const maxRetries = 5
 	command := &cobra.Command{
 		Use:   "push",
 		Short: "push artifact to artifact repository",

--- a/internal/commitinfo/conventional_test.go
+++ b/internal/commitinfo/conventional_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestParseConventionalCommit(t *testing.T) {
 	tt := []struct {
-		name          string
-		commitMessage []string
-		commitInfo    ConventionalCommitInfo
+		name                  string
+		commitMessage         []string
+		commitInfo            ConventionalCommitInfo
+		expectedCommitMessage []string
 	}{
 		{
 			name: "message with no description and field + no space",
@@ -182,6 +183,10 @@ func TestParseConventionalCommit(t *testing.T) {
 
 		t.Run(tc.name+" and back", func(t *testing.T) {
 			expectedCommitMessage := tc.commitMessage
+			if tc.expectedCommitMessage == nil {
+				expectedCommitMessage = tc.expectedCommitMessage
+				return
+			}
 			assert.Equal(t, strings.Join(expectedCommitMessage, "\n"), tc.commitInfo.String())
 		})
 	}

--- a/internal/commitinfo/conventional_test.go
+++ b/internal/commitinfo/conventional_test.go
@@ -9,10 +9,9 @@ import (
 
 func TestParseConventionalCommit(t *testing.T) {
 	tt := []struct {
-		name                  string
-		commitMessage         []string
-		commitInfo            ConventionalCommitInfo
-		expectedCommitMessage []string
+		name          string
+		commitMessage []string
+		commitInfo    ConventionalCommitInfo
 	}{
 		{
 			name: "message with no description and field + no space",
@@ -183,10 +182,6 @@ func TestParseConventionalCommit(t *testing.T) {
 
 		t.Run(tc.name+" and back", func(t *testing.T) {
 			expectedCommitMessage := tc.commitMessage
-			if tc.expectedCommitMessage == nil {
-				expectedCommitMessage = tc.expectedCommitMessage
-				return
-			}
 			assert.Equal(t, strings.Join(expectedCommitMessage, "\n"), tc.commitInfo.String())
 		})
 	}

--- a/internal/flow/describe_release.go
+++ b/internal/flow/describe_release.go
@@ -113,7 +113,7 @@ func (s *Service) DescribeRelease(ctx context.Context, environment, service stri
 }
 
 func findNamespaceFromCommit(ctx context.Context, commitObj *object.Commit, artifactFileName string) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "flow.findNamespace")
+	span, _ := opentracing.StartSpanFromContext(ctx, "flow.findNamespace")
 	defer span.Finish()
 	span.SetTag("gitcommit", commitObj.Hash.String())
 


### PR DESCRIPTION
staticcheck detected several unused variables.

	$ staticcheck ./...
	cmd/artifact/command/push.go:21:8: const maxRetries is unused (U1000)
	internal/commitinfo/conventional_test.go:187:5: this value of expectedCommitMessage is never used (SA4006)
	internal/flow/describe_release.go:116:2: this value of ctx is never used (SA4006)

These are removed.