### PR TITLE
Simplify code

### DIFF
--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -81,12 +81,9 @@ func (w *Worker) StartConsumer(consumerConfigs []ConsumerConfig, consumersStarte
 // waitForConsumerReady waits until the consumer state becomes Ready. It stops
 // only when the consumerState channel is closed.
 func waitForConsumerReady(consumerState chan consumer.State) {
-	for {
-		select {
-		case state := <-consumerState:
-			if state.Ready != nil {
-				return
-			}
+	for state := range consumerState {
+		if state.Ready != nil {
+			return
 		}
 	}
 }

--- a/internal/s3storage/artifactreadstorage.go
+++ b/internal/s3storage/artifactreadstorage.go
@@ -91,9 +91,7 @@ func (f *Service) ArtifactSpecifications(ctx context.Context, service string, n 
 		MaxKeys: aws.Int64(1000),
 		Prefix:  aws.String(prefix),
 	}, func(p *s3.ListObjectsV2Output, lastPage bool) bool {
-		for _, object := range p.Contents {
-			list = append(list, object)
-		}
+		list = append(list, p.Contents...)
 		return true
 	})
 	if err != nil {


### PR DESCRIPTION
This change updates two code snippets that are identified by staticcheck as complex. They are replaced by their recomended simplified version making it easier to read the code.

	$ staticcheck ./...
	internal/amqp/consumer.go:84:2: should use for range instead of for { select {} } (S1000)
	internal/s3storage/artifactreadstorage.go:94:3: should replace loop with list = append(list, p.Contents...) (S1011)