### PR TITLE
Change channel.Publish to channel.PublishContext

### DIFF
--- a/cmd/amqp/main.go
+++ b/cmd/amqp/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"math/rand"
@@ -52,7 +53,7 @@ func main() {
 	for i := 0; i < *count; i++ {
 		go func() {
 			defer wg.Done()
-			err = channel.Publish("amqp-load", "load", false, false, amqp.Publishing{
+			err = channel.PublishWithContext(context.Background(), "amqp-load", "load", false, false, amqp.Publishing{
 				Body: p,
 			})
 			if err != nil {


### PR DESCRIPTION
The channel.Publish method used in the amqp CLI is deprecated and replaced by a
context aware version.

This change updates our code to not used the deprecated version although we do
not have a context in the CLI for use.

	$ staticcheck ./...
	cmd/amqp/main.go:55:10: channel.Publish is deprecated: Use PublishWithContext instead.  (SA1019)