### PR TITLE
Inject copier instead of using globals

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lunarway/release-manager/internal/broker"
 	"github.com/lunarway/release-manager/internal/broker/amqpextra"
 	"github.com/lunarway/release-manager/internal/broker/memory"
+	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/flow"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/github"
@@ -144,8 +145,12 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					}
 				}
 			}
+
+			copier := copy.New(log.With("system", "copier"))
+
 			gitSvc := git.Service{
 				Tracer:            tracer,
+				Copier:            copier,
 				SSHPrivateKeyPath: startOptions.configRepo.SSHPrivateKeyPath,
 				ConfigRepoURL:     startOptions.configRepo.ConfigRepo,
 				Config:            startOptions.gitConfigOpts,
@@ -265,6 +270,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Storage:          s3storageSvc,
 				Policy:           &policySvc,
 				Tracer:           tracer,
+				Copier:           copier,
 				// TODO: figure out a better way of splitting the consumer and publisher
 				// to avoid this chicken and egg issue. It is not a real problem as the
 				// consumer is started later on and this we are sure this gets set, it

--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -18,19 +18,29 @@ var (
 	ErrUnknownSource = errors.New("copy: unknown source")
 )
 
-func CopyDir(ctx context.Context, src, dest string) error {
+type Copier struct {
+	logger *log.Logger
+}
+
+func New(logger *log.Logger) *Copier {
+	return &Copier{
+		logger: logger,
+	}
+}
+
+func (c *Copier) CopyDir(ctx context.Context, src, dest string) error {
 	if !strings.HasSuffix(src, string(os.PathSeparator)) {
 		src = fmt.Sprintf("%s/.", src)
 	}
-	return execCommand(ctx, ".", "cp", "-a", src, dest)
+	return c.execCommand(ctx, ".", "cp", "-a", src, dest)
 }
 
-func CopyFile(ctx context.Context, src, dest string) error {
-	return execCommand(ctx, ".", "cp", "-a", src, dest)
+func (c *Copier) CopyFile(ctx context.Context, src, dest string) error {
+	return c.execCommand(ctx, ".", "cp", "-a", src, dest)
 }
 
-func execCommand(ctx context.Context, rootPath string, cmdName string, args ...string) error {
-	logger := log.WithContext(ctx).WithFields("root", rootPath)
+func (c *Copier) execCommand(ctx context.Context, rootPath string, cmdName string, args ...string) error {
+	logger := c.logger.WithContext(ctx).WithFields("root", rootPath)
 	logger.Infof("copy/execCommand: running: %s %s", cmdName, strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, cmdName, args...)
 	cmd.Dir = rootPath

--- a/internal/copy/copy_test.go
+++ b/internal/copy/copy_test.go
@@ -34,7 +34,7 @@ func TestCopyDir(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			log.Init(&log.Configuration{
+			logger := log.New(&log.Configuration{
 				Level: log.Level{
 					Level: zapcore.DebugLevel,
 				},
@@ -47,7 +47,9 @@ func TestCopyDir(t *testing.T) {
 			t.Logf("Using pwd: %s", pwd)
 			absSrc := path.Join(pwd, tc.src)
 			absDest := path.Join(pwd, tc.dest)
-			err = copy.CopyDir(context.Background(), absSrc, absDest)
+
+			copier := copy.New(logger)
+			err = copier.CopyDir(context.Background(), absSrc, absDest)
 			defer os.RemoveAll(absDest)
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error(), "wrong error")

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -47,6 +47,7 @@ type Service struct {
 	CanRelease       func(ctx context.Context, svc, branch, env string) (bool, error)
 	Storage          ArtifactReadStorage
 	Policy           *policy.Service
+	Copier           *copy.Copier
 
 	PublishReleaseArtifactID func(context.Context, ReleaseArtifactIDEvent) error
 	PublishNewArtifact       func(context.Context, NewArtifactEvent) error
@@ -403,7 +404,7 @@ func (s *Service) cleanCopy(ctx context.Context, src, dest string) error {
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "copy files")
 	span.Finish()
-	err = copy.CopyDir(ctx, src, dest)
+	err = s.Copier.CopyDir(ctx, src, dest)
 	if err != nil {
 		if errors.Cause(err) == copy.ErrUnknownSource {
 			return ErrUnknownConfiguration

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/copy"
+	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestReleaseSpecification(t *testing.T) {
@@ -44,7 +47,15 @@ func TestReleaseSpecification(t *testing.T) {
 			gitService.Test(t)
 			gitService.On("MasterPath").Return("testdata")
 
+			logger := log.New(&log.Configuration{
+				Level: log.Level{
+					Level: zapcore.DebugLevel,
+				},
+				Development: true,
+			})
+
 			s := Service{
+				Copier:           copy.New(logger),
 				Git:              &gitService,
 				ArtifactFileName: "artifact.json",
 			}
@@ -96,7 +107,15 @@ func TestReleaseSpecifications(t *testing.T) {
 			gitService.Test(t)
 			gitService.On("MasterPath").Return("testdata")
 
+			logger := log.New(&log.Configuration{
+				Level: log.Level{
+					Level: zapcore.DebugLevel,
+				},
+				Development: true,
+			})
+
 			s := Service{
+				Copier:           copy.New(logger),
 				Git:              &gitService,
 				ArtifactFileName: "artifact.json",
 			}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/commitinfo"
-	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/intent"
 	"github.com/lunarway/release-manager/internal/log"
@@ -54,7 +53,7 @@ func (p *ReleaseArtifactIDEvent) Unmarshal(data []byte) error {
 
 // ReleaseArtifactID releases a specific artifact to environment env.
 //
-// Flow
+// # Flow
 //
 // Locate the commit of the artifact ID and checkout the config repository at
 // this point.
@@ -182,7 +181,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		// copy artifact spec
 		artifactDestinationPath := path.Join(destinationPath, s.ArtifactFileName)
 		logger.Infof("flow: ReleaseArtifactID: copy artifact from %s to %s", artifactSourcePath, artifactDestinationPath)
-		err = copy.CopyFile(ctx, artifactSourcePath, artifactDestinationPath)
+		err = s.Copier.CopyFile(ctx, artifactSourcePath, artifactDestinationPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("copy artifact spec from '%s' to '%s'", artifactSourcePath, artifactDestinationPath))
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -35,6 +35,7 @@ type GitConfig struct {
 
 type Service struct {
 	Tracer            tracing.Tracer
+	Copier            *copy.Copier
 	SSHPrivateKeyPath string
 	ConfigRepoURL     string
 	Config            *GitConfig
@@ -143,7 +144,7 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 	defer s.masterMutex.RUnlock()
 	span.Finish()
 	span, _ = s.Tracer.FromCtx(ctx, "copy to destination")
-	err = copy.CopyDir(ctx, s.MasterPath(), destination)
+	err = s.Copier.CopyDir(ctx, s.MasterPath(), destination)
 	span.Finish()
 	if err != nil {
 		return nil, errors.WithMessagef(err, "copy master from '%s'", s.MasterPath())

--- a/internal/policy/branch_restriction_test.go
+++ b/internal/policy/branch_restriction_test.go
@@ -246,6 +246,7 @@ func TestService_ApplyBranchRestriction(t *testing.T) {
 				},
 				Development: true,
 			})
+			logger := log.With() // bad way to get the global logger for now
 			gitService := MockGitService{}
 			var destinationPath string
 			gitService.On("MasterPath").Return(func() string {
@@ -259,7 +260,7 @@ func TestService_ApplyBranchRestriction(t *testing.T) {
 				// need it to later inspect the results of the operation
 				destinationPath = path
 				// copy testdata into path faking a master clone
-				err := copy.CopyDir(ctx, "testdata", path)
+				err := copy.New(logger).CopyDir(ctx, "testdata", path)
 				assert.NoError(t, err, "unexpected error when copying in Clone")
 				return nil
 			}, nil)


### PR DESCRIPTION
The current implementation of flows and git depends on a concrete global
implementation for copying in the copy package. This makes any usage hard to
test and also reason about. Further more does the copy functions rely on a
global logger instance making for an even more coupled implementation.

This change extracts the copying functionality into an injected struct with the
logger injected. No tests or functionality is changed. This is purely a
refactoring to enable future changes.

This is part of a larger change to remove the global logging state and inject it in all places.