### PR TITLE
Revert 'remove-duplicate-branch'

### DIFF
--- a/cmd/hamctl/command/actions/artifact_id.go
+++ b/cmd/hamctl/command/actions/artifact_id.go
@@ -37,7 +37,7 @@ func ArtifactIDFromBranch(client *httpinternal.Client, service string, branch st
 	var describeResp httpinternal.DescribeArtifactResponse
 	params := url.Values{}
 	params.Add("branch", branch)
-	path, err := client.URLWithQuery(fmt.Sprintf("describe/latest-artifact/%s", service), params)
+	path, err := client.URLWithQuery(fmt.Sprintf("describe/latest-artifact/%s/%s", service, branch), params)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
 We've seen issues with v0.24 where we cannot release artifacts from the cli, we suspect it is because of this