### PR TITLE
Make sure we don't crash on missing email

### DIFF
--- a/cmd/hamctl/command/policy.go
+++ b/cmd/hamctl/command/policy.go
@@ -2,13 +2,12 @@ package command
 
 import (
 	"github.com/lunarway/release-manager/cmd/hamctl/command/policy"
-	"github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func NewPolicy(client *http.Client, service *string, gitConfigAPI *git.LocalGitConfigAPI) *cobra.Command {
+func NewPolicy(client *http.Client, service *string, gitConfigAPI GitConfigAPI) *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "policy",
 		Short: "Manage release policies for services.",

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -58,8 +58,9 @@ func NewRoot(version *string) (*cobra.Command, error) {
 				committer, err := gitConfigAPI.CommitterDetails()
 				if err != nil {
 					missingFlags = append(missingFlags, "user-email")
+				} else {
+					email = committer.Email
 				}
-				email = committer.Email
 			}
 			client.Metadata.CallerEmail = email
 			if len(missingFlags) != 0 {

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -53,7 +53,7 @@ func NewRoot(version *string) (*cobra.Command, error) {
 			if service == "" {
 				missingFlags = append(missingFlags, "service")
 			}
-			if err := setCallerEmailFromCommitter(gitConfigAPI, &client, email); err != nil {
+			if err := setCallerEmail(gitConfigAPI, &client, email); err != nil {
 				missingFlags = append(missingFlags, "user-email")
 			}
 
@@ -134,7 +134,7 @@ func defaultShuttleString(shuttleLocator func() (shuttleSpec, bool), flagValue *
 	}
 }
 
-func setCallerEmailFromCommitter(gitConfigAPI GitConfigAPI, client *http.Client, email string) error {
+func setCallerEmail(gitConfigAPI GitConfigAPI, client *http.Client, email string) error {
 	if email != "" {
 		client.Metadata.CallerEmail = email
 	} else {

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -53,7 +53,7 @@ func NewRoot(version *string) (*cobra.Command, error) {
 			if service == "" {
 				missingFlags = append(missingFlags, "service")
 			}
-			if err := setCallerEmailFromCommitter(gitConfigAPI, &client); err != nil {
+			if err := setCallerEmailFromCommitter(gitConfigAPI, &client, email); err != nil {
 				missingFlags = append(missingFlags, "user-email")
 			}
 
@@ -134,11 +134,16 @@ func defaultShuttleString(shuttleLocator func() (shuttleSpec, bool), flagValue *
 	}
 }
 
-func setCallerEmailFromCommitter(gitConfigAPI GitConfigAPI, client *http.Client) error {
-	committer, err := gitConfigAPI.CommitterDetails()
-	if err != nil {
-		return fmt.Errorf("could not get committer from git: %w", err)
+func setCallerEmailFromCommitter(gitConfigAPI GitConfigAPI, client *http.Client, email string) error {
+	if email != "" {
+		client.Metadata.CallerEmail = email
+	} else {
+		committer, err := gitConfigAPI.CommitterDetails()
+		if err != nil {
+			return fmt.Errorf("could not get committer from git: %w", err)
+		}
+		client.Metadata.CallerEmail = committer.Email
 	}
-	client.Metadata.CallerEmail = committer.Email
+
 	return nil
 }

--- a/cmd/hamctl/command/root_test.go
+++ b/cmd/hamctl/command/root_test.go
@@ -70,7 +70,7 @@ func TestDefaultShuttleString_noSpec(t *testing.T) {
 	assert.Equal(t, "", flagValue, "flag value not as expected")
 }
 
-func TestSetCallerEmailFromCommitter(t *testing.T) {
+func TestSetCallerEmail(t *testing.T) {
 	tt := []struct {
 		name             string
 		gitConfigApiMock GitConfigAPI
@@ -105,13 +105,13 @@ func TestSetCallerEmailFromCommitter(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &http.Client{}
-			_ = setCallerEmailFromCommitter(tc.gitConfigApiMock, client, tc.email)
+			_ = setCallerEmail(tc.gitConfigApiMock, client, tc.email)
 			assert.Equal(t, tc.expectedEmail, client.Metadata.CallerEmail)
 		})
 	}
 }
 
-func TestSetCallerEmailFromCommitterReturnsError(t *testing.T) {
+func TestSetCallerEmailReturnsError(t *testing.T) {
 	tt := []struct {
 		name             string
 		gitConfigApiMock GitConfigAPI
@@ -132,7 +132,7 @@ func TestSetCallerEmailFromCommitterReturnsError(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &http.Client{}
-			err := setCallerEmailFromCommitter(tc.gitConfigApiMock, client, tc.email)
+			err := setCallerEmail(tc.gitConfigApiMock, client, tc.email)
 			assert.ErrorContains(t, err, tc.expectedError.Error())
 			assert.Equal(t, "", client.Metadata.CallerEmail)
 		})

--- a/cmd/hamctl/command/root_test.go
+++ b/cmd/hamctl/command/root_test.go
@@ -74,10 +74,11 @@ func TestSetCallerEmailFromCommitter(t *testing.T) {
 	tt := []struct {
 		name             string
 		gitConfigApiMock GitConfigAPI
+		email            string
 		expectedEmail    string
 	}{
 		{
-			name: "with valid email",
+			name: "with valid email from committer",
 			gitConfigApiMock: &GitConfigAPIMock{
 				CommitterDetailsFunc: func() (*git.CommitterDetails, error) {
 					return &git.CommitterDetails{Email: "some@email"}, nil
@@ -94,13 +95,17 @@ func TestSetCallerEmailFromCommitter(t *testing.T) {
 			},
 			expectedEmail: "",
 		},
+		{
+			name:          "with valid email",
+			email:         "some@email",
+			expectedEmail: "some@email",
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &http.Client{}
-			setCallerEmailFromCommitter(tc.gitConfigApiMock, client)
-
+			_ = setCallerEmailFromCommitter(tc.gitConfigApiMock, client, tc.email)
 			assert.Equal(t, tc.expectedEmail, client.Metadata.CallerEmail)
 		})
 	}
@@ -110,6 +115,7 @@ func TestSetCallerEmailFromCommitterReturnsError(t *testing.T) {
 	tt := []struct {
 		name             string
 		gitConfigApiMock GitConfigAPI
+		email            string
 		expectedError    error
 	}{
 		{
@@ -126,7 +132,7 @@ func TestSetCallerEmailFromCommitterReturnsError(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &http.Client{}
-			err := setCallerEmailFromCommitter(tc.gitConfigApiMock, client)
+			err := setCallerEmailFromCommitter(tc.gitConfigApiMock, client, tc.email)
 			assert.ErrorContains(t, err, tc.expectedError.Error())
 			assert.Equal(t, "", client.Metadata.CallerEmail)
 		})

--- a/cmd/hamctl/command/root_test.go
+++ b/cmd/hamctl/command/root_test.go
@@ -1,8 +1,12 @@
 package command
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/http"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,4 +68,67 @@ func TestDefaultShuttleString_noSpec(t *testing.T) {
 		return s.Vars.Service
 	})
 	assert.Equal(t, "", flagValue, "flag value not as expected")
+}
+
+func TestSetCallerEmailFromCommitter(t *testing.T) {
+	tt := []struct {
+		name             string
+		gitConfigApiMock GitConfigAPI
+		expectedEmail    string
+	}{
+		{
+			name: "with valid email",
+			gitConfigApiMock: &GitConfigAPIMock{
+				CommitterDetailsFunc: func() (*git.CommitterDetails, error) {
+					return &git.CommitterDetails{Email: "some@email"}, nil
+				},
+			},
+			expectedEmail: "some@email",
+		},
+		{
+			name: "with empty email",
+			gitConfigApiMock: &GitConfigAPIMock{
+				CommitterDetailsFunc: func() (*git.CommitterDetails, error) {
+					return nil, errors.New("could not find email")
+				},
+			},
+			expectedEmail: "",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{}
+			setCallerEmailFromCommitter(tc.gitConfigApiMock, client)
+
+			assert.Equal(t, tc.expectedEmail, client.Metadata.CallerEmail)
+		})
+	}
+}
+
+func TestSetCallerEmailFromCommitterReturnsError(t *testing.T) {
+	tt := []struct {
+		name             string
+		gitConfigApiMock GitConfigAPI
+		expectedError    error
+	}{
+		{
+			name: "with no email",
+			gitConfigApiMock: &GitConfigAPIMock{
+				CommitterDetailsFunc: func() (*git.CommitterDetails, error) {
+					return nil, errors.New("could not find email")
+				},
+			},
+			expectedError: fmt.Errorf("could not get committer from git: %w", errors.New("could not find email")),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{}
+			err := setCallerEmailFromCommitter(tc.gitConfigApiMock, client)
+			assert.ErrorContains(t, err, tc.expectedError.Error())
+			assert.Equal(t, "", client.Metadata.CallerEmail)
+		})
+	}
 }


### PR DESCRIPTION
If we cannot find the .gitconfig/comitter then we get a panic because the `committer` object is nil. As such we now use an else statement and report error in the case it is missing.

Fixes: AURA-147