### PR TITLE
Add release failed event

### DIFF
--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -14,9 +14,9 @@ COPY cmd/server/ ./cmd/server/
 RUN go build -o server cmd/server/main.go
 
 FROM alpine:3.16.2
-RUN   apk update && \
-      apk add --no-cache \
-      openssh-keygen bash openssh-client git ca-certificates gnupg
+RUN apk update && \
+  apk add --no-cache \
+  openssh-keygen bash openssh-client git ca-certificates gnupg
 RUN ssh-keyscan github.com bitbucket.org >> /etc/ssh/ssh_known_hosts
 WORKDIR /app
 

--- a/internal/events/release_failed.go
+++ b/internal/events/release_failed.go
@@ -1,0 +1,34 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/lunarway/release-manager/internal/broker"
+)
+
+type ReleaseFailed struct {
+	PodName     string   `json:"podName,omitempty"`
+	Namespace   string   `json:"namespace,omitempty"`
+	Errors      []string `json:"errors,omitempty"`
+	AuthorEmail string   `json:"authorEmail,omitempty"`
+	Environment string   `json:"environment,omitempty"`
+	ArtifactID  string   `json:"artifactId,omitempty"`
+	Squad       string   `json:"squad,omitempty"`
+	AlertSquad  string   `json:"alertSquad,omitempty"`
+}
+
+// Marshal implements broker.Publishable
+func (re ReleaseFailed) Marshal() ([]byte, error) {
+	return json.Marshal(re)
+}
+
+// Unmarshal implements broker.Publishable
+func (re ReleaseFailed) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, &re)
+}
+
+var _ broker.Publishable = &ReleaseFailed{}
+
+func (re ReleaseFailed) Type() string {
+	return "release_succeeded_event"
+}

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -62,6 +62,9 @@ type Service struct {
 	// succeeded. The context.Context is cancelled if the originating flow call is
 	// cancelled.
 	NotifyReleaseSucceededHook func(ctx context.Context, options NotifyReleaseSucceededOptions)
+
+	// NotifyReleaseFailedHook is trigger in a Go routine when a release has failed.
+	NotifyReleaseFailedHook func(ctx context.Context, options NotifyReleaseFailedOptions)
 }
 
 type NotifyReleaseOptions struct {
@@ -82,6 +85,17 @@ type NotifyReleaseSucceededOptions struct {
 	ArtifactID    string
 	AuthorEmail   string
 	Environment   string
+}
+
+type NotifyReleaseFailedOptions struct {
+	PodName     string   `json:"podName,omitempty"`
+	Namespace   string   `json:"namespace,omitempty"`
+	Errors      []string `json:"errors,omitempty"`
+	AuthorEmail string   `json:"authorEmail,omitempty"`
+	Environment string   `json:"environment,omitempty"`
+	ArtifactID  string   `json:"artifactId,omitempty"`
+	Squad       string   `json:"squad,omitempty"`
+	AlertSquad  string   `json:"alertSquad,omitempty"`
 }
 
 type GitService interface {

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -2,7 +2,6 @@ package flow
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/lunarway/release-manager/internal/http"
 

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -38,21 +38,11 @@ func (s *Service) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErr
 		return errors.WithMessage(err, "post k8s NotifyK8SPodErrorEvent slack message")
 	}
 	if s.NotifyReleaseFailedHook != nil {
-		errors := make([]string, 0)
-		for _, errMsg := range event.Errors {
-			errors = append(
-				errors,
-				fmt.Sprintf(
-					"pod: %s\n type: %s\n msg: %s\n",
-					errMsg.Name, errMsg.Type, errMsg.ErrorMessage,
-				),
-			)
-		}
 
 		go s.NotifyReleaseFailedHook(noCancel{ctx: ctx}, NotifyReleaseFailedOptions{
 			PodName:     event.PodName,
 			Namespace:   event.Namespace,
-			Errors:      errors,
+			Errors:      event.ErrorStrings(),
 			AuthorEmail: event.AuthorEmail,
 			Environment: event.Environment,
 			ArtifactID:  event.ArtifactID,

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
@@ -98,6 +100,21 @@ type PodErrorEvent struct {
 	ArtifactID  string           `json:"artifactId,omitempty"`
 	Squad       string           `json:"squad,omitempty"`
 	AlertSquad  string           `json:"alertSquad,omitempty"`
+}
+
+func (pee *PodErrorEvent) ErrorStrings() []string {
+	errors := make([]string, 0)
+	for _, errMsg := range pee.Errors {
+		errors = append(
+			errors,
+			fmt.Sprintf(
+				"pod: %s\n type: %s\n msg: %s\n",
+				errMsg.Name, errMsg.Type, errMsg.ErrorMessage,
+			),
+		)
+	}
+
+	return errors
 }
 
 type JobConditionError struct {

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -3,7 +3,6 @@ package http
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"


### PR DESCRIPTION
Adding a release failed event to be publishes on errors. This is not idempotent, which means that a release can potentially fail multiple times, on crashbackloopoff. This could potentially be built in the future, such that a release can only fail once pr. Artifact ID or something. 

I've kept the formula for the existing kubernetes error template.

Fixes: AURA-182