### PR TITLE
Added all events in an envelope when publishing to rabbitmq

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -303,7 +303,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				},
 				"events": func(ctx context.Context, opts flow.NotifyReleaseOptions) {
 					logger := log.WithContext(ctx)
-					err = brokerImpl.Publish(ctx, &events.ReleasedEvent{
+					err = publish(ctx, brokerImpl, &events.ReleasedEvent{
 						Service:     opts.Service,
 						Namespace:   opts.Namespace,
 						ArtifactID:  opts.Spec.ID,
@@ -340,7 +340,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				},
 				"event": func(ctx context.Context, opts flow.NotifyReleaseSucceededOptions) {
 					logger := log.WithContext(ctx)
-					err = brokerImpl.Publish(ctx, &events.ReleaseSucceeded{
+					err = publish(ctx, brokerImpl, &events.ReleaseSucceeded{
 						Name:          opts.Name,
 						Namespace:     opts.Namespace,
 						ResourceType:  opts.ResourceType,
@@ -362,7 +362,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			releaseFailedNotifiers := map[string]func(context.Context, flow.NotifyReleaseFailedOptions){
 				"event": func(ctx context.Context, opts flow.NotifyReleaseFailedOptions) {
 					logger := log.WithContext(ctx)
-					err = brokerImpl.Publish(ctx, &events.ReleaseFailed{
+					err = publish(ctx, brokerImpl, &events.ReleaseFailed{
 						PodName:     opts.PodName,
 						Namespace:   opts.Namespace,
 						Errors:      opts.Errors,
@@ -497,10 +497,10 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				}
 			}
 			flowSvc.PublishReleaseArtifactID = func(ctx context.Context, event flow.ReleaseArtifactIDEvent) error {
-				return brokerImpl.Publish(ctx, &event)
+				return publish(ctx, brokerImpl, &event)
 			}
 			flowSvc.PublishNewArtifact = func(ctx context.Context, event flow.NewArtifactEvent) error {
-				return brokerImpl.Publish(ctx, &event)
+				return publish(ctx, brokerImpl, &event)
 			}
 			defer func() {
 				err := brokerImpl.Close()
@@ -628,4 +628,16 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 		// values
 		return nil, errors.New("no broker selected")
 	}
+}
+
+func publish(ctx context.Context, broker broker.Broker, message broker.Publishable) error {
+	bytes, err := message.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return broker.Publish(ctx, events.Envelope{
+		EventName: message.Type(),
+		Content:   bytes,
+	})
 }

--- a/internal/events/envelope.go
+++ b/internal/events/envelope.go
@@ -1,0 +1,28 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/lunarway/release-manager/internal/broker"
+)
+
+type Envelope struct {
+	EventName string          `json:"eventName,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+}
+
+// Marshal implements broker.Publishable
+func (re Envelope) Marshal() ([]byte, error) {
+	return json.Marshal(re)
+}
+
+// Unmarshal implements broker.Publishable
+func (re Envelope) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, &re)
+}
+
+var _ broker.Publishable = &Envelope{}
+
+func (re Envelope) Type() string {
+	return re.EventName
+}


### PR DESCRIPTION
Currently, reasoning about amqp messages can be hard as there is no metadata around the payload. This change adds an envelope to contain the event name when deserialising the payload.