### PR TITLE
Migrate to the new Kubernetes community-owned image registry

### DIFF
--- a/e2e-test/statefulset.yaml
+++ b/e2e-test/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.7
+        image: registry.k8s.io/nginx-slim:0.7
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
k8s.gcr.io image registry will be frozen from the 3rd of April 2023.

https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/