### PR TITLE
Route all messages from the release-manager exchange

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -612,7 +612,7 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 			InitTimeout:         amqpOptions.InitTimeout,
 			Exchange:            amqpOptions.Exchange,
 			Queue:               amqpOptions.Queue,
-			RoutingKey:          "release-manager",
+			RoutingKey:          "#",
 			Prefetch:            amqpOptions.Prefetch,
 			Logger:              log.With("system", "amqp"),
 		})


### PR DESCRIPTION
Currently, the queue consumer will not receive all messages as it only has a binding on a hard-coded value. This change allows is to listed for all messages from its exchange.