### PR TITLE
Remove logging in daemon main.go

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/daemon/command"
-	"github.com/lunarway/release-manager/internal/log"
 )
 
 var (
@@ -14,12 +13,10 @@ var (
 func main() {
 	c, err := command.NewRoot(version)
 	if err != nil {
-		log.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
 	err = c.Execute()
 	if err != nil {
-		log.Errorf("Error: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The internal logger is initialized in commands but if a command fails main.go attempts to use the logger to print our the error. This results in a nil panic if the error is caused by a missing argument which is handled before commands are run.

    $ ./dist/daemon start
    Error: required flag(s) "environment" not set
    Usage:
      daemon start [flags]

    Flags:
          --auth-token string                 token to be used to communicate with the release-manager
          --environment string                environment where release-daemon is running
      -h, --help                              help for start
          --http-timeout duration             HTTP request timeout (default 20s)
          --kubeconfig string                 path to kubeconfig file. If not specified, then daemon is expected to run inside kubernetes
          --log.development                   configure log for development with human readable output (fallback to LOG_DEVELOPMENT)
          --log.level string                  configure log level. Available values are "debug", "info", "error" (fallback to LOG_LEVEL) (default "info")
          --modulo-crash-report-notif float   modulo for how often to report CrashLoopBackOff events (default 5)
          --release-manager-url string        address of the release-manager, e.g. http://release-manager

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x20f03c2]

    goroutine 1 [running]:
    github.com/lunarway/release-manager/internal/log.(*Logger).Errorf(...)
      /release-manager/internal/log/log.go:92
    github.com/lunarway/release-manager/internal/log.Errorf(...)
      /release-manager/internal/log/log.go:58
    main.main()
      /release-manager/cmd/daemon/main.go:22 +0xc2

This change removes the logging in main.go as cobra handles this automatically.

    $ ./dist/daemon start
    Error: required flag(s) "environment" not set
    Usage:
      daemon start [flags]

    Flags:
          --auth-token string                 token to be used to communicate with the release-manager
          --environment string                environment where release-daemon is running
      -h, --help                              help for start
          --http-timeout duration             HTTP request timeout (default 20s)
          --kubeconfig string                 path to kubeconfig file. If not specified, then daemon is expected to run inside kubernetes
          --log.development                   configure log for development with human readable output (fallback to LOG_DEVELOPMENT)
          --log.level string                  configure log level. Available values are "debug", "info", "error" (fallback to LOG_LEVEL) (default "info")
          --modulo-crash-report-notif float   modulo for how often to report CrashLoopBackOff events (default 5)
          --release-manager-url string        address of the release-manager, e.g. http://release-manager