### PR TITLE
Add context to http server log middleware

### DIFF
--- a/cmd/server/http/log.go
+++ b/cmd/server/http/log.go
@@ -31,17 +31,13 @@ func reqrespLogger(h http.Handler) http.Handler {
 		// request duration in miliseconds
 		duration := time.Since(start).Nanoseconds() / 1e6
 		statusCode := statusWriter.statusCode
-		requestID := getRequestID(r)
 		fields := []interface{}{
-			"requestId", requestID,
 			"req", struct {
-				ID      string            `json:"id,omitempty"`
 				URL     string            `json:"url,omitempty"`
 				Method  string            `json:"method,omitempty"`
 				Path    string            `json:"path,omitempty"`
 				Headers map[string]string `json:"headers,omitempty"`
 			}{
-				ID:      requestID,
 				URL:     r.URL.RequestURI(),
 				Method:  r.Method,
 				Path:    r.URL.Path,
@@ -58,7 +54,8 @@ func reqrespLogger(h http.Handler) http.Handler {
 		if err != nil {
 			fields = append(fields, "error", err)
 		}
-		logger := log.With(fields...)
+
+		logger := log.WithContext(r.Context()).With(fields...)
 		if statusCode >= http.StatusInternalServerError {
 			logger.Errorf("[%d] %s %s", statusCode, r.Method, r.URL.Path)
 			return

--- a/internal/log/context.go
+++ b/internal/log/context.go
@@ -14,5 +14,9 @@ func WithContext(ctx context.Context) *Logger {
 
 // AddContext adds fields to the context that can be used in WithContext.
 func AddContext(ctx context.Context, fields ...interface{}) context.Context {
+	values, ok := ctx.Value(contextKey{}).([]interface{})
+	if ok && values != nil {
+		fields = append(fields, values...)
+	}
 	return context.WithValue(ctx, contextKey{}, fields)
 }


### PR DESCRIPTION
Currently, the HTTP logging middleware adds the request ID to its context fields twice and ignores any other context values in the logger.

    info	http/server.go:2122	[200] GET /status	{"requestId": "73efeeb4-af33-46b5-b31b-6dbd21efa245", "req": {"id":"73efeeb4-af33-46b5-b31b-6dbd21efa245","url":"/status?service=test-service","method":"GET","path":"/status","headers":{"Accept-Encoding":"gzip","Authorization":"Bearer test","User-Agent":"Go-http-client/1.1","X-Cli-Version":"7fce8c29f7bbc1e38d683713aca5fa42c43215a8","X-Request-Id":"73efeeb4-af33-46b5-b31b-6dbd21efa245"}}, "res": {"statusCode":200}, "responseTime": 3}

This change removes the excessive request ID fields and uses a context logger, which automatically has the request ID available. This simplifies the middleware a bit but also allows for other context values to be propagated in the logging context, eg. subject when OAuth2.0 support is added.

    info	http/server.go:2122	[404] GET /policies	{"requestId": "b8ac36e3-f72c-4146-b43b-d61b02fb92f0", "req": {"url":"/policies?service=test","method":"GET","path":"/policies","headers":{"Accept-Encoding":"gzip","Authorization":"Bearer test","User-Agent":"Go-http-client/1.1","X-Caller-Email":"bso@lunar.app","X-Cli-Version":"96e2ef7d006e6b0e44aca10515cecd2821cc8123","X-Request-Id":"b8ac36e3-f72c-4146-b43b-d61b02fb92f0"}}, "res": {"statusCode":404}, "responseTime": 0}

The AddContext function is also expanded to merge existing values in the logging context to avoid overriding any values.

This change was extracted from #498 where the subject from JWT tokens will be added as context values. Here it became clear that it wasn't working as intended.