### PR TITLE
Print helpful text to know how to login

### DIFF
--- a/cmd/hamctl/main.go
+++ b/cmd/hamctl/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/lunarway/release-manager/cmd/hamctl/command"
+	"github.com/lunarway/release-manager/internal/http"
 )
 
 var (
@@ -17,8 +19,17 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+
 	err = c.Execute()
 	if err != nil {
+		if errors.Is(err, http.ErrLoginRequired) {
+			fmt.Printf("You are not logged in. To log in, please run the following command:\n 'hamctl login'\n")
+		} else {
+			fmt.Printf("Error: %v\n", err)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/internal/http/authenticator.go
+++ b/internal/http/authenticator.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +12,10 @@ import (
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+)
+
+var (
+	ErrLoginRequired = errors.New("login required")
 )
 
 type UserAuthenticator struct {
@@ -52,7 +57,7 @@ func (g *UserAuthenticator) Login(ctx context.Context) error {
 func (g *UserAuthenticator) Access(ctx context.Context) (*http.Client, error) {
 	token, err := readAccessToken()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrLoginRequired, err)
 	}
 	return g.conf.Client(ctx, token), nil
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -59,7 +59,7 @@ func (c *Client) Do(method string, path string, requestBody, responseBody interf
 	ctx := context.Background()
 	client, err := c.Auth.Access(ctx)
 	if err != nil {
-		return errors.Wrap(err, "please log in again to refresh the token")
+		return err
 	}
 	client.Timeout = c.Timeout
 


### PR DESCRIPTION
Currently, there is little help when `hamctl` fails due to a missing login.

This change write the command that needs to be run when it fails so that it is easy to progres.

For this to work, then usage and errors are silences and we take control of the output.