### PR TITLE
Bump go version for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19.0
+          go-version: 1.21.4
       - name: Cache Go modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Currently v0.28.1 has an error in its output due to it being released with an older version of golang that does not understand slices of errors in the fmt package.

This change bumps the version to fix the issue.

```
HAMCTL_VERSION=v0.28.1 hamctl status
Error: login required: %!w(*fs.PathError=&{open /Users/mah/.Config/release-manager/token.json 2})
```