### PR TITLE
Print login required output when token is expired

### DIFF
--- a/internal/http/authenticator.go
+++ b/internal/http/authenticator.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ErrLoginRequired = errors.New("login required")
+	ErrTokenExpired  = errors.New("oauth2: token expired and refresh token is not set")
 )
 
 type UserAuthenticator struct {


### PR DESCRIPTION
Currently, when the oauth2 token is expired, a generic error is outputtet which does not help with what to do.

This change prints the login required output instead to make it easier to progress.

Before:
```
./hamctl status
Error: Get "https://release-manager.lunar.tech/status?service=deferred-messages": oauth2: token expired and refresh token is not set (reference: 8af307a4-e114-4c98-a125-61f97a1ada09)
```

After:
```
./hamctl status
You are not logged in. To log in, please run the following command:
 'hamctl login'
```