### PR TITLE
add scope to CLI's

### DIFF
--- a/cmd/artifact/command/push.go
+++ b/cmd/artifact/command/push.go
@@ -23,7 +23,7 @@ func pushCommand(options *Options) *cobra.Command {
 			var artifactID string
 			var err error
 			ctx := context.Background()
-			authenticator := httpinternal.NewClientAuthenticator(clientID, clientSecret, idpURL)
+			authenticator := httpinternal.NewClientAuthenticator(clientID, clientSecret, idpURL, "release_artifact")
 			releaseManagerClient.Auth = &authenticator
 
 			artifactID, err = flow.PushArtifactToReleaseManager(ctx, &releaseManagerClient, options.FileName, options.RootPath)

--- a/cmd/daemon/command/start.go
+++ b/cmd/daemon/command/start.go
@@ -35,7 +35,7 @@ func StartDaemon() *cobra.Command {
 			logConfiguration.ParseFromEnvironmnet()
 			log.Init(logConfiguration)
 
-			authenticator := httpinternal.NewClientAuthenticator(clientID, clientSecret, idpURL)
+			authenticator := httpinternal.NewClientAuthenticator(clientID, clientSecret, idpURL, "release_deamon")
 			client.Auth = &authenticator
 
 			exporter := &kubernetes.ReleaseManagerExporter{

--- a/internal/http/authenticator.go
+++ b/internal/http/authenticator.go
@@ -108,12 +108,12 @@ type ClientAuthenticator struct {
 	conf *clientcredentials.Config
 }
 
-func NewClientAuthenticator(clientID, clientSecret, idpURL string) ClientAuthenticator {
+func NewClientAuthenticator(clientID, clientSecret, idpURL, scope string) ClientAuthenticator {
 	conf := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     fmt.Sprintf("%s/v1/token", idpURL),
-		Scopes:       []string{""},
+		Scopes:       []string{scope},
 	}
 	return ClientAuthenticator{
 		conf: conf,


### PR DESCRIPTION
We must request a scope when doing client credentials grant as we cannot rely on default scopes in the idp.