### PR TITLE
support auto login

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,17 @@ Examples of commands are `hamctl release` or `hamctl status`.
 
 See [Interactions](#interactions) for more examples.
 
-It uses a token-based authentication model for interacting with the server.
-This can either be provided as a command-line argument `--http-auth-token` or using the environment variable `HAMCTL_AUTH_TOKEN`.
+It uses a oauth2 authentication model for interacting with the server.
+Specifically the Device Authorization flow.
+
+This must be set up using the command-line arguments:
+
+`--idp-url` pointing to your IdP where there must be an endpoint `{idp-url}/v1/token` for exchanging tokens.
+
+`--client-id` which is the oauth2 client id.
+
+`hamctl` will automatically initiate a login if you do not have a valid token on your system.
+You can opt out of this behaviour by setting the environement variable `HAMCTL_OAUTH_AUTO_LOGIN=false`.
 
 ### Completions
 

--- a/cmd/hamctl/command/root.go
+++ b/cmd/hamctl/command/root.go
@@ -137,6 +137,10 @@ func setupAuthenticator() (http.UserAuthenticator, error) {
 	if clientID == "" {
 		return http.UserAuthenticator{}, errors.New("no HAMCTL_OAUTH_CLIENT_ID env var set")
 	}
+	autoLogin := true
+	if os.Getenv("HAMCTL_OAUTH_AUTO_LOGIN") == "false" {
+		autoLogin = false
+	}
 
-	return http.NewUserAuthenticator(clientID, idpURL), nil
+	return http.NewUserAuthenticator(clientID, idpURL, autoLogin), nil
 }

--- a/internal/http/authenticator.go
+++ b/internal/http/authenticator.go
@@ -21,9 +21,10 @@ var (
 
 type UserAuthenticator struct {
 	conf *oauth2.Config
+	autoLogin bool
 }
 
-func NewUserAuthenticator(clientID, idpURL string) UserAuthenticator {
+func NewUserAuthenticator(clientID, idpURL string, autoLogin bool) UserAuthenticator {
 	conf := &oauth2.Config{
 		ClientID: clientID,
 		Endpoint: oauth2.Endpoint{
@@ -34,6 +35,7 @@ func NewUserAuthenticator(clientID, idpURL string) UserAuthenticator {
 	}
 	return UserAuthenticator{
 		conf: conf,
+		autoLogin: autoLogin,
 	}
 }
 
@@ -60,6 +62,12 @@ func (g *UserAuthenticator) Access(ctx context.Context) (*http.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrLoginRequired, err)
 	}
+	if !token.Valid() && g.autoLogin {
+		err = g.Login(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrLoginRequired, err)
+		}
+	}
 	return g.conf.Client(ctx, token), nil
 }
 
@@ -79,6 +87,7 @@ func readAccessToken() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	token.
 	return &token, nil
 }
 

--- a/internal/http/authenticator.go
+++ b/internal/http/authenticator.go
@@ -87,7 +87,6 @@ func readAccessToken() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	token.
 	return &token, nil
 }
 


### PR DESCRIPTION
Adds the env var `HAMCTL_OAUTH_AUTO_LOGIN`. It defaults to true but you can opt out of the auto login.

We initiate a login if the token is invalid and we have configured auto login.