### PR TITLE
Add squad to release notifications

### DIFF
--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -7,6 +7,7 @@ example:
 	./artifact init \
 		--service "test-service"\
 		--artifact-id "${ARTIFACT_ID}"\
+		--squad "aura"\
 		--git-branch "master"\
 		--git-author-name "Kasper Nissen"\
 		--git-author-email "kni@lunar.app"\

--- a/cmd/artifact/command/init.go
+++ b/cmd/artifact/command/init.go
@@ -113,6 +113,7 @@ func initCommand(options *Options) *cobra.Command {
 	command.Flags().StringVar(&s.ID, "artifact-id", "", "the id of the artifact")
 	command.Flags().StringVar(&s.Service, "service", "", "the service name")
 	command.Flags().StringVar(&s.Namespace, "namespace", "", "the namespace to deploy the service to")
+	command.Flags().StringVar(&s.Squad, "squad", "", "the squad who owns the service")
 
 	// Init git data
 	command.Flags().StringVar(&s.Application.AuthorName, "git-author-name", "", "the commit author name")

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -279,6 +279,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 						"environment", opts.Environment,
 						"namespace", opts.Namespace,
 						"artifact-id", opts.Spec.ID,
+						"squad", opts.Spec.Squad,
 						"commit-message", opts.Spec.Application.Message,
 						"commit-author", opts.Spec.Application.AuthorName,
 						"commit-author-email", opts.Spec.Application.AuthorEmail,
@@ -305,6 +306,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 							Service:     opts.Service,
 							Releaser:    opts.Releaser,
 							Intent:      opts.Intent.Type,
+							Squad:       opts.Spec.Squad,
 						},
 					)
 				},

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ func NewObserver() *Observer {
 			"service",
 			"releaser",
 			"intent",
+			"squad",
 		}),
 	}
 }
@@ -28,6 +29,7 @@ type Release struct {
 	Service     string
 	Releaser    string
 	Intent      string
+	Squad       string
 }
 
 func (o *Observer) ObserveRelease(release Release) {
@@ -36,5 +38,6 @@ func (o *Observer) ObserveRelease(release Release) {
 		release.Service,
 		release.Releaser,
 		release.Intent,
+		release.Squad,
 	).Inc()
 }


### PR DESCRIPTION
This change prints the owning squad to release logs along with adding a new label to the total releases metric.

The field was already part of the artifact specification (and used by the release event), but it was never populated by artifact.

This change adds an optional --squad argument to the artifact init command enabling a migration path to start populating the field in pipelines.