### PR TITLE
Fix OOMKilled check and update OOMKilled log

### DIFF
--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -128,7 +128,7 @@ func (p *PodInformer) handle(e interface{}) {
 	}
 
 	if isPodOOMKilled(pod) {
-		log.With("killedPodNamespace", pod.Namespace).Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
+		log.With("targetPodNamespace", pod.Namespace, "targetPodName", pod.Name, "targetPodSquad", getCodeOwnerSquad(pod.Labels)).Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
 		var errorContainers []http.ContainerError
 		for _, cst := range pod.Status.ContainerStatuses {
 			if isContainerOOMKilled(cst) {

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -128,7 +128,7 @@ func (p *PodInformer) handle(e interface{}) {
 	}
 
 	if isPodOOMKilled(pod) {
-		log.Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
+		log.With("killedPodNamespace", pod.Namespace).Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
 		var errorContainers []http.ContainerError
 		for _, cst := range pod.Status.ContainerStatuses {
 			if isContainerOOMKilled(cst) {
@@ -187,7 +187,7 @@ func isPodOOMKilled(pod *corev1.Pod) bool {
 }
 
 func isContainerOOMKilled(containerStatus corev1.ContainerStatus) bool {
-	if containerStatus.State.Terminated != nil && containerStatus.State.Terminated.Reason == "OOMKilled" {
+	if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled" {
 		return true
 	}
 

--- a/cmd/daemon/kubernetes/pods_test.go
+++ b/cmd/daemon/kubernetes/pods_test.go
@@ -188,7 +188,7 @@ func TestIsPodOOMKilled(t *testing.T) {
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
-							State: corev1.ContainerState{
+							LastTerminationState: corev1.ContainerState{
 								Terminated: &corev1.ContainerStateTerminated{},
 							},
 						},
@@ -204,7 +204,7 @@ func TestIsPodOOMKilled(t *testing.T) {
 					Phase: corev1.PodRunning,
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
-							State: corev1.ContainerState{
+							LastTerminationState: corev1.ContainerState{
 								Terminated: &corev1.ContainerStateTerminated{
 									Reason: "OOMKilled",
 								},


### PR DESCRIPTION
The current check was not correct. In many cases it didn't catch pods that was OOM killed. This is corroborated by https://github.com/xing/kubernetes-oom-event-generator/blob/master/src/controller/controller.go#L150. Further details provided in Slack.