### PR TITLE
Added environmnet to deployment annotation

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -232,7 +232,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 								opts.Spec.Application.Message,
 								opts.Spec.ID,
 							),
-							Tags: []string{"deployment", opts.Service},
+							Tags: []string{"deployment", opts.Service, opts.Environment},
 						},
 					)
 					if err != nil {


### PR DESCRIPTION
Currently, deployment annotations does not include the environment in its list of tags which is useful when using the annotation on a Grafana panel that shows metrics from one or more environments.

This change adds the environment as a tag so it can be used as a filter.