### PR TITLE
Fix go releaser

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,14 +1,12 @@
-name: release
+name: GoReleaser Check
 
 on:
-  release:
-    types: [published]
-
-permissions:
-  contents: write
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  release:
+  goreleaser-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,17 +24,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Docker Login
-        uses: docker/login-action@v3
+
+      - name: Run GoReleaser Check
+        uses: goreleaser/goreleaser-action@v4
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
           version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: check

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -18,14 +18,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.0
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Run GoReleaser Check
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,9 +1,10 @@
 name: GoReleaser Check
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - "master"
+  pull_request:
 
 jobs:
   goreleaser-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: 1.23.0      
       - name: Docker Login
         uses: docker/login-action@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ checksum:
   name_template: '{{ .ProjectName }}-checksums.txt'
 
 snapshot:
-  name_template: "git-{{.Commit}}"
+  version_template: "git-{{.Commit}}"
 
 release:
   name_template: "v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+version: 2
 
 builds:
 - binary: artifact
@@ -69,4 +68,4 @@ release:
   prerelease: auto
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Currently, the release actions is broken due to deprecations in goreleaser.

This change aims at fixing the issues.