### PR TITLE
Fix Grafana annotation formatting

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -227,7 +227,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 						grafana.AnnotateRequest{
 							What: fmt.Sprintf("Deployment: %s", opts.Service),
 							Data: fmt.Sprintf(
-								"Author: %s\nMessage: %s\nArtifactID: %s",
+								"<br>Author: %s<br>Message: %s<br>ArtifactID: %s",
 								opts.Spec.Application.AuthorName,
 								opts.Spec.Application.Message,
 								opts.Spec.ID,


### PR DESCRIPTION
`\n` does not seem to create a line break in annotations in Grafana. `<br>` seems to create a line break when viewing the annotation. To verify this, try editing an annotation and adding a `<br>` in it. (Public repository, so not inserting a screenshot with proof)