### PR TITLE
Fix/modify statefulset

### DIFF
--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -2,11 +2,11 @@ package kubernetes
 
 import (
 	"context"
-	"strings"
 
 	"github.com/lunarway/release-manager/internal/http"
 	"github.com/lunarway/release-manager/internal/log"
 	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -135,10 +135,9 @@ func annotateStatefulSet(ctx context.Context, c kubernetes.Interface, ss *appsv1
 			return nil
 		}
 		// If it's not a conflict error, return immediately
-		if !strings.Contains(err.Error(), "please apply your changes to the latest version") {
+		if !k8serrors.IsConflict(err) {
 			return err
 		}
-		// Otherwise, retry with the latest version
 	}
 	return err
 }

--- a/cmd/daemon/kubernetes/statefulsets_test.go
+++ b/cmd/daemon/kubernetes/statefulsets_test.go
@@ -1,0 +1,137 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestAnnotateStatefulSet(t *testing.T) {
+	t.Run("successfully annotates statefulset", func(t *testing.T) {
+		// Setup
+		ss := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-statefulset",
+				Namespace: "test-namespace",
+				Annotations: map[string]string{
+					artifactIDAnnotationKey: "test-artifact",
+				},
+			},
+		}
+
+		clientset := fake.NewSimpleClientset(ss)
+
+		// Test
+		err := annotateStatefulSet(context.Background(), clientset, ss)
+
+		// Assert
+		assert.NoError(t, err)
+
+		// Verify the StatefulSet was updated with observed annotation
+		updated, err := clientset.AppsV1().StatefulSets(ss.Namespace).Get(context.Background(), ss.Name, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, "test-artifact", updated.Annotations[observedAnnotationKey])
+	})
+
+	t.Run("handles nil annotations map", func(t *testing.T) {
+		// Setup
+		ss := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-statefulset",
+				Namespace: "test-namespace",
+			},
+		}
+
+		clientset := fake.NewSimpleClientset(ss)
+
+		// Test
+		err := annotateStatefulSet(context.Background(), clientset, ss)
+
+		// Assert
+		assert.NoError(t, err)
+
+		// Verify annotations were created and set
+		updated, err := clientset.AppsV1().StatefulSets(ss.Namespace).Get(context.Background(), ss.Name, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, updated.Annotations)
+	})
+
+	t.Run("handles non-existent statefulset", func(t *testing.T) {
+		// Setup
+		ss := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "non-existent",
+				Namespace: "test-namespace",
+			},
+		}
+
+		clientset := fake.NewSimpleClientset()
+
+		// Test
+		err := annotateStatefulSet(context.Background(), clientset, ss)
+
+		// Assert
+		assert.Error(t, err)
+	})
+
+	t.Run("handles concurrent modification", func(t *testing.T) {
+		// Setup initial StatefulSet
+		ss := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-statefulset",
+				Namespace: "test-namespace",
+				Annotations: map[string]string{
+					artifactIDAnnotationKey: "test-artifact",
+				},
+			},
+		}
+
+		clientset := fake.NewSimpleClientset(ss)
+
+		// Simulate concurrent modification by having another process modify the StatefulSet
+		// between our Get and Update calls
+		count := 0
+		clientset.PrependReactor("get", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if count == 0 {
+				count++
+				return false, nil, nil // let the first Get go through normally
+			}
+			// On second Get (after first Update fails), return StatefulSet with updated annotations
+			modifiedSS := ss.DeepCopy()
+			if modifiedSS.Annotations == nil {
+				modifiedSS.Annotations = make(map[string]string)
+			}
+			modifiedSS.Annotations[artifactIDAnnotationKey] = "test-artifact"
+			modifiedSS.Annotations[observedAnnotationKey] = "test-artifact"
+			return true, modifiedSS, nil
+		})
+
+		// First update fails with conflict
+		firstUpdate := true
+		clientset.PrependReactor("update", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if firstUpdate {
+				firstUpdate = false
+				return true, nil, errors.New("the object has been modified; please apply your changes to the latest version and try again")
+			}
+			return false, nil, nil // let subsequent updates go through
+		})
+
+		// Test
+		err := annotateStatefulSet(context.Background(), clientset, ss)
+
+		// Assert
+		assert.NoError(t, err)
+
+		// Verify the StatefulSet was updated with observed annotation
+		updated, err := clientset.AppsV1().StatefulSets(ss.Namespace).Get(context.Background(), ss.Name, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, "test-artifact", updated.Annotations[observedAnnotationKey])
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,10 @@ require (
 
 require github.com/gorilla/mux v1.8.0
 
-require gopkg.in/yaml.v2 v2.4.0 // indirect
+require (
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)
 
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=


### PR DESCRIPTION
Currently, we see warnings where we statefulset has been modified by another controller.
This is just noise and should be handled instead of logging an error.

This change adds retry logic so that annotation has a higher change of succeeding.