### PR TITLE
chore(flux): Update Kustomization API version to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ It is also not possible to overwrite them with custom policies, e.g. changing br
 Release files are structured as shown below.
 In the root are folders for each environment, e.g. `dev`, `prod`.
 These folders contain a `releases` directory with kubernetes resource definitions of each namespace and their running applications.
-If an artifact contains a Flux `Kustomization` (`apiVersion: kustomize.toolkit.fluxcd.io/v1beta1` and `kind: Kustomization`) custom resource the release manager moves it into the `clusters` directory tree.
+If an artifact contains a Flux `Kustomization` (`apiVersion: kustomize.toolkit.fluxcd.io/v1` and `kind: Kustomization`) custom resource the release manager moves it into the `clusters` directory tree.
 This is tailored to support Flux2.
 
 A `policies` directory holds all recorded release policies.

--- a/cmd/artifact/Makefile
+++ b/cmd/artifact/Makefile
@@ -81,7 +81,7 @@ endef
 export CONFIG_MAP
 
 define FLUX_KUSTOMIZATION
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: product

--- a/internal/flow/testdata/flux-toolkit-kustomization-v1beta1/flux-toolkit-kustomization-v1beta1.yaml
+++ b/internal/flow/testdata/flux-toolkit-kustomization-v1beta1/flux-toolkit-kustomization-v1beta1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: releases


### PR DESCRIPTION
This batch change updates the `apiVersion` for Flux Kustomization resources from `v1beta1` to `v1`. `v1beta1` is deprecated.

[_Created by Sourcegraph batch change `jan/use-v1-kyverno-2`._](https://lunar.sourcegraph.com/users/jan/batch-changes/use-v1-kyverno-2)