### PR TITLE
Refactor authentication to support multiple tokens

### DIFF
--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -14,6 +14,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func splitOrNil(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, sep)
+}
+
 // NewRoot returns a new instance of a hamctl command.
 func NewRoot(version string) (*cobra.Command, error) {
 	var brokerOpts brokerOptions
@@ -81,9 +88,9 @@ func NewRoot(version string) (*cobra.Command, error) {
 	)
 	command.PersistentFlags().IntVar(&httpOpts.Port, "http-port", 8080, "port of the http server")
 	command.PersistentFlags().DurationVar(&httpOpts.Timeout, "timeout", 20*time.Second, "HTTP server timeout for incomming requests")
-	command.PersistentFlags().StringVar(&httpOpts.HamCtlAuthToken, "hamctl-auth-token", os.Getenv("HAMCTL_AUTH_TOKEN"), "hamctl authentication token")
-	command.PersistentFlags().StringVar(&httpOpts.ArtifactAuthToken, "artifact-auth-token", os.Getenv("ARTIFACT_AUTH_TOKEN"), "artifact authentication token")
-	command.PersistentFlags().StringVar(&httpOpts.DaemonAuthToken, "daemon-auth-token", os.Getenv("DAEMON_AUTH_TOKEN"), "daemon webhook authentication token")
+	command.PersistentFlags().StringSliceVar(&httpOpts.HamCtlAuthTokens, "hamctl-auth-token", splitOrNil(os.Getenv("HAMCTL_AUTH_TOKEN"), ","), "hamctl authentication tokens (comma-separated)")
+	command.PersistentFlags().StringSliceVar(&httpOpts.ArtifactAuthTokens, "artifact-auth-token", splitOrNil(os.Getenv("ARTIFACT_AUTH_TOKEN"), ","), "artifact authentication tokens (comma-separated)")
+	command.PersistentFlags().StringSliceVar(&httpOpts.DaemonAuthTokens, "daemon-auth-token", splitOrNil(os.Getenv("DAEMON_AUTH_TOKEN"), ","), "daemon webhook authentication tokens (comma-separated)")
 	command.PersistentFlags().StringVar(&configRepoOpts.ConfigRepo, "config-repo", os.Getenv("CONFIG_REPO"), "ssh url for the git config repository")
 	command.PersistentFlags().StringVar(&configRepoOpts.ArtifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
 	command.PersistentFlags().StringVar(&configRepoOpts.SSHPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")

--- a/cmd/server/http/jwt.go
+++ b/cmd/server/http/jwt.go
@@ -79,19 +79,21 @@ func ParseBearerToken(token string) (string, error) {
 //
 // If authentication fails a 401 Unauthorized HTTP status is returned with an
 // ErrorResponse body.
-func (v *Verifier) authentication(staticAuthToken string) func(http.Handler) http.Handler {
+func (v *Verifier) authentication(staticAuthTokens []string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authorization := r.Header.Get("Authorization")
 
-			// use value as feature toggle
-			if staticAuthToken != "" {
+			// use slice length as feature toggle
+			if len(staticAuthTokens) > 0 {
 				// old hamctl token auth
 				t := strings.TrimPrefix(authorization, "Bearer ")
 				t = strings.TrimSpace(t)
-				if t == staticAuthToken {
-					h.ServeHTTP(w, r)
-					return
+				for _, staticAuthToken := range staticAuthTokens {
+					if staticAuthToken != "" && t == staticAuthToken {
+						h.ServeHTTP(w, r)
+						return
+					}
 				}
 			}
 


### PR DESCRIPTION
**Why**

To support rolling the static auth tokens without downtime. 
By allowing multiple tokens to be valid simultaneously, we can add a new token, update all clients to use it, and then remove the old token — without any service interruption.

**What Has Changed**

- Multiple auth tokens support: HamCtlAuthToken, DaemonAuthToken, and ArtifactAuthToken now accept comma-separated values (e.g., HAMCTL_AUTH_TOKEN=token1,token2)
- Updated authentication middleware: The static token authentication now iterates through all configured tokens, accepting a request if any token matches
- Added splitOrNil helper: Ensures unset environment variables result in nil instead of [""], maintaining consistent "not configured" semantics
- Backward compatible: Existing single-token configurations continue to work without changes
Added tests: New test cases for multiple tokens, empty token arrays, and JWT fallback behavior