### PR TITLE
feat: add arm64 architecture to goreleaser builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,15 +46,31 @@ builds:
   env:
     - CGO_ENABLED=0
 
-dockers:
-  - dockerfile: Dockerfile-server-goreleaser
-    image_templates:
-    - "quay.io/lunarway/release-manager:{{ .Tag }}"
+dockers_v2:
+  - id: release-manager
+    dockerfile: Dockerfile-server-goreleaser
+    ids:
+    - server
+    images:
+    - "quay.io/lunarway/release-manager"
+    tags:
+    - "{{ .Tag }}"
     extra_files:
     - ssh_config
-  - dockerfile: Dockerfile-daemon-goreleaser
-    image_templates:
-    - "quay.io/lunarway/release-daemon:{{ .Tag }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
+  - id: release-daemon
+    dockerfile: Dockerfile-daemon-goreleaser
+    ids:
+    - daemon
+    images:
+    - "quay.io/lunarway/release-daemon"
+    tags:
+    - "{{ .Tag }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
 
 archives:
   - id: archives

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ builds:
   main: ./cmd/artifact/main.go
   goarch:
   - amd64
+  - arm64
   goos:
   - darwin
   - linux
@@ -16,6 +17,7 @@ builds:
   main: ./cmd/hamctl/main.go
   goarch:
   - amd64
+  - arm64
   goos:
   - darwin
   - linux
@@ -26,6 +28,7 @@ builds:
   main: ./cmd/server/main.go
   goarch:
   - amd64
+  - arm64
   goos:
   - darwin
   - linux
@@ -36,6 +39,7 @@ builds:
   main: ./cmd/daemon/main.go
   goarch:
   - amd64
+  - arm64
   goos:
   - darwin
   - linux

--- a/Dockerfile-daemon-goreleaser
+++ b/Dockerfile-daemon-goreleaser
@@ -1,9 +1,10 @@
-FROM alpine:3.23.3 as builder
+FROM --platform=$BUILDPLATFORM alpine:3.23.3 AS builder
 
 RUN apk update
 RUN apk add ca-certificates
 
 FROM scratch
+ARG TARGETPLATFORM
 ENTRYPOINT [ "/daemon", "start" ]
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY daemon /
+COPY $TARGETPLATFORM/daemon /daemon

--- a/Dockerfile-server-goreleaser
+++ b/Dockerfile-server-goreleaser
@@ -1,11 +1,14 @@
+FROM --platform=$BUILDPLATFORM alpine:3.23.3 AS setup
+RUN apk add --no-cache openssh-client && \
+    mkdir -p /etc/ssh && \
+    ssh-keyscan github.com bitbucket.org >> /etc/ssh/ssh_known_hosts
+
 FROM alpine:3.23.3
-RUN   apk update && \
-      apk add --no-cache \
-      openssh-keygen bash openssh-client git ca-certificates gnupg
-RUN ssh-keyscan github.com bitbucket.org >> /etc/ssh/ssh_known_hosts
-
+RUN apk update && \
+    apk add --no-cache \
+    openssh-keygen bash openssh-client git ca-certificates gnupg
+COPY --from=setup /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
 COPY ssh_config /etc/ssh/ssh_config
-
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/server /server
 ENTRYPOINT [ "/server", "start" ]
-
-COPY server /


### PR DESCRIPTION
## Summary
- Add `arm64` to `goarch` for all four binaries: `artifact`, `hamctl`, `server`, `daemon`
- Builds now target `darwin/arm64` (Apple Silicon) and `linux/arm64` in addition to existing `amd64` targets

## Test plan
- [ ] Verify goreleaser builds succeed for all new targets
- [ ] Confirm `darwin/arm64` binaries run on Apple Silicon Macs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release/build pipeline changes can break artifact publishing or produce incorrect images if the new `dockers_v2` and platform-specific copy paths don’t match GoReleaser’s output layout. Runtime code is unchanged, but CI/release failures are possible until validated across amd64/arm64.
> 
> **Overview**
> Adds `arm64` as a target architecture for all GoReleaser builds (`artifact`, `hamctl`, `server`, `daemon`) to produce `darwin` and `linux` arm64 binaries.
> 
> Updates GoReleaser Docker publishing to `dockers_v2` and builds multi-arch (`linux/amd64`, `linux/arm64`) images for `release-manager` and `release-daemon`. Dockerfiles are adjusted for multi-platform builds by using `--platform=$BUILDPLATFORM`, introducing `TARGETPLATFORM`, and copying platform-specific binaries from `$TARGETPLATFORM/...` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f283f18bc5f224721cf62f1e71f9eb12b2f71e9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->