### PR TITLE
fix: add Docker Buildx setup to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.1      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker Login
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

Add `docker/setup-buildx-action@v3` to the release workflow to fix failing releases.

## Changes

- Added `docker/setup-buildx-action@v3` step before Docker login in the release workflow

## Why

GoReleaser v2's `dockers_v2` automatically adds `--attest=type=sbom` to `docker buildx build` commands. This requires the `docker-container` buildx driver, but the release workflow was using the default `docker` driver which doesn't support attestations.

The v0.34.2 release failed with: `Attestation is not supported for the docker driver.`

See: https://github.com/lunarway/release-manager/actions/runs/24453287873/job/71447311295

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adjusts the release workflow environment before Docker builds; main risk is altered build behavior if Buildx configuration differs from prior defaults.
> 
> **Overview**
> The release GitHub Actions workflow now sets up Docker Buildx (via `docker/setup-buildx-action@v3`) before logging into Quay and running GoReleaser.
> 
> This ensures the release pipeline uses a Buildx-capable builder needed by GoReleaser’s Docker build flow (e.g., SBOM attestations), preventing failures that occur with the default Docker builder driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba85bf7c12d19edec8a731133082cd52a0e59601. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->