### PR TITLE
fix(ci): use pull_request_target for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: release-drafter/release-drafter@v6
         with:


### PR DESCRIPTION
## Summary

Fix the release drafter GitHub Action failing with `Validation Failed: target_commitish` error on pull request events.

## Changes

- Switch trigger from `pull_request` to `pull_request_target` so `GITHUB_SHA` points to the base branch (valid release target) instead of the PR merge ref
- Add `edited` event type for autolabeling on PR edits
- Scope `contents: write` and `pull-requests: write` permissions to job level

## Why

The `pull_request` event sets `GITHUB_SHA` to `refs/pull/N/merge`, which the GitHub Releases API rejects as an invalid `target_commitish`. `pull_request_target` runs in the base branch context where `GITHUB_SHA` is a valid commit.

See failed run: https://github.com/lunarway/release-manager/actions/runs/24453750048/job/71448897099

Closes ESA-1931

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching to `pull_request_target` changes the security context of PR-triggered runs and can expose the workflow to untrusted fork PRs if future steps use secrets unsafely. The added write permissions also increase blast radius if misused.
> 
> **Overview**
> Release Drafter now triggers on `pull_request_target` (including `edited`) instead of `pull_request`, so PR events run in the base-branch context and can update release drafts reliably.
> 
> The workflow scopes required `contents: write` and `pull-requests: write` permissions at the job level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e2d48c50558db8e6cda73568fa4a9345d55b3a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->