### PR TITLE
Adding slack release notifications for squads per env

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,11 @@ When releasing applications the server will notify different upstream services a
 info  command/start.go:145  Release [dev]: verification (master-e8da185c2c-06249f1a78) by Bjørn Sørensen, author Bjørn Sørensen
 ```
 
-A Slack message is pushed to a `#releases-<env>` Slack channel.
+A Slack message is pushed to the `#releases-<env>` Slack channel for the release environment.
+
+If a `squad` label can be resolved for the release, a best-effort copy is also pushed to `#squad-<squad>-releases-<env>`. The squad notification does not affect the release flow if the label is missing, the Slack channel does not exist, or posting the message fails.
+
+Kubernetes deploy success, pod error and job error notifications follow the same squad channel pattern.
 
 ![](docs/slack_release_message.png)
 

--- a/cmd/daemon/kubernetes/daemonsets.go
+++ b/cmd/daemon/kubernetes/daemonsets.go
@@ -80,6 +80,7 @@ func (d *DaemonSetInformer) handle(e interface{}) {
 		ResourceType:  "DaemonSet",
 		ArtifactID:    ds.Annotations[artifactIDAnnotationKey],
 		AuthorEmail:   ds.Annotations[authorAnnotationKey],
+		Squad:         firstNonEmpty(getSquadLabel(ds.Labels), getSquadLabel(ds.Spec.Template.Labels)),
 		AvailablePods: ds.Status.NumberAvailable,
 		DesiredPods:   ds.Status.DesiredNumberScheduled,
 	})

--- a/cmd/daemon/kubernetes/deployments.go
+++ b/cmd/daemon/kubernetes/deployments.go
@@ -80,6 +80,7 @@ func (d *DeploymentInformer) handleDeployment(e interface{}) {
 		ResourceType:  "Deployment",
 		ArtifactID:    deploy.Annotations[artifactIDAnnotationKey],
 		AuthorEmail:   deploy.Annotations[authorAnnotationKey],
+		Squad:         firstNonEmpty(getSquadLabel(deploy.Labels), getSquadLabel(deploy.Spec.Template.Labels)),
 		AvailablePods: deploy.Status.AvailableReplicas,
 		DesiredPods:   *deploy.Spec.Replicas,
 	})

--- a/cmd/daemon/kubernetes/jobs.go
+++ b/cmd/daemon/kubernetes/jobs.go
@@ -64,6 +64,7 @@ func (j JobInformer) handle(e interface{}) {
 			Errors:      jobErrorMessages(job),
 			ArtifactID:  job.Annotations[artifactIDAnnotationKey],
 			AuthorEmail: job.Annotations[authorAnnotationKey],
+			Squad:       firstNonEmpty(getSquadLabel(job.Labels), getSquadLabel(job.Spec.Template.Labels)),
 		})
 		if err != nil {
 			log.Errorf("Failed to send job error event: %v", err)

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/pkg/errors"
@@ -91,4 +92,21 @@ func observe(annotations map[string]string) {
 
 func isObserved(annotations map[string]string) bool {
 	return annotations[observedAnnotationKey] == annotations[artifactIDAnnotationKey]
+}
+
+func getSquadLabel(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	return strings.TrimSpace(labels[squadLabelKey])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/cmd/daemon/kubernetes/kubernetes.go
+++ b/cmd/daemon/kubernetes/kubernetes.go
@@ -98,7 +98,10 @@ func getSquadLabel(labels map[string]string) string {
 	if labels == nil {
 		return ""
 	}
-	return strings.TrimSpace(labels[squadLabelKey])
+	if squad, ok := labels[squadLabelKey]; ok {
+		return strings.TrimSpace(squad)
+	}
+	return ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -67,13 +67,15 @@ func (p *PodInformer) handle(obj interface{}) {
 	}
 
 	ctx := context.Background()
+	squad := getSquadLabel(pod.Labels)
+	alertSquadName := alertSquad(firstNonEmpty(squad, "no-one"), pod.Annotations)
 	event := http.PodErrorEvent{
 		PodName:     pod.Name,
 		Namespace:   pod.Namespace,
 		ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
 		AuthorEmail: pod.Annotations[authorAnnotationKey],
-		Squad:       getCodeOwnerSquad(pod.Labels),
-		AlertSquad:  alertSquad(getCodeOwnerSquad(pod.Labels), pod.Annotations),
+		Squad:       squad,
+		AlertSquad:  alertSquadName,
 	}
 
 	if isPodInCrashLoopBackOff(pod) {
@@ -84,7 +86,7 @@ func (p *PodInformer) handle(obj interface{}) {
 				pod.Name)
 			return
 		}
-		log.Infof("Pod: %s is in CrashLoopBackOff owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
+		log.Infof("Pod: %s is in CrashLoopBackOff owned by squad %s", pod.Name, firstNonEmpty(squad, "no-one"))
 		restartCount := pod.Status.ContainerStatuses[0].RestartCount
 		if math.Mod(float64(restartCount), p.moduloCrashReportNotif) != 1 {
 			return
@@ -114,7 +116,7 @@ func (p *PodInformer) handle(obj interface{}) {
 	}
 
 	if isPodInCreateContainerConfigError(pod) {
-		log.Infof("Pod: %s is in CreateContainerConfigError owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
+		log.Infof("Pod: %s is in CreateContainerConfigError owned by squad %s", pod.Name, firstNonEmpty(squad, "no-one"))
 		// Determine which container of the deployment has CreateContainerConfigError
 		var errorContainers []http.ContainerError
 		for _, cst := range pod.Status.ContainerStatuses {
@@ -134,7 +136,7 @@ func (p *PodInformer) handle(obj interface{}) {
 	}
 
 	if isPodOOMKilled(pod) {
-		log.With("targetPodNamespace", pod.Namespace, "targetPodName", pod.Name, "targetPodSquad", getCodeOwnerSquad(pod.Labels)).Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, getCodeOwnerSquad(pod.Labels))
+		log.With("targetPodNamespace", pod.Namespace, "targetPodName", pod.Name, "targetPodSquad", firstNonEmpty(squad, "no-one")).Infof("Pod: %s was OOMKilled owned by squad %s", pod.Name, firstNonEmpty(squad, "no-one"))
 		var errorContainers []http.ContainerError
 		for _, cst := range pod.Status.ContainerStatuses {
 			if isContainerOOMKilled(cst) {
@@ -267,13 +269,6 @@ func parseToJSONAray(str string) ([]ContainerLog, error) {
 		return nil, errors.WithMessage(err, "unmarshal")
 	}
 	return logs, nil
-}
-
-func getCodeOwnerSquad(labels map[string]string) string {
-	if squad, ok := labels[squadLabelKey]; ok {
-		return squad
-	}
-	return "no-one"
 }
 
 func alertSquad(squad string, annotations map[string]string) (alertChannel string) {

--- a/cmd/daemon/kubernetes/pods.go
+++ b/cmd/daemon/kubernetes/pods.go
@@ -68,14 +68,14 @@ func (p *PodInformer) handle(obj interface{}) {
 
 	ctx := context.Background()
 	squad := getSquadLabel(pod.Labels)
-	alertSquadName := alertSquad(firstNonEmpty(squad, "no-one"), pod.Annotations)
+	squadAlertChannel := alertSquad(firstNonEmpty(squad, "no-one"), pod.Annotations)
 	event := http.PodErrorEvent{
 		PodName:     pod.Name,
 		Namespace:   pod.Namespace,
 		ArtifactID:  pod.Annotations[artifactIDAnnotationKey],
 		AuthorEmail: pod.Annotations[authorAnnotationKey],
 		Squad:       squad,
-		AlertSquad:  alertSquadName,
+		AlertSquad:  squadAlertChannel,
 	}
 
 	if isPodInCrashLoopBackOff(pod) {

--- a/cmd/daemon/kubernetes/statefulsets.go
+++ b/cmd/daemon/kubernetes/statefulsets.go
@@ -81,6 +81,7 @@ func (s *StatefulSetInformer) handle(e interface{}) {
 		ResourceType:  "StatefulSet",
 		ArtifactID:    ss.Annotations[artifactIDAnnotationKey],
 		AuthorEmail:   ss.Annotations[authorAnnotationKey],
+		Squad:         firstNonEmpty(getSquadLabel(ss.Labels), getSquadLabel(ss.Spec.Template.Labels)),
 		AvailablePods: ss.Status.ReadyReplicas,
 		DesiredPods:   ss.Status.Replicas,
 	})

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -217,7 +217,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 							CommitLink:        opts.Spec.Application.URL,
 							CommitSHA:         opts.Spec.Application.SHA,
 							Releaser:          opts.Releaser,
-							Squads:            opts.Squads,
+							Squad:             opts.Squad,
 						},
 					)
 				},

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -217,6 +217,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 							CommitLink:        opts.Spec.Application.URL,
 							CommitSHA:         opts.Spec.Application.SHA,
 							Releaser:          opts.Releaser,
+							Squads:            opts.Squads,
 						},
 					)
 				},
@@ -342,6 +343,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 						DesiredPods:   opts.DesiredPods,
 						ResourceType:  opts.ResourceType,
 						ArtifactID:    opts.ArtifactID,
+						Squad:         opts.Squad,
 					})
 					if err != nil {
 						logger.Errorf("post k8s deploy slack message failed: %v", err)

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -72,7 +72,7 @@ type NotifyReleaseOptions struct {
 	Namespace   string
 	Service     string
 	Releaser    string
-	Squads      []string
+	Squad       string
 	Spec        artifact.Spec
 	Intent      intent.Intent
 }

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -72,6 +72,7 @@ type NotifyReleaseOptions struct {
 	Namespace   string
 	Service     string
 	Releaser    string
+	Squads      []string
 	Spec        artifact.Spec
 	Intent      intent.Intent
 }
@@ -84,6 +85,7 @@ type NotifyReleaseSucceededOptions struct {
 	DesiredPods   int32
 	ArtifactID    string
 	AuthorEmail   string
+	Squad         string
 	Environment   string
 }
 

--- a/internal/flow/notify.go
+++ b/internal/flow/notify.go
@@ -20,6 +20,7 @@ func (s *Service) NotifyK8SDeployEvent(ctx context.Context, event *http.ReleaseE
 			DesiredPods:   event.DesiredPods,
 			ArtifactID:    event.ArtifactID,
 			AuthorEmail:   event.AuthorEmail,
+			Squad:         event.Squad,
 			Environment:   event.Environment,
 		})
 	}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -208,6 +208,11 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		if err != nil {
 			return true, errors.WithMessage(err, "locate source spec")
 		}
+		squads, err := squadsFromManifests(sourcePath)
+		if err != nil {
+			logger.Errorf("flow: ReleaseArtifactID: extract squads from '%s' failed: %v", sourcePath, err)
+			squads = nil
+		}
 		artifactAuthor := commitinfo.NewPersonInfo(sourceSpec.Application.AuthorName, sourceSpec.Application.AuthorEmail)
 		releaseAuthor := commitinfo.NewPersonInfo(actor.Name, actor.Email)
 		releaseMessage := commitinfo.ReleaseCommitMessage(environment, service, artifactID, event.Intent, artifactAuthor, releaseAuthor)
@@ -227,6 +232,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			Service:     service,
 			Environment: environment,
 			Namespace:   namespace,
+			Squads:      squads,
 			Spec:        sourceSpec,
 			Releaser:    actor.Name,
 		})

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -208,10 +208,10 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		if err != nil {
 			return true, errors.WithMessage(err, "locate source spec")
 		}
-		squads, err := squadsFromManifests(sourcePath)
+		squad, err := squadFromManifests(sourcePath)
 		if err != nil {
-			logger.Errorf("flow: ReleaseArtifactID: extract squads from '%s' failed: %v", sourcePath, err)
-			squads = nil
+			logger.Errorf("flow: ReleaseArtifactID: extract squad from '%s' failed: %v", sourcePath, err)
+			squad = ""
 		}
 		artifactAuthor := commitinfo.NewPersonInfo(sourceSpec.Application.AuthorName, sourceSpec.Application.AuthorEmail)
 		releaseAuthor := commitinfo.NewPersonInfo(actor.Name, actor.Email)
@@ -232,7 +232,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			Service:     service,
 			Environment: environment,
 			Namespace:   namespace,
-			Squads:      squads,
+			Squad:       squad,
 			Spec:        sourceSpec,
 			Releaser:    actor.Name,
 		})

--- a/internal/flow/squads.go
+++ b/internal/flow/squads.go
@@ -1,0 +1,110 @@
+package flow
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v3"
+)
+
+type manifestMetadata struct {
+	Labels map[string]string `yaml:"labels"`
+}
+
+type manifestTemplate struct {
+	Metadata manifestMetadata `yaml:"metadata"`
+}
+
+type manifestJobTemplate struct {
+	Spec struct {
+		Template manifestTemplate `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+type manifestSpec struct {
+	Template    manifestTemplate    `yaml:"template"`
+	JobTemplate manifestJobTemplate `yaml:"jobTemplate"`
+}
+
+type manifestDocument struct {
+	Metadata manifestMetadata   `yaml:"metadata"`
+	Spec     manifestSpec       `yaml:"spec"`
+	Items    []manifestDocument `yaml:"items"`
+}
+
+func squadsFromManifests(dir string) ([]string, error) {
+	squadSet := make(map[string]struct{})
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return errors.WithMessagef(walkErr, "walk dir '%s'", dir)
+		}
+		if d.IsDir() || !isManifestFile(path) {
+			return nil
+		}
+		return scanManifestFile(path, squadSet)
+	})
+	if err != nil {
+		return nil, errors.WithMessage(err, "walk manifest directory")
+	}
+
+	squads := make([]string, 0, len(squadSet))
+	for squad := range squadSet {
+		squads = append(squads, squad)
+	}
+	sort.Strings(squads)
+	return squads, nil
+}
+
+func scanManifestFile(path string, squadSet map[string]struct{}) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return errors.WithMessagef(err, "open file '%s'", path)
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	for {
+		var manifest manifestDocument
+		err := decoder.Decode(&manifest)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return errors.WithMessagef(err, "decode '%s'", path)
+		}
+		collectManifestSquads(manifest, squadSet)
+	}
+}
+
+func collectManifestSquads(manifest manifestDocument, squadSet map[string]struct{}) {
+	addSquad(squadSet, manifest.Metadata.Labels["squad"])
+	addSquad(squadSet, manifest.Spec.Template.Metadata.Labels["squad"])
+	addSquad(squadSet, manifest.Spec.JobTemplate.Spec.Template.Metadata.Labels["squad"])
+
+	for _, item := range manifest.Items {
+		collectManifestSquads(item, squadSet)
+	}
+}
+
+func addSquad(squadSet map[string]struct{}, squad string) {
+	squad = strings.TrimSpace(squad)
+	if squad == "" {
+		return
+	}
+	squadSet[squad] = struct{}{}
+}
+
+func isManifestFile(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/flow/squads.go
+++ b/internal/flow/squads.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -37,8 +36,8 @@ type manifestDocument struct {
 	Items    []manifestDocument `yaml:"items"`
 }
 
-func squadsFromManifests(dir string) ([]string, error) {
-	squadSet := make(map[string]struct{})
+func squadFromManifests(dir string) (string, error) {
+	var squad string
 
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -47,24 +46,26 @@ func squadsFromManifests(dir string) ([]string, error) {
 		if d.IsDir() || !isManifestFile(path) {
 			return nil
 		}
-		return scanManifestFile(path, squadSet)
+		squadInFile, err := scanManifestFile(path)
+		if err != nil {
+			return err
+		}
+		if squadInFile == "" {
+			return nil
+		}
+		squad = squadInFile
+		return filepath.SkipAll
 	})
 	if err != nil {
-		return nil, errors.WithMessage(err, "walk manifest directory")
+		return "", errors.WithMessage(err, "walk manifest directory")
 	}
-
-	squads := make([]string, 0, len(squadSet))
-	for squad := range squadSet {
-		squads = append(squads, squad)
-	}
-	sort.Strings(squads)
-	return squads, nil
+	return squad, nil
 }
 
-func scanManifestFile(path string, squadSet map[string]struct{}) error {
+func scanManifestFile(path string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return errors.WithMessagef(err, "open file '%s'", path)
+		return "", errors.WithMessagef(err, "open file '%s'", path)
 	}
 	defer file.Close()
 
@@ -73,31 +74,39 @@ func scanManifestFile(path string, squadSet map[string]struct{}) error {
 		var manifest manifestDocument
 		err := decoder.Decode(&manifest)
 		if err == io.EOF {
-			return nil
+			return "", nil
 		}
 		if err != nil {
-			return errors.WithMessagef(err, "decode '%s'", path)
+			return "", errors.WithMessagef(err, "decode '%s'", path)
 		}
-		collectManifestSquads(manifest, squadSet)
+		squad := squadFromManifestDocument(manifest)
+		if squad != "" {
+			return squad, nil
+		}
 	}
 }
 
-func collectManifestSquads(manifest manifestDocument, squadSet map[string]struct{}) {
-	addSquad(squadSet, manifest.Metadata.Labels["squad"])
-	addSquad(squadSet, manifest.Spec.Template.Metadata.Labels["squad"])
-	addSquad(squadSet, manifest.Spec.JobTemplate.Spec.Template.Metadata.Labels["squad"])
+func squadFromManifestDocument(manifest manifestDocument) string {
+	if squad := normalizeSquad(manifest.Metadata.Labels["squad"]); squad != "" {
+		return squad
+	}
+	if squad := normalizeSquad(manifest.Spec.Template.Metadata.Labels["squad"]); squad != "" {
+		return squad
+	}
+	if squad := normalizeSquad(manifest.Spec.JobTemplate.Spec.Template.Metadata.Labels["squad"]); squad != "" {
+		return squad
+	}
 
 	for _, item := range manifest.Items {
-		collectManifestSquads(item, squadSet)
+		if squad := squadFromManifestDocument(item); squad != "" {
+			return squad
+		}
 	}
+	return ""
 }
 
-func addSquad(squadSet map[string]struct{}, squad string) {
-	squad = strings.TrimSpace(squad)
-	if squad == "" {
-		return
-	}
-	squadSet[squad] = struct{}{}
+func normalizeSquad(squad string) string {
+	return strings.TrimSpace(squad)
 }
 
 func isManifestFile(path string) bool {

--- a/internal/flow/squads_test.go
+++ b/internal/flow/squads_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSquadsFromManifests(t *testing.T) {
-	t.Run("collects distinct squads from top level, template and job template labels", func(t *testing.T) {
+func TestSquadFromManifests(t *testing.T) {
+	t.Run("returns the first squad found in manifest walk order", func(t *testing.T) {
 		dir := t.TempDir()
 
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a-deployment.yaml"), []byte(`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,7 +26,7 @@ spec:
         app: demo
 `), 0o600))
 
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "job.yaml"), []byte(`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b-job.yaml"), []byte(`
 apiVersion: batch/v1
 kind: Job
 spec:
@@ -36,7 +36,7 @@ spec:
         squad: beta
 `), 0o600))
 
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "cronjob.yaml"), []byte(`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "c-cronjob.yaml"), []byte(`
 apiVersion: batch/v1
 kind: CronJob
 spec:
@@ -56,19 +56,37 @@ metadata:
 
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "README.txt"), []byte("not a manifest"), 0o600))
 
-		actual, err := squadsFromManifests(dir)
+		actual, err := squadFromManifests(dir)
 
 		require.NoError(t, err)
-		assert.Equal(t, []string{"alpha", "beta", "gamma"}, actual)
+		assert.Equal(t, "alpha", actual)
 	})
 
 	t.Run("returns an error for invalid yaml manifests", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "invalid.yaml"), []byte("metadata: ["), 0o600))
 
-		_, err := squadsFromManifests(dir)
+		_, err := squadFromManifests(dir)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
+	})
+
+	t.Run("short circuits before later invalid manifests once a squad is found", func(t *testing.T) {
+		dir := t.TempDir()
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a-valid.yaml"), []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    squad: alpha
+`), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "z-invalid.yaml"), []byte("metadata: ["), 0o600))
+
+		actual, err := squadFromManifests(dir)
+
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", actual)
 	})
 }

--- a/internal/flow/squads_test.go
+++ b/internal/flow/squads_test.go
@@ -1,0 +1,74 @@
+package flow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSquadsFromManifests(t *testing.T) {
+	t.Run("collects distinct squads from top level, template and job template labels", func(t *testing.T) {
+		dir := t.TempDir()
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    squad: alpha
+spec:
+  template:
+    metadata:
+      labels:
+        app: demo
+`), 0o600))
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "job.yaml"), []byte(`
+apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    metadata:
+      labels:
+        squad: beta
+`), 0o600))
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cronjob.yaml"), []byte(`
+apiVersion: batch/v1
+kind: CronJob
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            squad: gamma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    squad: alpha
+`), 0o600))
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "README.txt"), []byte("not a manifest"), 0o600))
+
+		actual, err := squadsFromManifests(dir)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"alpha", "beta", "gamma"}, actual)
+	})
+
+	t.Run("returns an error for invalid yaml manifests", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "invalid.yaml"), []byte("metadata: ["), 0o600))
+
+		_, err := squadsFromManifests(dir)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+}

--- a/internal/http/types.go
+++ b/internal/http/types.go
@@ -76,6 +76,7 @@ type ReleaseEvent struct {
 	DesiredPods   int32  `json:"replicas,omitempty"`
 	ArtifactID    string `json:"artifactId,omitempty"`
 	AuthorEmail   string `json:"authorEmail,omitempty"`
+	Squad         string `json:"squad,omitempty"`
 	Environment   string `json:"environment,omitempty"`
 }
 type ContainerError struct {
@@ -122,6 +123,7 @@ type JobErrorEvent struct {
 	AuthorEmail string              `json:"authorEmail,omitempty"`
 	Environment string              `json:"environment,omitempty"`
 	ArtifactID  string              `json:"artifactId,omitempty"`
+	Squad       string              `json:"squad,omitempty"`
 }
 
 type KubernetesNotifyResponse struct {

--- a/internal/slack/notifications_test.go
+++ b/internal/slack/notifications_test.go
@@ -1,0 +1,161 @@
+package slack_test
+
+import (
+	"context"
+	"testing"
+
+	httpinternal "github.com/lunarway/release-manager/internal/http"
+	"github.com/lunarway/release-manager/internal/log"
+	intslack "github.com/lunarway/release-manager/internal/slack"
+	"github.com/nlopes/slack"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap/zapcore"
+)
+
+func initTestLogger() {
+	log.Init(&log.Configuration{
+		Level: log.Level{
+			Level: zapcore.DebugLevel,
+		},
+		Development: true,
+	})
+}
+
+func TestNotifyRelease_postsSquadReleaseChannelsBestEffort(t *testing.T) {
+	initTestLogger()
+
+	slackClient := intslack.MockSlackClient{}
+	slackClient.Test(t)
+	slackUser := &slack.User{ID: "user-id"}
+
+	slackClient.On("PostMessageContext", mock.Anything, "#releases-dev", mock.Anything, mock.Anything).
+		Return("", "", nil).Once()
+	slackClient.On("PostMessageContext", mock.Anything, "#squad-alpha-releases-dev", mock.Anything, mock.Anything).
+		Return("", "", errors.New("channel_not_found")).Once()
+	slackClient.On("PostMessageContext", mock.Anything, "#squad-beta-releases-dev", mock.Anything, mock.Anything).
+		Return("", "", nil).Once()
+	slackClient.On("GetUserByEmailContext", mock.Anything, "author@corp.com").
+		Return(slackUser, nil).Once()
+	slackClient.On("PostMessageContext", mock.Anything, slackUser.ID, mock.Anything, mock.Anything).
+		Return("", "", nil).Once()
+
+	client, err := intslack.NewClient(&slackClient, nil, "corp.com")
+	if !assert.NoError(t, err, "unexpected instantiation error") {
+		return
+	}
+
+	client.NotifyRelease(context.Background(), intslack.ReleaseOptions{
+		Service:           "release-manager",
+		ArtifactID:        "artifact-1",
+		CommitMessage:     "ship it",
+		CommitAuthor:      "Author",
+		CommitAuthorEmail: "author@corp.com",
+		CommitLink:        "https://example.com",
+		Environment:       "dev",
+		Releaser:          "Releaser",
+		Squads:            []string{"beta", "alpha", "", "alpha"},
+	})
+
+	slackClient.AssertExpectations(t)
+}
+
+func TestNotifyK8SDeployEvent_postsSquadReleaseChannelBestEffort(t *testing.T) {
+	initTestLogger()
+
+	t.Run("squad channel failure is ignored", func(t *testing.T) {
+		slackClient := intslack.MockSlackClient{}
+		slackClient.Test(t)
+		slackUser := &slack.User{ID: "user-id"}
+
+		slackClient.On("GetUserByEmailContext", mock.Anything, "author@corp.com").
+			Return(slackUser, nil).Once()
+		slackClient.On("PostMessageContext", mock.Anything, slackUser.ID, mock.Anything, mock.Anything).
+			Return("", "", nil).Once()
+		slackClient.On("PostMessageContext", mock.Anything, "#squad-sentinel-releases-prod", mock.Anything, mock.Anything).
+			Return("", "", errors.New("channel_not_found")).Once()
+
+		client, err := intslack.NewClient(&slackClient, nil, "corp.com")
+		if !assert.NoError(t, err, "unexpected instantiation error") {
+			return
+		}
+
+		err = client.NotifyK8SDeployEvent(context.Background(), intslack.NotifyK8sDeployOptions{
+			AuthorEmail:   "author@corp.com",
+			Environment:   "prod",
+			Name:          "deploy",
+			AvailablePods: 2,
+			DesiredPods:   2,
+			ResourceType:  "Deployment",
+			ArtifactID:    "artifact-1",
+			Squad:         "sentinel",
+		})
+
+		assert.NoError(t, err)
+		slackClient.AssertExpectations(t)
+	})
+
+	t.Run("primary notification error is still returned after squad fan out", func(t *testing.T) {
+		slackClient := intslack.MockSlackClient{}
+		slackClient.Test(t)
+
+		slackClient.On("GetUserByEmailContext", mock.Anything, "author@corp.com").
+			Return(&slack.User{}, errors.New("users_not_found")).Once()
+		slackClient.On("PostMessageContext", mock.Anything, "#squad-sentinel-releases-prod", mock.Anything, mock.Anything).
+			Return("", "", nil).Once()
+
+		client, err := intslack.NewClient(&slackClient, nil, "corp.com")
+		if !assert.NoError(t, err, "unexpected instantiation error") {
+			return
+		}
+
+		err = client.NotifyK8SDeployEvent(context.Background(), intslack.NotifyK8sDeployOptions{
+			AuthorEmail:   "author@corp.com",
+			Environment:   "prod",
+			Name:          "deploy",
+			AvailablePods: 2,
+			DesiredPods:   2,
+			ResourceType:  "Deployment",
+			ArtifactID:    "artifact-1",
+			Squad:         "sentinel",
+		})
+
+		assert.EqualError(t, err, "users_not_found")
+		slackClient.AssertExpectations(t)
+	})
+}
+
+func TestNotifyK8SPodErrorEvent_postsSquadReleaseChannelBestEffort(t *testing.T) {
+	initTestLogger()
+
+	slackClient := intslack.MockSlackClient{}
+	slackClient.Test(t)
+	slackUser := &slack.User{ID: "user-id"}
+
+	slackClient.On("GetUserByEmailContext", mock.Anything, "author@corp.com").
+		Return(slackUser, nil).Once()
+	slackClient.On("PostMessageContext", mock.Anything, slackUser.ID, mock.Anything, mock.Anything).
+		Return("", "", nil).Once()
+	slackClient.On("PostMessageContext", mock.Anything, "#squad-sentinel-alerts", mock.Anything, mock.Anything).
+		Return("", "", nil).Once()
+	slackClient.On("PostMessageContext", mock.Anything, "#squad-sentinel-releases-dev", mock.Anything, mock.Anything).
+		Return("", "", errors.New("channel_not_found")).Once()
+
+	client, err := intslack.NewClient(&slackClient, nil, "corp.com")
+	if !assert.NoError(t, err, "unexpected instantiation error") {
+		return
+	}
+
+	err = client.NotifyK8SPodErrorEvent(context.Background(), &httpinternal.PodErrorEvent{
+		PodName:     "pod-1",
+		AuthorEmail: "author@corp.com",
+		Environment: "dev",
+		ArtifactID:  "artifact-1",
+		Squad:       "sentinel",
+		AlertSquad:  "#squad-sentinel-alerts",
+	})
+
+	assert.NoError(t, err)
+	slackClient.AssertExpectations(t)
+}

--- a/internal/slack/notifications_test.go
+++ b/internal/slack/notifications_test.go
@@ -34,8 +34,6 @@ func TestNotifyRelease_postsSquadReleaseChannelsBestEffort(t *testing.T) {
 		Return("", "", nil).Once()
 	slackClient.On("PostMessageContext", mock.Anything, "#squad-alpha-releases-dev", mock.Anything, mock.Anything).
 		Return("", "", errors.New("channel_not_found")).Once()
-	slackClient.On("PostMessageContext", mock.Anything, "#squad-beta-releases-dev", mock.Anything, mock.Anything).
-		Return("", "", nil).Once()
 	slackClient.On("GetUserByEmailContext", mock.Anything, "author@corp.com").
 		Return(slackUser, nil).Once()
 	slackClient.On("PostMessageContext", mock.Anything, slackUser.ID, mock.Anything, mock.Anything).
@@ -55,7 +53,7 @@ func TestNotifyRelease_postsSquadReleaseChannelsBestEffort(t *testing.T) {
 		CommitLink:        "https://example.com",
 		Environment:       "dev",
 		Releaser:          "Releaser",
-		Squads:            []string{"beta", "alpha", "", "alpha"},
+		Squad:             "alpha",
 	})
 
 	slackClient.AssertExpectations(t)

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lunarway/release-manager/internal/http"
@@ -150,6 +151,7 @@ type ReleaseOptions struct {
 	CommitAuthor      string
 	CommitAuthorEmail string
 	Releaser          string
+	Squads            []string
 	Environment       string
 }
 
@@ -179,9 +181,7 @@ func (c *Client) notifySlackReleasesChannel(ctx context.Context, options Release
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err := c.client.PostMessageContext(ctx, fmt.Sprintf("#releases-%s", options.Environment), asUser, attachments)
-	if err != nil {
-		return err
-	}
+	c.notifySquadReleaseChannelsBestEffort(ctx, options.Squads, options.Environment, asUser, attachments)
 	return err
 }
 
@@ -289,15 +289,12 @@ type NotifyK8sDeployOptions struct {
 	DesiredPods   int32
 	ResourceType  string
 	ArtifactID    string
+	Squad         string
 }
 
 func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event NotifyK8sDeployOptions) error {
 	if c.muteOptions.Kubernetes {
 		return nil
-	}
-	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
-	if err != nil {
-		return err
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	attachments := slack.MsgOptionAttachments(slack.Attachment{
@@ -306,10 +303,12 @@ func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event NotifyK8sDeploy
 		Text:       fmt.Sprintf("%s deployed\n%d/%d pods are running (%s)\nArtifact: *%s*", event.Name, event.AvailablePods, event.DesiredPods, event.ResourceType, event.ArtifactID),
 		MarkdownIn: []string{"text", "fields"},
 	})
-	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
-	if err != nil {
-		return err
+	var err error
+	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
+	if err == nil {
+		_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	}
+	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
 	return err
 }
 
@@ -358,10 +357,6 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	if c.muteOptions.Kubernetes {
 		return nil
 	}
-	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
-	if err != nil {
-		return err
-	}
 	asUser := slack.MsgOptionAsUser(true)
 	var fields []slack.AttachmentField
 	for _, container := range event.Errors {
@@ -378,23 +373,25 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     fields,
 	})
-	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
+	var err error
+	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
+	if err == nil {
+		_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
+	}
+	var alertErr error
+	if event.AlertSquad != "" {
+		_, _, alertErr = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
+	}
+	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
 	if err != nil {
 		return err
 	}
-	if event.AlertSquad != "" {
-		_, _, err = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
-	}
-	return err
+	return alertErr
 }
 
 func (c *Client) NotifyK8SJobErrorEvent(ctx context.Context, event *http.JobErrorEvent) error {
 	if c.muteOptions.Kubernetes {
 		return nil
-	}
-	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
-	if err != nil {
-		return err
 	}
 	asUser := slack.MsgOptionAsUser(true)
 	var fields []slack.AttachmentField
@@ -412,11 +409,48 @@ func (c *Client) NotifyK8SJobErrorEvent(ctx context.Context, event *http.JobErro
 		MarkdownIn: []string{"text", "fields"},
 		Fields:     fields,
 	})
-	_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
-	if err != nil {
-		return err
+	var err error
+	userID, err := c.getIdByEmail(ctx, event.AuthorEmail)
+	if err == nil {
+		_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	}
+	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
 	return err
+}
+
+func (c *Client) notifySquadReleaseChannelsBestEffort(ctx context.Context, squads []string, environment string, options ...slack.MsgOption) {
+	for _, channel := range squadReleaseChannels(squads, environment) {
+		_, _, err := c.client.PostMessageContext(ctx, channel, options...)
+		if err != nil {
+			log.WithContext(ctx).
+				With("channel", channel).
+				Infof("slack: skipping squad release channel notification: %v", err)
+		}
+	}
+}
+
+func squadReleaseChannels(squads []string, environment string) []string {
+	environment = strings.TrimSpace(environment)
+	if environment == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, squad := range squads {
+		squad = strings.TrimSpace(squad)
+		if squad == "" {
+			continue
+		}
+		channel := fmt.Sprintf("#squad-%s-releases-%s", squad, environment)
+		seen[channel] = struct{}{}
+	}
+
+	channels := make([]string, 0, len(seen))
+	for channel := range seen {
+		channels = append(channels, channel)
+	}
+	sort.Strings(channels)
+	return channels
 }
 
 func (c *Client) NotifyReleaseManagerError(ctx context.Context, msgType, service, environment, branch, namespace, actorEmail string, inputErr error) error {

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/lunarway/release-manager/internal/http"
@@ -151,7 +150,7 @@ type ReleaseOptions struct {
 	CommitAuthor      string
 	CommitAuthorEmail string
 	Releaser          string
-	Squads            []string
+	Squad             string
 	Environment       string
 }
 
@@ -181,7 +180,7 @@ func (c *Client) notifySlackReleasesChannel(ctx context.Context, options Release
 		MarkdownIn: []string{"text", "fields"},
 	})
 	_, _, err := c.client.PostMessageContext(ctx, fmt.Sprintf("#releases-%s", options.Environment), asUser, attachments)
-	c.notifySquadReleaseChannelsBestEffort(ctx, options.Squads, options.Environment, asUser, attachments)
+	c.notifySquadReleaseChannelBestEffort(ctx, options.Squad, options.Environment, asUser, attachments)
 	return err
 }
 
@@ -308,7 +307,7 @@ func (c *Client) NotifyK8SDeployEvent(ctx context.Context, event NotifyK8sDeploy
 	if err == nil {
 		_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	}
-	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
+	c.notifySquadReleaseChannelBestEffort(ctx, event.Squad, event.Environment, asUser, attachments)
 	return err
 }
 
@@ -382,7 +381,7 @@ func (c *Client) NotifyK8SPodErrorEvent(ctx context.Context, event *http.PodErro
 	if event.AlertSquad != "" {
 		_, _, alertErr = c.client.PostMessageContext(ctx, event.AlertSquad, asUser, attachments)
 	}
-	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
+	c.notifySquadReleaseChannelBestEffort(ctx, event.Squad, event.Environment, asUser, attachments)
 	if err != nil {
 		return err
 	}
@@ -414,43 +413,30 @@ func (c *Client) NotifyK8SJobErrorEvent(ctx context.Context, event *http.JobErro
 	if err == nil {
 		_, _, err = c.client.PostMessageContext(ctx, userID, asUser, attachments)
 	}
-	c.notifySquadReleaseChannelsBestEffort(ctx, []string{event.Squad}, event.Environment, asUser, attachments)
+	c.notifySquadReleaseChannelBestEffort(ctx, event.Squad, event.Environment, asUser, attachments)
 	return err
 }
 
-func (c *Client) notifySquadReleaseChannelsBestEffort(ctx context.Context, squads []string, environment string, options ...slack.MsgOption) {
-	for _, channel := range squadReleaseChannels(squads, environment) {
-		_, _, err := c.client.PostMessageContext(ctx, channel, options...)
-		if err != nil {
-			log.WithContext(ctx).
-				With("channel", channel).
-				Infof("slack: skipping squad release channel notification: %v", err)
-		}
+func (c *Client) notifySquadReleaseChannelBestEffort(ctx context.Context, squad, environment string, options ...slack.MsgOption) {
+	channel := squadReleaseChannel(squad, environment)
+	if channel == "" {
+		return
+	}
+	_, _, err := c.client.PostMessageContext(ctx, channel, options...)
+	if err != nil {
+		log.WithContext(ctx).
+			With("channel", channel).
+			Infof("slack: skipping squad release channel notification: %v", err)
 	}
 }
 
-func squadReleaseChannels(squads []string, environment string) []string {
+func squadReleaseChannel(squad, environment string) string {
+	squad = strings.TrimSpace(squad)
 	environment = strings.TrimSpace(environment)
-	if environment == "" {
-		return nil
+	if squad == "" || environment == "" {
+		return ""
 	}
-
-	seen := make(map[string]struct{})
-	for _, squad := range squads {
-		squad = strings.TrimSpace(squad)
-		if squad == "" {
-			continue
-		}
-		channel := fmt.Sprintf("#squad-%s-releases-%s", squad, environment)
-		seen[channel] = struct{}{}
-	}
-
-	channels := make([]string, 0, len(seen))
-	for channel := range seen {
-		channels = append(channels, channel)
-	}
-	sort.Strings(channels)
-	return channels
+	return fmt.Sprintf("#squad-%s-releases-%s", squad, environment)
 }
 
 func (c *Client) NotifyReleaseManagerError(ctx context.Context, msgType, service, environment, branch, namespace, actorEmail string, inputErr error) error {


### PR DESCRIPTION
  - Adds Slack notification to squad release channels using Kubernetes squad labels, with the pattern `#squad-<squad>-releases-<env>`.
  - Release announcements now scan the manifests in the artifact and post to each distinct squad channel found.
  - Deployment success, pod error, and job error notifications now carry squad information from live Kubernetes labels and also post to the matching squad release channel.
  - The new squad-channel notification path is fully failsafe: if no squad label is present, the Slack channel does not exist, or Slack posting fails, the main flow continues unchanged and the error is only logged.
  - Existing notifications to `#releases-<env>`, direct user messages, and squad alert channels remain unchanged.

_Testing_

  - Added tests for manifest squad extraction and best-effort Slack notifications.
  - Ran go test ./...

Seel also: https://lunar.slack.com/archives/C04QA2ZUU1M/p1778138870000079


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new squad propagation across k8s event ingestion and Slack notification paths, including new best-effort fan-out behavior and new fields in shared event types. Main risk is unintended notification routing/noise or missed direct messages due to changed Slack error-handling paths.
> 
> **Overview**
> Adds *squad-aware* release and Kubernetes notifications by propagating a new `Squad` field through `http.ReleaseEvent`/`http.JobErrorEvent` and flow notify options, and populating it from Kubernetes `squad` labels (falling back to pod template labels).
> 
> Slack notifications now **fan out best-effort** to per-squad per-environment channels (`#squad-<squad>-releases-<env>`) for release announcements, deploy success, pod errors, and job errors; failures to post to squad channels are logged and do not fail the primary notification.
> 
> Release commits additionally attempt to derive `Squad` by scanning rendered manifest YAMLs in the artifact (`squadFromManifests`), with new tests covering manifest parsing/short-circuiting and Slack best-effort squad channel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96467d5108ca474a099282d9edd8404dfdb03261. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->