### PR TITLE
Migrate from esa to dark matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Administrative ownership metadata only; no application or infrastructure code changes.
> 
> **Overview**
> Updates the repository’s default **CODEOWNERS** entry from `@lunarway/squad-esa` to `@lunarway/squad-dark-matter`, so new review requests and ownership routing follow the renamed squad.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e78fcfeb023cd156e33f22301fc832d9991c37a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->