### PR TITLE
fix(git): use hardlink local clone instead of cp -a in copyMaster

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -161,7 +161,6 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			copier := copy.New(log.With("system", "copier"))
 			gitSvc := git.Service{
 				Tracer:            tracer,
-				Copier:            copier,
 				SSHPrivateKeyPath: startOptions.configRepo.SSHPrivateKeyPath,
 				ConfigRepoURL:     startOptions.configRepo.ConfigRepo,
 				Config:            startOptions.gitConfigOpts,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -154,7 +154,7 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "set remote url")
 	err = execCommand(ctx, destination, "git", "remote", "set-url", "origin", s.ConfigRepoURL)
-	span.Finish()
+	span.End()
 	if err != nil {
 		return nil, errors.WithMessagef(err, "set origin remote to '%s'", s.ConfigRepoURL)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/lunarway/release-manager/internal/commitinfo"
-	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/pkg/errors"
@@ -36,7 +35,6 @@ type GitConfig struct {
 
 type Service struct {
 	Tracer            tracing.Tracer
-	Copier            *copy.Copier
 	SSHPrivateKeyPath string
 	ConfigRepoURL     string
 	Config            *GitConfig

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -131,6 +131,10 @@ func (s *Service) Clone(ctx context.Context, destination string) (*git.Repositor
 	return s.copyMaster(ctx, destination)
 }
 
+// copyMaster creates a cheap local clone of the master repository at destination
+// using git's --local transport, which hardlinks objects instead of copying them.
+// After cloning, the origin remote is repointed to ConfigRepoURL so that
+// subsequent git push origin master calls reach the real remote (GitHub).
 func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repository, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.copyMaster")
 	defer span.End()
@@ -144,11 +148,17 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 	s.masterMutex.RLock()
 	defer s.masterMutex.RUnlock()
 	span.End()
-	span, _ = s.Tracer.FromCtx(ctx, "copy to destination")
-	err = s.Copier.CopyDir(ctx, s.MasterPath(), destination)
+	span, _ = s.Tracer.FromCtx(ctx, "clone to destination")
+	err = execCommand(ctx, ".", "git", "clone", "--local", s.MasterPath(), destination)
 	span.End()
 	if err != nil {
-		return nil, errors.WithMessagef(err, "copy master from '%s'", s.MasterPath())
+		return nil, errors.WithMessagef(err, "local clone master from '%s'", s.MasterPath())
+	}
+	span, _ = s.Tracer.FromCtx(ctx, "set remote url")
+	err = execCommand(ctx, destination, "git", "remote", "set-url", "origin", s.ConfigRepoURL)
+	span.Finish()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "set origin remote to '%s'", s.ConfigRepoURL)
 	}
 	span, _ = s.Tracer.FromCtx(ctx, "open repo")
 	r, err := git.PlainOpen(destination)


### PR DESCRIPTION
## Summary
Replaces the per-release full-repo `cp -a` (which copied the entire config repo including all `.git` history) with a hardlink-based `git clone --local`, making `copyMaster` near-instant.

## Changes
- `internal/git/git.go` `copyMaster`: swap `Copier.CopyDir` (`cp -a`) for `git clone --local <masterPath> <dest>`.
- After cloning, `git remote set-url origin <ConfigRepoURL>` so `git push origin master` still reaches the real GitHub remote rather than the local master path.
- Updated tracing span names ("clone to destination", "set remote url") and the godoc on `copyMaster` to reflect the new behavior.

## Why

Tracing a release showed `copyMaster` consuming ~1.9s on every release — and up to ~3.8s total when a push is rejected due to a concurrent release (the entire flow retries from scratch, re-running `copyMaster` a second time):

| Phase | Attempt 1 (failed) | Attempt 2 (ok) |
|---|---|---|
| copyMaster | 1.88s | 1.93s |
| git add . | 1.27s | 1.49s |
| commit | 0.14s | 0.17s |
| push | 1.07s | 1.85s |
| SyncMaster (after reject) | 6.45s | — |
| **Total** | **~11.0s** | **~5.7s** |

The working directory only needs to commit one file and push — it does not need the full object history. Replacing `cp -a` with `git clone --local` hardlinks `.git/objects` instead of byte-copying them, cutting the ~1.9s `copyMaster` cost to near-zero on every release — conflict retries included.

## Review notes
- Concurrency: `masterMutex` read-lock behavior around the operation is unchanged.
- The `git remote set-url origin` step is required so pushes still target the real GitHub remote rather than the local master path.