### PR TITLE
fix: read released env spec from master under RLock instead of cloning

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -102,6 +102,10 @@ type GitService interface {
 	SyncMaster(context.Context) error
 	Clone(context.Context, string) (*git.Repository, error)
 	MasterPath() string
+	// WithMasterPath calls fn with the master working-copy path while holding
+	// the master read lock. Use this to read files from the master copy without
+	// racing against SyncMaster.
+	WithMasterPath(ctx context.Context, fn func(masterPath string) error) error
 	Commit(ctx context.Context, rootPath, changesPath, msg string) error
 	LocateServiceReleaseRollbackSkip(ctx context.Context, r *git.Repository, env, service string, n uint) (plumbing.Hash, error)
 	Checkout(ctx context.Context, rootPath string, hash plumbing.Hash) error

--- a/internal/flow/mock_GitService.go
+++ b/internal/flow/mock_GitService.go
@@ -104,6 +104,20 @@ func (_m *MockGitService) MasterPath() string {
 	return r0
 }
 
+// WithMasterPath provides a mock function with given fields: ctx, fn
+func (_m *MockGitService) WithMasterPath(ctx context.Context, fn func(masterPath string) error) error {
+	ret := _m.Called(ctx, fn)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, func(string) error) error); ok {
+		r0 = rf(ctx, fn)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SyncMaster provides a mock function with given fields: _a0
 func (_m *MockGitService) SyncMaster(_a0 context.Context) error {
 	ret := _m.Called(_a0)

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -103,18 +103,19 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 	// environment. If there is no artifact released to the target environment an
 	// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
 	// will then be the default value and this its ID will be the empty string.
-	destinationConfigRepoPath, closeDestinationSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
+	// The read is performed under the master read lock so it cannot race with
+	// SyncMaster (which takes the write lock).
+	var currentSpec artifact.Spec
+	err = s.Git.WithMasterPath(ctx, func(masterPath string) error {
+		var specErr error
+		currentSpec, specErr = envSpec(masterPath, s.ArtifactFileName, service, environment, namespace)
+		if specErr != nil && errors.Cause(specErr) != artifact.ErrFileNotFound {
+			return errors.WithMessage(specErr, "get current released spec")
+		}
+		return nil
+	})
 	if err != nil {
 		return "", err
-	}
-	defer closeDestinationSource(ctx)
-	_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", destinationConfigRepoPath)
-	}
-	currentSpec, err := envSpec(destinationConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
-	if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
-		return "", errors.WithMessage(err, "get current released spec")
 	}
 	logger.WithFields("currentSpec", currentSpec).Debugf("Found artifact '%s' in environment '%s'", currentSpec.ID, environment)
 	if currentSpec.ID == sourceSpec.ID {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -46,8 +46,20 @@ type Service struct {
 	master      *git.Repository
 }
 
+// MasterPath returns the filesystem path of the master working copy.
 func (s *Service) MasterPath() string {
 	return s.masterPath
+}
+
+// WithMasterPath calls fn with the master working-copy path while holding the
+// master read lock. This allows callers to read files from the master copy
+// without racing against SyncMaster, which takes the write lock.
+func (s *Service) WithMasterPath(ctx context.Context, fn func(masterPath string) error) error {
+	span, _ := s.Tracer.FromCtx(ctx, "git.WithMasterPath")
+	defer span.Finish()
+	s.masterMutex.RLock()
+	defer s.masterMutex.RUnlock()
+	return fn(s.masterPath)
 }
 
 // InitMasterRepo clones the configuration repository into a master directory.


### PR DESCRIPTION
## Summary

Avoids a full repository clone on the release API/publish path. `ReleaseArtifactID` now reads the currently-released environment spec directly from the master working copy under the master read lock, instead of cloning the config repo into a temp directory just to read a single file.

## Changes

- Add `WithMasterPath(ctx, fn)` to the git `Service` (`internal/git/git.go`). It holds `masterMutex.RLock()` for the duration of `fn`, giving callers a race-free read window against the master working copy.
- Add `WithMasterPath` to the `GitService` interface (`internal/flow/flow.go`) and regenerate the mock (`internal/flow/mock_GitService.go`).
- Rewrite the "is this artifact already released" check in `ReleaseArtifactID` (`internal/flow/release.go`) to read the env spec via `WithMasterPath` + `envSpec`, removing the `git.TempDirAsync` + `s.Git.Clone` + cleanup block.
- Preserve existing behavior exactly: `artifact.ErrFileNotFound` is tolerated (empty `currentSpec.ID`), the debug log line is unchanged, and the `ErrNothingToRelease` early return is unchanged.

## Why

Every release API request previously performed a full clone of the config repo into a temp dir solely to read one `currentSpec`. That competed for disk I/O and the git lock with the actual release consumer and added latency. Reading the single spec directly from the master copy under `RLock` eliminates the clone while remaining race-free: `SyncMaster` takes the write lock for its fetch+pull, so a reader holding `RLock` can never observe a half-synced tree. This mirrors the existing `Clone`/`copyMaster` RLock pattern.

## Review notes

- Concurrency: `masterMutex` is a `sync.RWMutex`. `SyncMaster` holds `Lock()` across the entire fetch+pull; `WithMasterPath` holds `RLock()` across the entire `envSpec` read, so no half-synced read is possible.
- The read is read-only (`releasePath` via SecureJoin + `artifact.Get`), safe to run against the shared master copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the release publish path observes config state (shared master + locking) but the read is read-only and aligned with existing SyncMaster/Clone locking.
> 
> **Overview**
> **Release API path no longer clones the config repo** just to see what is already deployed. `ReleaseArtifactID` now loads the current environment spec from the shared **master working copy** via new `Git.WithMasterPath`, which runs the read while holding `masterMutex` **read lock** so it cannot overlap `SyncMaster`’s **write lock**.
> 
> The git layer exposes `WithMasterPath` on `GitService` (and the mock). **Same release semantics** as before: missing spec still means empty ID, `ErrNothingToRelease` when IDs match, and real read errors still fail the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467c6ee9e626506d6e4ac203d8cffe9dc9a812f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->