### PR TITLE
fix: ack messages on success path in amqp consumer

### DIFF
--- a/internal/broker/amqpextra/consumer_mux.go
+++ b/internal/broker/amqpextra/consumer_mux.go
@@ -39,7 +39,7 @@ func (m mux) ServeMsg(ctx context.Context, msg amqp.Delivery) error {
 }
 
 func (m mux) ack(msg amqp.Delivery) {
-	err := msg.Nack(false, false)
+	err := msg.Ack(false)
 	if err != nil {
 		m.log.Errorf("ack failed for event '%s': %v", msg.Type, err)
 	}


### PR DESCRIPTION
## Summary

Fixes a message-acknowledgement bug in the AMQP consumer multiplexer where successfully-processed messages were silently dropped instead of being acknowledged.

## Changes

- `internal/broker/amqpextra/consumer_mux.go`: the `ack` method now calls `msg.Ack(false)` instead of `msg.Nack(false, false)` on the success path.
- The failure-path `nack` method is unchanged.

## Why

The success path (`ServeMsg` after a handler returns `nil`) called `msg.Nack(false, false)`. With `requeue=false` and no dead-letter exchange configured, RabbitMQ discards the message. This meant every successfully-processed event was silently dropped from the queue rather than acknowledged — a data-integrity bug. Acking with `Ack(false)` correctly confirms the single delivery to the broker.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects broker acknowledgement on the hot path for all successfully processed queue events; wrong ack behavior previously caused silent message loss.
> 
> **Overview**
> Fixes the AMQP consumer multiplexer so **successful** handler completions are **acknowledged** to RabbitMQ instead of **nacked without requeue** (which discarded them).
> 
> In `internal/broker/amqpextra/consumer_mux.go`, `ack` now calls `msg.Ack(false)` on the success path after `ServeMsg` returns nil. Error handling (`nack` with requeue or drop) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4c2b5829b2d58a6d5fd1f1c78b5d138067c2b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->