### PR TITLE
fix: avoid full re-clone on every retry of ExecReleaseArtifactID

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -105,6 +105,9 @@ type GitService interface {
 	Commit(ctx context.Context, rootPath, changesPath, msg string) error
 	LocateServiceReleaseRollbackSkip(ctx context.Context, r *git.Repository, env, service string, n uint) (plumbing.Hash, error)
 	Checkout(ctx context.Context, rootPath string, hash plumbing.Hash) error
+	// ResetToOriginMaster fetches the latest commits from origin and hard-resets
+	// the working tree at rootPath to origin/master.
+	ResetToOriginMaster(ctx context.Context, rootPath string) error
 }
 
 // retry tries the function f until max attempts is reached

--- a/internal/flow/mock_GitService.go
+++ b/internal/flow/mock_GitService.go
@@ -117,3 +117,17 @@ func (_m *MockGitService) SyncMaster(_a0 context.Context) error {
 
 	return r0
 }
+
+// ResetToOriginMaster provides a mock function with given fields: ctx, rootPath
+func (_m *MockGitService) ResetToOriginMaster(ctx context.Context, rootPath string) error {
+	ret := _m.Called(ctx, rootPath)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, rootPath)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -139,31 +139,44 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifactIDEvent) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.ExecReleaseArtifactID")
 	defer span.Finish()
-	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
-		service := event.Service
-		branch := event.Branch
-		environment := event.Environment
-		namespace := event.Namespace
-		actor := event.Actor
-		artifactID := event.ArtifactID
 
+	service := event.Service
+	branch := event.Branch
+	environment := event.Environment
+	namespace := event.Namespace
+	actor := event.Actor
+	artifactID := event.ArtifactID
+
+	artifactSourcePath, sourcePath, closeSource, err := s.Storage.ArtifactPaths(ctx, service, environment, branch, artifactID)
+	if err != nil {
+		return errors.WithMessage(err, "get artifact paths")
+	}
+	defer closeSource(ctx)
+
+	// Allocate the destination clone once. On ErrBranchBehindOrigin the retry
+	// loop (via flow.retry → SyncMaster) updates the shared master, and we
+	// bring the destination clone up to date with ResetToOriginMaster before
+	// re-applying the (idempotent) resource copy.
+	destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
+	if err != nil {
+		return err
+	}
+	defer closeDestination(ctx)
+
+	_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
+	if err != nil {
+		return errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
+	}
+
+	err = s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
 		logger := log.WithContext(ctx)
 
-		artifactSourcePath, sourcePath, closeSource, err := s.Storage.ArtifactPaths(ctx, service, environment, branch, artifactID)
-		if err != nil {
-			return true, errors.WithMessage(err, "get artifact paths")
-		}
-		defer closeSource(ctx)
-
-		destinationConfigRepoPath, closeDestination, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
-		if err != nil {
-			return true, err
-		}
-		defer closeDestination(ctx)
-
-		_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
-		if err != nil {
-			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
+		// On a retry the shared master has already been synced by flow.retry.
+		// Bring the destination clone to the new tip without a full re-clone.
+		if attempt > 1 {
+			if err := s.Git.ResetToOriginMaster(ctx, destinationConfigRepoPath); err != nil {
+				return true, errors.WithMessage(err, "reset destination clone to origin/master")
+			}
 		}
 
 		// release service to env from original release

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -123,6 +123,30 @@ func (s *Service) SyncMaster(ctx context.Context) error {
 	return nil
 }
 
+// ResetToOriginMaster fetches the latest commits from origin and hard-resets
+// the working tree at rootPath to origin/master. This is cheaper than a full
+// clone and is used to bring a destination clone up to date before retrying a
+// failed push.
+func (s *Service) ResetToOriginMaster(ctx context.Context, rootPath string) error {
+	span, ctx := s.Tracer.FromCtx(ctx, "git.ResetToOriginMaster")
+	defer span.Finish()
+
+	span, _ = s.Tracer.FromCtx(ctx, "fetch")
+	err := execCommand(ctx, rootPath, "git", "fetch", "origin", "master")
+	span.Finish()
+	if err != nil {
+		return errors.WithMessage(err, "fetch origin master")
+	}
+
+	span, _ = s.Tracer.FromCtx(ctx, "reset hard")
+	err = execCommand(ctx, rootPath, "git", "reset", "--hard", "origin/master")
+	span.Finish()
+	if err != nil {
+		return errors.WithMessage(err, "reset hard to origin/master")
+	}
+	return nil
+}
+
 // Clone returns a Git repository copy from the master repository.
 func (s *Service) Clone(ctx context.Context, destination string) (*git.Repository, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.Clone")


### PR DESCRIPTION
## Summary

Avoid re-doing a full destination repo clone on every retry of `ExecReleaseArtifactID`. The temp-dir allocation and clone are now done once, before the retry loop. On retry attempts the destination clone is brought up to date with a cheap `git fetch origin master` + `git reset --hard origin/master` instead of a fresh full clone and full resource copy.

## Changes

- `internal/git/git.go`: add `ResetToOriginMaster(ctx, rootPath)` — `git fetch origin master` followed by `git reset --hard origin/master`, mirroring the auth/remote setup used by the existing `gitPush`.
- `internal/flow/flow.go`: add `ResetToOriginMaster` to the `GitService` interface.
- `internal/flow/mock_GitService.go`: regenerated mock for the new method.
- `internal/flow/release.go`: move `TempDirAsync` + `Clone` (and their deferred close) outside the retry loop; hoist event field unpacking and `ArtifactPaths` out of the loop; on `attempt > 1` call `ResetToOriginMaster` before re-applying the idempotent resource copy + commit.

## Why

When a push failed with `ErrBranchBehindOrigin`, `flow.retry` synced the shared master and re-ran the closure. Previously the closure re-did a full destination clone (a full `CopyDir` of the master working tree) and a full resource copy on every attempt — typically 2–3 times under contention. Now the destination clone is created once, and each retry only fetches the few new commits and hard-resets to the new tip before re-applying the (idempotent) copy + commit. This cuts redundant I/O on the hot release path while preserving identical behavior.

## Review notes

Quality gates: `go build ./...`, `go vet ./...`, and `go test ./...` all pass (shuttle has no project config; fell back to `go`). Confirmed:

- Temp-dir is created once and `closeDestination` is deferred exactly once outside the loop — no per-attempt leak.
- The destination clone inherits the `origin` remote and SSH config via `copyMaster`'s `CopyDir` of the master clone, so `git fetch origin master` works with the same auth as the existing `git push origin master`.
- `git reset --hard origin/master` discards the prior attempt's failed local commit and any working-tree state, giving a clean tree at the new tip so the idempotent re-copy and kustomization move are safe.
- `try.Do` numbers attempts from 1, so the first attempt reuses the fresh clone and only retries (`attempt > 1`) reset. The `(stop, err)` retry contract is preserved (reset failure returns `(true, err)` to stop).

No CRITICAL findings; no HIGH/MEDIUM/LOW findings. Commit not amended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot release-to-git path and retry semantics around config-repo pushes; behavior should be equivalent but wrong reset/clone ordering could affect commits under contention.
> 
> **Overview**
> **`ExecReleaseArtifactID`** now creates the destination config temp dir and **clones once** before `retry`, instead of re-cloning on every attempt when push races on `ErrBranchBehindOrigin`.
> 
> On retries (`attempt > 1`), after `flow.retry` syncs the shared master, the same destination working tree is refreshed via new **`ResetToOriginMaster`** (`git fetch origin master` + `git reset --hard origin/master`) on `GitService` / `internal/git`, then the existing copy/commit path runs again—avoiding repeated full master copies while keeping behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92a0497be0a77e5fbaa4d0013aad0616ce46604. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->