### PR TITLE
feat: add flow execution latency histogram

### DIFF
--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -406,6 +406,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 				Policy:                   &policySvc,
 				Tracer:                   tracer,
 				Copier:                   copier,
+				Observer:                 metricsObserver,
 				PublishReleaseArtifactID: nil,
 				PublishNewArtifact:       nil,
 				MaxRetries:               3, // retries for comitting changes into config repo can be required for racing writes

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -38,6 +38,13 @@ var (
 	ErrReleaseProhibited             = errors.New("release prohibited")
 )
 
+// FlowObserver records the duration of flow operations. operation is the flow
+// name, start is when the operation began, and err is its final error (nil on
+// success).
+type FlowObserver interface {
+	ObserveFlowDuration(operation string, start time.Time, err error)
+}
+
 type Service struct {
 	ArtifactFileName string
 	UserMappings     map[string]string
@@ -48,6 +55,9 @@ type Service struct {
 	Storage          ArtifactReadStorage
 	Policy           *policy.Service
 	Copier           *copy.Copier
+
+	// Observer records flow operation durations. May be nil; calls must be nil-safe.
+	Observer FlowObserver
 
 	PublishReleaseArtifactID func(context.Context, ReleaseArtifactIDEvent) error
 	PublishNewArtifact       func(context.Context, NewArtifactEvent) error

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/lunarway/release-manager/internal/artifact"
 	"github.com/lunarway/release-manager/internal/commitinfo"
@@ -136,10 +137,19 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 	return artifactID, nil
 }
 
-func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifactIDEvent) error {
+// ExecReleaseArtifactID executes the release of a specific artifact ID to the
+// target environment, retrying on transient git conflicts. It records total
+// elapsed time and final outcome via the service Observer (if non-nil).
+func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifactIDEvent) (err error) {
+	start := time.Now()
+	defer func() {
+		if s.Observer != nil {
+			s.Observer.ObserveFlowDuration("ExecReleaseArtifactID", start, err)
+		}
+	}()
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.ExecReleaseArtifactID")
 	defer span.Finish()
-	err := s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
+	err = s.retry(ctx, func(ctx context.Context, attempt int) (bool, error) {
 		service := event.Service
 		branch := event.Branch
 		environment := event.Environment
@@ -239,8 +249,5 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		logger.Infof("flow: ReleaseArtifactID: release committed: %s, ArtifactAuthor: %s, ReleaseAuthor: %s", releaseMessage, artifactAuthor, releaseAuthor)
 		return true, nil
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,14 +1,19 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Observer holds Prometheus metrics for the release manager.
 type Observer struct {
 	releaseCounter *prometheus.CounterVec
+	flowDuration   *prometheus.HistogramVec
 }
 
+// NewObserver creates and registers all Prometheus metrics.
 func NewObserver() *Observer {
 	return &Observer{
 		releaseCounter: promauto.NewCounterVec(prometheus.CounterOpts{
@@ -21,9 +26,15 @@ func NewObserver() *Observer {
 			"intent",
 			"squad",
 		}),
+		flowDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "release_manager_flow_duration_seconds",
+			Help:    "Duration of flow operations in seconds",
+			Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		}, []string{"operation", "outcome"}),
 	}
 }
 
+// Release holds the metadata for a single release event.
 type Release struct {
 	Environment string
 	Service     string
@@ -32,6 +43,7 @@ type Release struct {
 	Squad       string
 }
 
+// ObserveRelease increments the release counter for the given release metadata.
 func (o *Observer) ObserveRelease(release Release) {
 	o.releaseCounter.WithLabelValues(
 		release.Environment,
@@ -40,4 +52,15 @@ func (o *Observer) ObserveRelease(release Release) {
 		release.Intent,
 		release.Squad,
 	).Inc()
+}
+
+// ObserveFlowDuration records the elapsed time since start for a flow
+// operation, deriving the outcome label from err (success on nil, error
+// otherwise).
+func (o *Observer) ObserveFlowDuration(operation string, start time.Time, err error) {
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	o.flowDuration.WithLabelValues(operation, outcome).Observe(time.Since(start).Seconds())
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// newTestObserver builds an Observer whose flowDuration histogram is registered
+// against a fresh, isolated registry so tests can run in parallel without
+// triggering duplicate-registration panics.
+func newTestObserver(t *testing.T) (*Observer, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	hist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "release_manager_flow_duration_seconds",
+		Help:    "Duration of flow operations in seconds",
+		Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"operation", "outcome"})
+	reg.MustRegister(hist)
+	return &Observer{flowDuration: hist}, reg
+}
+
+// TestObserveFlowDuration verifies that ObserveFlowDuration maps nil errors to
+// the "success" outcome and non-nil errors to the "error" outcome, and that
+// exactly one sample is recorded per call.
+func TestObserveFlowDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		operation       string
+		err             error
+		expectedOutcome string
+	}{
+		{
+			name:            "nil error yields success outcome",
+			operation:       "deploy",
+			err:             nil,
+			expectedOutcome: "success",
+		},
+		{
+			name:            "non-nil error yields error outcome",
+			operation:       "rollback",
+			err:             errors.New("something went wrong"),
+			expectedOutcome: "error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obs, reg := newTestObserver(t)
+			obs.ObserveFlowDuration(tc.operation, time.Now(), tc.err)
+
+			mfs, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gather metrics: %v", err)
+			}
+
+			var found bool
+			for _, mf := range mfs {
+				if mf.GetName() != "release_manager_flow_duration_seconds" {
+					continue
+				}
+				for _, m := range mf.GetMetric() {
+					var op, outcome string
+					for _, lp := range m.GetLabel() {
+						switch lp.GetName() {
+						case "operation":
+							op = lp.GetValue()
+						case "outcome":
+							outcome = lp.GetValue()
+						}
+					}
+					if op == tc.operation && outcome == tc.expectedOutcome {
+						got := m.GetHistogram().GetSampleCount()
+						if got != 1 {
+							t.Errorf("expected sample count 1, got %d", got)
+						}
+						found = true
+					}
+				}
+			}
+			if !found {
+				t.Errorf("no metric found for operation=%q outcome=%q", tc.operation, tc.expectedOutcome)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Value

SREs and the squad can now see how long the heavy async release path (`ExecReleaseArtifactID`) takes — p50/p95/p99 duration split by success vs. error — in Grafana/Prometheus. Previously only a release *count* was exported; there was no latency signal for the git-heavy clone/commit/push flow.

## What changed

- **`internal/metrics/metrics.go`** — new `release_manager_flow_duration_seconds` histogram on `Observer`, with `operation`/`outcome` labels and buckets `.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60`s. New `ObserveFlowDuration(operation, start, err)` derives the outcome from the error (`success` on nil, `error` otherwise) and observes the elapsed time.
- **`internal/flow/flow.go`** — small nil-safe `FlowObserver` interface defined in the `flow` package (so existing `Service{}` tests don't need a real Prometheus registry) and a new `Observer` field on `Service`.
- **`internal/flow/release.go`** — `ExecReleaseArtifactID` converted to a named error return with a top-of-method `defer` that records duration + outcome. The timer wraps the **whole retry loop** (retries included).
- **`cmd/server/command/start.go`** — wired the existing `metrics.NewObserver()` into `flowSvc.Observer`.
- **`internal/metrics/metrics_test.go`** — table-driven test verifying outcome derivation and sample recording against an isolated registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with nil-safe wiring; no release, auth, or data-path behavior changes beyond timing metrics.
> 
> **Overview**
> Adds **Prometheus latency** for the async release path so SREs can see how long `ExecReleaseArtifactID` takes, split by **success vs error**.
> 
> A new `release_manager_flow_duration_seconds` histogram on `metrics.Observer` records elapsed time with `operation` and `outcome` labels (sub-second through 60s buckets). `flow.Service` gains an optional nil-safe `FlowObserver`; server startup passes the existing metrics observer into it. **`ExecReleaseArtifactID`** now defers a single observation that covers the **full retry loop** (git clone, copy, commit), not per attempt. Unit tests assert outcome labeling against an isolated registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b8678f20848ed51b9e85dae9d2f5c310497dc1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->