### PR TITLE
perf(git): rebase in place on push conflict instead of re-cloning

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -335,8 +335,33 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
-	defer span.End()
+	err = gitPush(ctx, rootPath)
+	span.End()
+	if err == nil {
+		return nil
+	}
+	if errors.Cause(err) != ErrBranchBehindOrigin {
+		return err
+	}
+	if rebaseErr := rebaseOntoOrigin(ctx, rootPath); rebaseErr != nil {
+		log.WithContext(ctx).WithFields("error", rebaseErr).Infof("git/Commit: rebase onto origin/master failed; falling back to outer retry")
+		return ErrBranchBehindOrigin
+	}
+	pushSpan, _ := s.Tracer.FromCtx(ctx, "push after rebase")
+	defer pushSpan.End()
 	return gitPush(ctx, rootPath)
+}
+
+// rebaseOntoOrigin fetches origin/master and rebases the current branch onto
+// it. Called after a push rejection to recover without re-cloning.
+func rebaseOntoOrigin(ctx context.Context, rootPath string) error {
+	if err := execCommand(ctx, rootPath, "git", "fetch", "origin", "master"); err != nil {
+		return errors.WithMessage(err, "fetch origin")
+	}
+	if err := execCommand(ctx, rootPath, "git", "rebase", "origin/master"); err != nil {
+		return errors.WithMessage(err, "rebase onto origin/master")
+	}
+	return nil
 }
 
 func (s *Service) SignedCommit(ctx context.Context, rootPath, changesPath, authorName, authorEmail, msg string) error {


### PR DESCRIPTION
## Summary

On a push rejection (`ErrBranchBehindOrigin`), `git.Commit` now rebases the existing temp clone onto `origin/master` and retries the push inline, instead of propagating the error and letting the outer retry loop re-clone the whole repo from scratch.

## Changes

- `git.Commit` (`internal/git/git.go`): after `gitPush` returns `ErrBranchBehindOrigin`, run `git fetch origin master && git rebase origin/master` in the existing working copy, then retry the push once
- `rebaseOntoOrigin`: new unexported helper that encapsulates the fetch + rebase sequence
- If the rebase fails, logs the error and returns `ErrBranchBehindOrigin` so the outer retry loop in `flow.go` handles it as before

## Why

From trace analysis (`docs/trace.md`), a conflicting release runs the full closure twice — re-cloning (~1.9s) + re-staging (~1.5s) + re-committing + re-pushing — because the outer retry in `flow.go` replays everything from scratch. The rebase path skips ~3.4s of that repeated work per conflict.

The outer retry loop (`flow.go:retry`) is preserved as a safety net for the rare case where the rebase itself has a conflict.

Closes DMAT-336

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release commit/push conflict handling on the critical master push path; rebase conflicts still fall back to the existing outer retry, but successful rebases alter timing and failure modes versus full re-clone.
> 
> **Overview**
> When a push is rejected because the branch is behind `origin`, **`git.Commit`** now tries to recover in the existing working copy instead of always surfacing `ErrBranchBehindOrigin` to the release flow.
> 
> On that specific error it runs **`rebaseOntoOrigin`** (`git fetch origin master` + `git rebase origin/master`), then pushes once more. If rebase fails, it logs and still returns **`ErrBranchBehindOrigin`** so **`flow.retry`** can sync master and replay the full clone/commit path as before.
> 
> **`SignedCommit`** is unchanged and still pushes without this inline rebase path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89fd1934f04144217bd3fae93dda36fa056f1416. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->