### PR TITLE
perf(git): use shallow clone for working-tree operations

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -112,6 +112,7 @@ type NotifyReleaseFailedOptions struct {
 type GitService interface {
 	SyncMaster(context.Context) error
 	Clone(context.Context, string) (*git.Repository, error)
+	ShallowClone(ctx context.Context, destination string) error
 	MasterPath() string
 	Commit(ctx context.Context, rootPath, changesPath, msg string) error
 	LocateServiceReleaseRollbackSkip(ctx context.Context, r *git.Repository, env, service string, n uint) (plumbing.Hash, error)

--- a/internal/flow/mock_GitService.go
+++ b/internal/flow/mock_GitService.go
@@ -53,6 +53,20 @@ func (_m *MockGitService) Clone(_a0 context.Context, _a1 string) (*git.Repositor
 	return r0, r1
 }
 
+// ShallowClone provides a mock function with given fields: ctx, destination
+func (_m *MockGitService) ShallowClone(ctx context.Context, destination string) error {
+	ret := _m.Called(ctx, destination)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, destination)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Commit provides a mock function with given fields: ctx, rootPath, changesPath, msg
 func (_m *MockGitService) Commit(ctx context.Context, rootPath string, changesPath string, msg string) error {
 	ret := _m.Called(ctx, rootPath, changesPath, msg)

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -109,7 +109,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		return "", err
 	}
 	defer closeDestinationSource(ctx)
-	_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
+	err = s.Git.ShallowClone(ctx, destinationConfigRepoPath)
 	if err != nil {
 		return "", errors.WithMessagef(err, "clone into '%s'", destinationConfigRepoPath)
 	}
@@ -171,7 +171,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 		}
 		defer closeDestination(ctx)
 
-		_, err = s.Git.Clone(ctx, destinationConfigRepoPath)
+		err = s.Git.ShallowClone(ctx, destinationConfigRepoPath)
 		if err != nil {
 			return true, errors.WithMessagef(err, "clone destination repo into '%s'", destinationConfigRepoPath)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -139,17 +139,11 @@ func (s *Service) ShallowClone(ctx context.Context, destination string) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.ShallowClone")
 	defer span.End()
 
-	span, _ = s.Tracer.FromCtx(ctx, "remove destination")
-	err := os.RemoveAll(destination)
-	span.End()
+	unlock, err := s.prepareDestination(ctx, destination)
 	if err != nil {
-		return errors.WithMessage(err, "remove existing destination")
+		return err
 	}
-
-	span, _ = s.Tracer.FromCtx(ctx, "lock mutex")
-	s.masterMutex.RLock()
-	defer s.masterMutex.RUnlock()
-	span.End()
+	defer unlock()
 
 	span, _ = s.Tracer.FromCtx(ctx, "shallow clone")
 	err = execCommand(ctx, filepath.Dir(destination), "git", "clone", "--depth", "1", "--local", s.masterPath, destination)
@@ -171,16 +165,13 @@ func (s *Service) ShallowClone(ctx context.Context, destination string) error {
 func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repository, error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.copyMaster")
 	defer span.End()
-	span, _ = s.Tracer.FromCtx(ctx, "remove destination")
-	err := os.RemoveAll(destination)
-	span.End()
+
+	unlock, err := s.prepareDestination(ctx, destination)
 	if err != nil {
-		return nil, errors.WithMessage(err, "remove existing destination")
+		return nil, err
 	}
-	span, _ = s.Tracer.FromCtx(ctx, "lock mutex")
-	s.masterMutex.RLock()
-	defer s.masterMutex.RUnlock()
-	span.End()
+	defer unlock()
+
 	span, _ = s.Tracer.FromCtx(ctx, "copy to destination")
 	err = s.Copier.CopyDir(ctx, s.MasterPath(), destination)
 	span.End()
@@ -194,6 +185,21 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 		return nil, errors.WithMessage(err, "open repo")
 	}
 	return r, nil
+}
+
+// prepareDestination removes destination and acquires the master read lock.
+// The caller must defer the returned unlock function.
+func (s *Service) prepareDestination(ctx context.Context, destination string) (func(), error) {
+	span, _ := s.Tracer.FromCtx(ctx, "remove destination")
+	err := os.RemoveAll(destination)
+	span.End()
+	if err != nil {
+		return nil, errors.WithMessage(err, "remove existing destination")
+	}
+	span, _ = s.Tracer.FromCtx(ctx, "lock mutex")
+	s.masterMutex.RLock()
+	span.End()
+	return s.masterMutex.RUnlock, nil
 }
 
 func (s *Service) Checkout(ctx context.Context, rootPath string, hash plumbing.Hash) error {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -129,6 +130,42 @@ func (s *Service) Clone(ctx context.Context, destination string) (*git.Repositor
 	span, ctx := s.Tracer.FromCtx(ctx, "git.Clone")
 	defer span.End()
 	return s.copyMaster(ctx, destination)
+}
+
+// ShallowClone creates a depth-1 local clone of the master repository into destination.
+// It sets the remote URL to ConfigRepoURL so subsequent pushes reach the real origin.
+// Use this when the caller only needs the working tree (commit+push), not git history.
+func (s *Service) ShallowClone(ctx context.Context, destination string) error {
+	span, ctx := s.Tracer.FromCtx(ctx, "git.ShallowClone")
+	defer span.End()
+
+	span, _ = s.Tracer.FromCtx(ctx, "remove destination")
+	err := os.RemoveAll(destination)
+	span.End()
+	if err != nil {
+		return errors.WithMessage(err, "remove existing destination")
+	}
+
+	span, _ = s.Tracer.FromCtx(ctx, "lock mutex")
+	s.masterMutex.RLock()
+	defer s.masterMutex.RUnlock()
+	span.End()
+
+	span, _ = s.Tracer.FromCtx(ctx, "shallow clone")
+	err = execCommand(ctx, filepath.Dir(destination), "git", "clone", "--depth", "1", "--local", s.masterPath, destination)
+	span.End()
+	if err != nil {
+		return errors.WithMessagef(err, "shallow clone master from '%s'", s.masterPath)
+	}
+
+	span, _ = s.Tracer.FromCtx(ctx, "set remote url")
+	err = execCommand(ctx, destination, "git", "remote", "set-url", "origin", s.ConfigRepoURL)
+	span.End()
+	if err != nil {
+		return errors.WithMessage(err, "set remote url")
+	}
+
+	return nil
 }
 
 func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repository, error) {

--- a/internal/policy/branch_restriction_test.go
+++ b/internal/policy/branch_restriction_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	git "github.com/go-git/go-git/v5"
 	"github.com/lunarway/release-manager/internal/copy"
 	"github.com/lunarway/release-manager/internal/log"
 	"github.com/lunarway/release-manager/internal/tracing"
@@ -255,15 +254,15 @@ func TestService_ApplyBranchRestriction(t *testing.T) {
 				}
 				return "testdata"
 			})
-			gitService.On("Clone", mock.Anything, mock.Anything).Return(func(ctx context.Context, path string) *git.Repository {
+			gitService.On("ShallowClone", mock.Anything, mock.Anything).Return(func(ctx context.Context, path string) error {
 				// store the destination path. It will be a temporary directory so we
 				// need it to later inspect the results of the operation
 				destinationPath = path
 				// copy testdata into path faking a master clone
 				err := copy.New(logger).CopyDir(ctx, "testdata", path)
-				assert.NoError(t, err, "unexpected error when copying in Clone")
+				assert.NoError(t, err, "unexpected error when copying in ShallowClone")
 				return nil
-			}, nil)
+			})
 			gitService.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			s := Service{
 				Tracer:                          tracing.NewNoop(),

--- a/internal/policy/mock_GitService.go
+++ b/internal/policy/mock_GitService.go
@@ -5,7 +5,6 @@ package policy
 import (
 	context "context"
 
-	git "github.com/go-git/go-git/v5"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -14,27 +13,18 @@ type MockGitService struct {
 	mock.Mock
 }
 
-// Clone provides a mock function with given fields: _a0, _a1
-func (_m *MockGitService) Clone(_a0 context.Context, _a1 string) (*git.Repository, error) {
-	ret := _m.Called(_a0, _a1)
+// ShallowClone provides a mock function with given fields: ctx, destination
+func (_m *MockGitService) ShallowClone(ctx context.Context, destination string) error {
+	ret := _m.Called(ctx, destination)
 
-	var r0 *git.Repository
-	if rf, ok := ret.Get(0).(func(context.Context, string) *git.Repository); ok {
-		r0 = rf(_a0, _a1)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, destination)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*git.Repository)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Commit provides a mock function with given fields: ctx, rootPath, changesPath, msg

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	git "github.com/go-git/go-git/v5"
 	"github.com/lunarway/release-manager/internal/commitinfo"
 	internalgit "github.com/lunarway/release-manager/internal/git"
 	"github.com/lunarway/release-manager/internal/log"
@@ -41,7 +40,7 @@ type Service struct {
 
 type GitService interface {
 	MasterPath() string
-	Clone(context.Context, string) (*git.Repository, error)
+	ShallowClone(ctx context.Context, destination string) error
 	Commit(ctx context.Context, rootPath, changesPath, msg string) error
 }
 
@@ -210,7 +209,7 @@ func (s *Service) updatePolicies(ctx context.Context, actor Actor, svc, commitMs
 		// file flags used. This is to avoid opening and closing to file multiple
 		// times during the operation.
 		logger.Debugf("internal/policy: clone config repository")
-		_, err = s.Git.Clone(ctx, configRepoPath)
+		err = s.Git.ShallowClone(ctx, configRepoPath)
 		if err != nil {
 			return true, errors.WithMessage(err, fmt.Sprintf("clone to '%s'", configRepoPath))
 		}


### PR DESCRIPTION
## Summary

Replace the full `cp -a` master repo copy (including `.git/` history) with a `git clone --depth 1 --local` for callers that only need to commit and push a single file. Saves ~1.9s on every release, conflict or not.

## Changes

- Add `ShallowClone(ctx, destination string) error` to `git.Service` — runs `git clone --depth 1 --local <masterPath> <destination>` then fixes the remote URL to `ConfigRepoURL` so subsequent pushes reach the real origin
- Add `ShallowClone` to `GitService` interface in both `flow` and `policy` packages
- Update 3 callers to use `ShallowClone`: `release.go` ×2, `policy.go`
- `describe_release.go` keeps using `Clone` since it walks the git log
- Remove now-unused `Clone` from `policy.GitService` interface and mock
- Update `branch_restriction_test.go` mock expectation accordingly

## Why

From `docs/trace.md`: `copyMaster` copies the full `.git/` history on every release (~1.9s). The per-release working dir only needs to commit one file and push — it never traverses history. This is fix #2 of 4 low-hanging-fruit items identified in the trace.

Closes DMAT-338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release and policy commit/push paths; behavior should match prior flows but shallow clones differ from full copies if anything relied on full history in those temp dirs.
> 
> **Overview**
> Adds **`ShallowClone`** on `git.Service`: a depth-1 local clone from the in-memory master (`git clone --depth 1 --local`) followed by resetting `origin` to `ConfigRepoURL`, so commit/push still hit the real remote without copying full `.git` history.
> 
> **Release** and **policy** paths that only need a writable tree now call `ShallowClone` instead of full `Clone`/`copyMaster` (`release.go` for pre-check and `ExecReleaseArtifactID`, `policy.updatePolicies`). **`describe_release`** still uses **`Clone`** because it walks history. The **`policy.GitService`** interface drops `Clone` in favor of `ShallowClone`; flow keeps both. Mocks and `branch_restriction_test` expectations are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61cca8abe6e7118d9ff1de29d9b52b329215e93c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->