### PR TITLE
fix(git): rebase onto synced master mirror on push conflict

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -386,8 +386,8 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	if errors.Cause(err) != ErrBranchBehindOrigin {
 		return err
 	}
-	if rebaseErr := rebaseOntoOrigin(ctx, s.Tracer, rootPath); rebaseErr != nil {
-		log.WithContext(ctx).WithFields("error", rebaseErr).Infof("git/Commit: rebase onto origin/master failed; falling back to outer retry")
+	if rebaseErr := s.rebaseOntoMaster(ctx, rootPath); rebaseErr != nil {
+		log.WithContext(ctx).WithFields("error", rebaseErr).Infof("git/Commit: rebase onto master failed; falling back to outer retry")
 		return ErrBranchBehindOrigin
 	}
 	pushSpan, _ := s.Tracer.FromCtx(ctx, "push after rebase")
@@ -395,19 +395,39 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	return gitPush(ctx, rootPath)
 }
 
-// rebaseOntoOrigin fetches origin/master and rebases the current branch onto
-// it. Called after a push rejection to recover without re-cloning.
-func rebaseOntoOrigin(ctx context.Context, tracer tracing.Tracer, rootPath string) error {
-	fetchSpan, ctx := tracer.FromCtx(ctx, "fetch origin for rebase")
-	err := execCommand(ctx, rootPath, "git", "fetch", "origin", "master")
+// rebaseOntoMaster refreshes the local master mirror, then fetches from it and
+// rebases the working tree at rootPath onto the updated master. Called after a
+// push rejection to recover in place without re-cloning.
+//
+// The fetch targets the local mirror rather than the remote origin on purpose:
+// the working tree is a depth-1 shallow clone, so a fetch from the remote
+// origin would also be shallow and leave the branch without a merge base,
+// failing the rebase. The mirror shares full history with the working tree, so
+// the merge base is available locally and the fetch costs no network round
+// trip.
+func (s *Service) rebaseOntoMaster(ctx context.Context, rootPath string) error {
+	span, ctx := s.Tracer.FromCtx(ctx, "git.rebaseOntoMaster")
+	defer span.End()
+
+	if err := s.SyncMaster(ctx); err != nil {
+		return errors.WithMessage(err, "sync master mirror")
+	}
+
+	s.masterMutex.RLock()
+	masterPath := s.masterPath
+	s.masterMutex.RUnlock()
+
+	fetchSpan, fetchCtx := s.Tracer.FromCtx(ctx, "fetch master for rebase")
+	err := execCommand(fetchCtx, rootPath, "git", "fetch", masterPath, "master")
 	fetchSpan.End()
 	if err != nil {
-		return errors.WithMessage(err, "fetch origin")
+		return errors.WithMessage(err, "fetch master mirror")
 	}
-	rebaseSpan, ctx := tracer.FromCtx(ctx, "rebase onto origin/master")
-	err = execCommand(ctx, rootPath, "git", "rebase", "origin/master")
+
+	rebaseSpan, rebaseCtx := s.Tracer.FromCtx(ctx, "rebase onto master")
+	err = execCommand(rebaseCtx, rootPath, "git", "rebase", "FETCH_HEAD")
 	rebaseSpan.End()
-	return errors.WithMessage(err, "rebase onto origin/master")
+	return errors.WithMessage(err, "rebase onto master")
 }
 
 func (s *Service) SignedCommit(ctx context.Context, rootPath, changesPath, authorName, authorEmail, msg string) error {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -413,13 +413,15 @@ func (s *Service) rebaseOntoMaster(ctx context.Context, rootPath string) error {
 		return errors.WithMessage(err, "sync master mirror")
 	}
 
+	// Hold the read lock across the fetch so a concurrent SyncMaster cannot
+	// mutate the mirror mid-fetch, matching the locking convention used by
+	// ShallowClone and copyMaster. The subsequent rebase only touches rootPath
+	// and FETCH_HEAD, so it runs without the lock.
 	s.masterMutex.RLock()
-	masterPath := s.masterPath
-	s.masterMutex.RUnlock()
-
 	fetchSpan, fetchCtx := s.Tracer.FromCtx(ctx, "fetch master for rebase")
-	err := execCommand(fetchCtx, rootPath, "git", "fetch", masterPath, "master")
+	err := execCommand(fetchCtx, rootPath, "git", "fetch", s.masterPath, "master")
 	fetchSpan.End()
+	s.masterMutex.RUnlock()
 	if err != nil {
 		return errors.WithMessage(err, "fetch master mirror")
 	}

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -1,0 +1,118 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestMain(m *testing.M) {
+	log.Init(&log.Configuration{
+		Level:       log.Level{Level: zapcore.DebugLevel},
+		Development: true,
+	})
+	os.Exit(m.Run())
+}
+
+// TestCommitRebasesOntoSyncedMirrorOnConflict reproduces the release-flow
+// conflict path: a depth-1 shallow working clone whose local master mirror is
+// stale relative to origin. On push rejection Commit must refresh the mirror,
+// rebase the working tree onto it, and re-push in place without falling back to
+// a full re-clone. The mirror ending up with the upstream commit is what proves
+// the in-place sync+rebase recovery ran.
+func TestCommitRebasesOntoSyncedMirrorOnConflict(t *testing.T) {
+	// Isolate from the developer's global/system git config (e.g. commit.gpgsign)
+	// so the production exec paths behave deterministically.
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	ctx := context.Background()
+	root := t.TempDir()
+
+	originDir := filepath.Join(root, "origin")
+	seedDir := filepath.Join(root, "seed")
+	mirrorDir := filepath.Join(root, "mirror")
+	workDir := filepath.Join(root, "work")
+
+	// Bare origin (stands in for the config repo) with an initial commit.
+	runGit(t, root, "init", "--bare", "-b", "master", originDir)
+	runGit(t, root, "clone", originDir, seedDir)
+	configureIdentity(t, seedDir)
+	writeFile(t, seedDir, "a.txt", "a")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add a")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	// Full-history local mirror (Service.masterPath) cloned from origin.
+	runGit(t, root, "clone", originDir, mirrorDir)
+
+	// Depth-1 shallow working clone from the mirror, then point origin at the
+	// real config repo, exactly as ShallowClone does.
+	runGit(t, root, "clone", "--depth", "1", "--local", mirrorDir, workDir)
+	runGit(t, workDir, "remote", "set-url", "origin", originDir)
+	configureIdentity(t, workDir)
+
+	// An upstream commit lands on origin after the mirror and working clone were
+	// taken, leaving both stale.
+	writeFile(t, seedDir, "b.txt", "b")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add b")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	// The release change in the working tree.
+	writeFile(t, workDir, "c.txt", "c")
+
+	s := &Service{
+		Tracer:        tracing.NewNoop(),
+		Config:        &GitConfig{User: "test", Email: "test@example.com"},
+		ConfigRepoURL: originDir,
+		masterPath:    mirrorDir,
+	}
+
+	err := s.Commit(ctx, workDir, ".", "[env/svc] release c")
+	require.NoError(t, err, "commit should recover from the push conflict in place")
+
+	// Origin now carries the upstream commit and the release commit: the working
+	// tree was rebased and re-pushed, not abandoned.
+	assert.FileExists(t, filepath.Join(seedDir, "a.txt"))
+	pullLatest(t, seedDir)
+	assert.FileExists(t, filepath.Join(seedDir, "b.txt"))
+	assert.FileExists(t, filepath.Join(seedDir, "c.txt"))
+
+	// The mirror was synced as part of the recovery. The old rebase-onto-origin
+	// path never touched the mirror, so this is the behavioural discriminator.
+	assert.FileExists(t, filepath.Join(mirrorDir, "b.txt"),
+		"recovery must sync the local master mirror")
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, out)
+}
+
+func configureIdentity(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "user.name", "test")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+}
+
+func pullLatest(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "pull", "origin", "master")
+}


### PR DESCRIPTION
## Summary

Fixes a release-latency regression where two prior optimizations interact badly. [#623](https://github.com/lunarway/release-manager/pull/623) added rebase-in-place recovery on git push conflicts; [#624](https://github.com/lunarway/release-manager/pull/624) switched working-tree clones to `git clone --depth 1`. Together they made the conflict path *slower* than before #623.

A production Tempo trace (`flow.ExecReleaseArtifactID`) showed a conflicting release taking **20s**:

- The depth-1 shallow working clone fetched from the **network origin** for the rebase. That fetch stays shallow → no merge base → `git rebase` fails.
- Recovery fell back to the outer retry's `SyncMaster` + a **full re-clone + re-commit + re-push**.
- The trace also showed the local master mirror is **stale at conflict time** — the conflict was only resolved after `SyncMaster` pulled the upstream commit.

## Fix

`rebaseOntoMaster` (was `rebaseOntoOrigin`) now recovers in place:

1. `SyncMaster()` — refresh the full-history local mirror from origin (it's stale at conflict time).
2. `git fetch <masterPath> master` — local fetch from the mirror; shares full history with the shallow working tree, so a merge base exists and there's **no network round trip**.
3. `git rebase FETCH_HEAD`, then re-push.

If the re-push is still rejected (another concurrent push), the existing outer retry recovers — behaviour preserved.



Refs: [DMAT-336](https://linear.app/lunar/issue/DMAT-336)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release commit/push conflict recovery and master-mirror locking; failures still fall back to the outer retry, but incorrect rebase behavior could affect config-repo pushes.
> 
> **Overview**
> When `Commit` hits a push rejection (`ErrBranchBehindOrigin`), recovery no longer runs `git fetch origin master` + `git rebase origin/master`. It now calls **`rebaseOntoMaster`** on `git.Service`: **`SyncMaster()`** refreshes the full-history local mirror, then the shallow working tree **fetches `master` from `masterPath`** (under `masterMutex` RLock) and **rebases onto `FETCH_HEAD`**, then pushes again.
> 
> This targets depth-1 shallow clones: a network fetch from `origin` stays shallow and often lacks a merge base, so rebase failed and the flow fell back to a full re-clone path. Fetching from the synced mirror is local and shares history with the working tree.
> 
> Adds **`rebase_test.go`** with an integration test that simulates stale mirror + upstream commit and asserts in-place sync, rebase, re-push (including mirror updated with upstream).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3345b5aae71ef187468d311b28c48e17b7713123. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->