### PR TITLE
feat(broker): broadcast config changes to all replicas via fanout

### DIFF
--- a/cmd/server/command/root.go
+++ b/cmd/server/command/root.go
@@ -94,6 +94,7 @@ func NewRoot(version string) (*cobra.Command, error) {
 	command.PersistentFlags().StringVar(&configRepoOpts.ConfigRepo, "config-repo", os.Getenv("CONFIG_REPO"), "ssh url for the git config repository")
 	command.PersistentFlags().StringVar(&configRepoOpts.ArtifactFileName, "artifact-filename", "artifact.json", "the filename of the artifact to be used")
 	command.PersistentFlags().StringVar(&configRepoOpts.SSHPrivateKeyPath, "ssh-private-key", "/etc/release-manager/ssh/identity", "ssh-private-key for the config repo")
+	command.PersistentFlags().DurationVar(&configRepoOpts.SyncInterval, "config-repo-sync-interval", 60*time.Second, "interval at which each replica re-syncs its local config repo clone as a safety net for missed config-changed broadcasts")
 	command.PersistentFlags().StringVar(&jwtVerifierOpts.JwksLocation, "jwks-urls", "", "URL of the JWKS for the IdP")
 	command.PersistentFlags().StringVar(&jwtVerifierOpts.Audience, "jwt-audience", "release-manager", "the expected audience of the access token")
 	command.PersistentFlags().StringVar(&jwtVerifierOpts.Issuer, "jwt-issuer", "", "the issuer of the access tokens")
@@ -139,6 +140,7 @@ func registerBrokerFlags(cmd *cobra.Command, c *brokerOptions) {
 	cmd.PersistentFlags().IntVar(&c.AMQP.Prefetch, "amqp-prefetch", 1, "AMQP queue prefetch")
 	cmd.PersistentFlags().StringVar(&c.AMQP.Exchange, "amqp-exchange", "release-manager", "AMQP exchange")
 	cmd.PersistentFlags().StringVar(&c.AMQP.Queue, "amqp-queue", "release-manager", "AMQP queue")
+	cmd.PersistentFlags().StringVar(&c.AMQP.BroadcastExchange, "amqp-broadcast-exchange", "release-manager-broadcast", "AMQP fanout exchange used to broadcast config-changed notifications to all replicas")
 }
 
 func registerGitFlags(cmd *cobra.Command, opts *git.GitConfig) {

--- a/cmd/server/command/start.go
+++ b/cmd/server/command/start.go
@@ -80,6 +80,7 @@ type amqpOptions struct {
 	Prefetch            int
 	Exchange            string
 	Queue               string
+	BroadcastExchange   string
 }
 
 type memoryOptions struct {
@@ -90,6 +91,7 @@ type configRepoOptions struct {
 	ConfigRepo        string
 	ArtifactFileName  string
 	SSHPrivateKeyPath string
+	SyncInterval      time.Duration
 }
 
 type s3storageOptions struct {
@@ -514,6 +516,9 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			flowSvc.PublishNewArtifact = func(ctx context.Context, event flow.NewArtifactEvent) error {
 				return brokerImpl.Publish(ctx, &event)
 			}
+			publishConfigChanged := func(ctx context.Context, sha string) error {
+				return brokerImpl.PublishBroadcast(ctx, &events.ConfigChangedEvent{SHA: sha})
+			}
 			defer func() {
 				err := brokerImpl.Close()
 				if err != nil {
@@ -535,6 +540,7 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 					s3storageSvc,
 					tracer,
 					jwtVerifier,
+					publishConfigChanged,
 				)
 				if err != nil {
 					done <- errors.WithMessage(err, "new http server")
@@ -544,6 +550,44 @@ func NewStart(startOptions *startOptions) *cobra.Command {
 			go func() {
 				err := brokerImpl.StartConsumer(eventHandlers, errorHandler)
 				done <- errors.WithMessage(err, "broker")
+			}()
+			// Broadcast consumer: keep this replica's local clone fresh by syncing
+			// on every config-changed broadcast. Skip the sync when the local clone
+			// already points at the broadcast SHA (e.g. our own self-delivered
+			// message or a coalesced duplicate push).
+			go func() {
+				err := brokerImpl.StartBroadcastConsumer(func(body []byte) error {
+					var event events.ConfigChangedEvent
+					if err := event.Unmarshal(body); err != nil {
+						return errors.WithMessage(err, "unmarshal config changed event")
+					}
+					currentSHA, err := gitSvc.MasterHash(ctx)
+					if err == nil && currentSHA == event.SHA {
+						log.WithContext(ctx).Debugf("Config change broadcast for %s already applied, skipping sync", event.SHA)
+						return nil
+					}
+					return gitSvc.SyncMaster(ctx)
+				})
+				done <- errors.WithMessage(err, "broadcast consumer")
+			}()
+			// Background sync ticker: a coarse safety net that heals missed
+			// broadcasts (reconnects, cold-start window before the queue is bound).
+			// Broadcasts deliver the sub-second freshness; this only bounds staleness.
+			syncCtx, cancelSync := context.WithCancel(ctx)
+			defer cancelSync()
+			go func() {
+				ticker := time.NewTicker(startOptions.configRepo.SyncInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-syncCtx.Done():
+						return
+					case <-ticker.C:
+						if err := gitSvc.SyncMaster(syncCtx); err != nil {
+							log.WithContext(syncCtx).Errorf("background config repo sync failed: %v", err)
+						}
+					}
+				}
 			}()
 			if s3storageSvc != nil {
 				sqsHandler := func(msg string) error {
@@ -630,6 +674,7 @@ func getBroker(c *brokerOptions) (broker.Broker, error) {
 			InitTimeout:         amqpOptions.InitTimeout,
 			Exchange:            amqpOptions.Exchange,
 			Queue:               amqpOptions.Queue,
+			BroadcastExchange:   amqpOptions.BroadcastExchange,
 			RoutingKey:          "#",
 			Prefetch:            amqpOptions.Prefetch,
 			Logger:              log.With("system", "amqp"),

--- a/cmd/server/http/github_webhook.go
+++ b/cmd/server/http/github_webhook.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/go-playground/webhooks.v5/github"
 )
 
-func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyinternal.Service, gitSvc *git.Service, slackClient *slack.Client, githubWebhookSecret string) http.HandlerFunc {
+func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyinternal.Service, gitSvc *git.Service, slackClient *slack.Client, githubWebhookSecret string, publishConfigChanged func(ctx context.Context, sha string) error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// copy span from request context but ignore any deadlines on the request context
 		ctx := oteltrace.ContextWithSpan(context.Background(), oteltrace.SpanFromContext(r.Context()))
@@ -38,6 +38,18 @@ func githubWebhook(payload *payload, flowSvc *flow.Service, policySvc *policyint
 				logger.Errorf("http: github webhook: failed to sync master: %v", err)
 				w.WriteHeader(http.StatusOK)
 				return
+			}
+			// Broadcast the new HEAD so the other replicas sync their local clone
+			// too. A failure here only affects propagation speed (the ticker still
+			// heals it), so we log it and still return 200.
+			sha, err := gitSvc.MasterHash(ctx)
+			if err != nil {
+				logger.Errorf("http: github webhook: failed to read master hash: %v", err)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if err := publishConfigChanged(ctx, sha); err != nil {
+				logger.Errorf("http: github webhook: failed to broadcast config change: %v", err)
 			}
 			w.WriteHeader(http.StatusOK)
 			return

--- a/cmd/server/http/http.go
+++ b/cmd/server/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -29,7 +30,7 @@ type Options struct {
 	S3WebhookSecret     string
 }
 
-func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, policySvc *policyinternal.Service, gitSvc *git.Service, artifactWriteStorage ArtifactWriteStorage, tracer tracing.Tracer, jwtVerifier *Verifier) error {
+func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, policySvc *policyinternal.Service, gitSvc *git.Service, artifactWriteStorage ArtifactWriteStorage, tracer tracing.Tracer, jwtVerifier *Verifier, publishConfigChanged func(ctx context.Context, sha string) error) error {
 	payloader := payload{
 		tracer: tracer,
 	}
@@ -78,7 +79,7 @@ func NewServer(opts *Options, slackClient *slack.Client, flowSvc *flow.Service, 
 
 	m.HandleFunc("/ping", ping)
 	m.Handle("/metrics", promhttp.Handler())
-	m.HandleFunc("/webhook/github", githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret))
+	m.HandleFunc("/webhook/github", githubWebhook(&payloader, flowSvc, policySvc, gitSvc, slackClient, opts.GithubWebhookSecret, publishConfigChanged))
 
 	s := http.Server{
 		Addr:              fmt.Sprintf(":%d", opts.Port),

--- a/docs/multi-replica-analysis.md
+++ b/docs/multi-replica-analysis.md
@@ -1,0 +1,290 @@
+# Running release-manager as multiple replicas
+
+**Status:** Analysis — not yet implemented
+**Date:** 2026-06-09
+**Question:** What does it take to run multiple replicas of the release-manager so it answers correctly on its APIs and handles its flows?
+
+---
+
+## Goals
+
+1. **Run N replicas of the release-manager safely.** The fleet must tolerate losing any
+   single replica (rolling deploys, node failure, OOM) without losing correctness or
+   availability of either reads or flows.
+2. **Every read endpoint returns fresh data from every replica.** A client hitting
+   `/status`, `/describe/*`, or `/policies` must get the same, up-to-date answer no
+   matter which replica the load balancer routes it to — no stale-read window that
+   depends on which pod received the last git webhook.
+3. **Achieve freshness via near-instant fanout propagation.** On every config-repo push,
+   *all* replicas sync their local clone, driven by a fanout broadcast of the
+   config-changed notification — not a per-request git fetch (too slow on the read path)
+   and not only a coarse background ticker (too stale).
+4. **Preserve serialized, HA write flows.** Releases and artifact processing stay
+   effectively serialized fleet-wide with automatic failover, with no change to the
+   existing quorum + single-active-consumer queue.
+5. **No new stateful infrastructure.** Multi-replica support must work with a plain
+   `Deployment` and per-pod ephemeral storage — no StatefulSet, no shared volume, no
+   database.
+
+### Non-goals
+
+- **Parallel write throughput.** The service pushes to a single `master` branch; N
+  replicas buy HA failover, not concurrent writes. Removing single-active-consumer is
+  explicitly out of scope.
+- **Strong read-after-write consistency on a per-request basis.** We accept a small,
+  bounded propagation delay (sub-second to low seconds) between a push and all replicas
+  reflecting it, rather than syncing synchronously on every read.
+
+### Success criteria
+
+- [ ] With `replicas: N` (N ≥ 3) behind the load balancer, the same read request issued
+      repeatedly returns identical, current data regardless of which replica serves it.
+- [ ] After a config-repo push, **all** replicas reflect the change within a bounded
+      target (e.g. **< 2s** p99), measured end-to-end from webhook receipt to a fresh
+      read on the replica that did *not* receive the webhook.
+- [ ] Killing the replica that currently holds the active flow consumer causes another
+      replica to take over and continue processing releases/artifacts with no manual
+      intervention and no duplicate pushes.
+- [ ] Read-endpoint p99 latency does **not** regress versus single-replica today (i.e.
+      freshness is not bought with a per-request git fetch).
+- [ ] A newly started / rejoining replica converges to fresh data without operator
+      action (initial clone on boot, then fanout updates).
+
+---
+
+## TL;DR
+
+- **Flows (releases, artifacts) are already multi-replica safe.** The AMQP queue is a
+  quorum queue declared with `x-single-active-consumer: true`, so across the whole
+  fleet only one replica processes at a time, with automatic failover. Running N
+  replicas gives **HA failover, not write throughput** — which is correct for a
+  service that pushes to a single git branch. **Do not remove single-active-consumer.**
+- **Reads are the blocker.** The read APIs serve from a per-replica local clone of the
+  config repo that is refreshed **only** by the inbound GitHub push webhook. A load
+  balancer delivers each webhook to exactly one replica, so the other replicas serve
+  **stale** data indefinitely.
+- **The one real fix:** make every replica keep its own clone fresh by **fanout-broadcasting
+  config-changed notifications** so all replicas sync immediately on push (see Goals). A
+  background ticker is a simpler fallback but only bounds staleness coarsely. Deployment-wise
+  a plain `Deployment` with `emptyDir` is sufficient — no StatefulSet, no shared volume.
+
+---
+
+## Architecture context
+
+The release-manager has **no database**. Its sources of truth are:
+
+- the **config git repo** (remote) — releases, policies, status
+- **S3** — artifacts
+
+On startup each replica clones the config repo into a **local temp dir**
+(`internal/git/git.go:55` `InitMasterRepo`), guarded by a per-process
+`sync.RWMutex` (`internal/git/git.go:46`). Every API read and every write copies
+*that local clone* (`copyMaster`, `git.go:134`) and operates on the copy.
+
+**This single fact drives everything:** the local clone is per-replica state, and
+correctness depends entirely on keeping each replica's clone fresh.
+
+---
+
+## Writes / flows — already safe across replicas
+
+The AMQP queue is declared as a **quorum queue with `x-single-active-consumer: true`**:
+
+```go
+// internal/amqp/consumer.go:121
+queueArgs := amqp.Table{
+    "x-queue-type":             "quorum",
+    "x-single-active-consumer": true,
+}
+```
+
+Across *all* connected replicas, RabbitMQ allows only **one** consumer to process at a
+time, failing over to another consumer if the active one dies. Combined with the
+git-push-conflict retry (`internal/flow/flow.go:124` → `SyncMaster` on
+`ErrBranchBehindOrigin`), release and artifact flows are effectively serialized
+fleet-wide.
+
+**Implication:** N replicas buy you HA failover, not parallel write throughput. That is
+the correct design — the service pushes to a single `master` branch on the config repo.
+
+> ⚠️ **Do not** remove `x-single-active-consumer` to "enable scaling." It would let
+> multiple replicas push to the config repo concurrently, increasing push contention
+> for no benefit.
+
+---
+
+## Reads — the actual blocker
+
+The read APIs (`/status`, `/describe/*`, `/policies`) **do not sync before reading**.
+`SyncMaster` is only called from two places:
+
+- the GitHub push webhook handler (`cmd/server/http/github_webhook.go:36`)
+- the write-conflict retry path (`internal/flow/flow.go:130`)
+
+Reads simply copy the local master clone and walk the git log. The local clone is
+refreshed **only** when this replica receives a GitHub push webhook.
+
+With a load balancer in front of N replicas, GitHub delivers each push webhook to
+**exactly one** replica:
+
+```
+Replica A receives webhook → SyncMaster → serves fresh data
+Replicas B, C            → never sync   → serve STALE releases/policies indefinitely
+```
+
+This is why a naive `replicas: 3` makes the API return different/wrong answers
+depending on which pod the request lands on.
+
+---
+
+## What it takes to run multiple replicas correctly
+
+1. **Keep every replica's clone fresh** (the core fix). **Chosen approach: fanout
+   broadcast.**
+   - **Fanout broadcast (chosen)** of config-changed notifications via a dedicated
+     exchange with a **per-replica exclusive, auto-delete queue**, so all replicas sync
+     immediately on push and meet the `< 2s` freshness target. The current flow queue
+     (`internal/amqp/consumer.go:120`) is a single named durable queue with
+     `x-single-active-consumer` — by design only *one* replica consumes each message, so
+     it **cannot** be reused for broadcast. This requires a new exchange/queue topology:
+     each replica declares its own exclusive queue (`exclusive: true`, auto-deleted on
+     disconnect, no single-active-consumer) bound to the notification exchange, and on
+     delivery calls `SyncMaster`.
+   - **Background sync ticker (fallback)** per replica calling `SyncMaster` every N
+     seconds. No new topology, but only bounds staleness coarsely and won't hit the
+     sub-2s target — keep as a safety net / fallback, not the primary mechanism.
+
+2. **Keep the AMQP flow queue exactly as-is** (quorum + single-active-consumer). Flows
+   are already correct; you get failover for free.
+
+3. **Verify SQS artifact processing** is a competing-consumer setup (SQS is by nature) —
+   fine across replicas, no change expected.
+
+4. **Deployment.** The master clone lives in an **ephemeral per-pod temp dir**, so a
+   plain `Deployment` with `emptyDir` works — no StatefulSet, no shared ReadWriteOnce
+   PV. `/ping` liveness/readiness probes are fine.
+   - The `hostPath` volumes flagged during analysis are in the **e2e-test manifest only**
+     (`e2e-test/release-manager.yaml`, local git-server fixture), **not** a production
+     blocker. Confirm against the actual prod Helm chart (likely in a separate deploy
+     repo) before changing replica count.
+
+---
+
+## Design
+
+This is the implementation design for the chosen fanout-broadcast approach. It resolves
+the topology, payload, wiring, and failure-handling questions left open by the analysis.
+
+### Note on the actual broker layering
+
+The production AMQP path is **not** `internal/amqp` directly — it is the
+`broker.Broker` interface (`internal/broker/broker.go:9`) implemented by
+`internal/broker/amqpextra`, which *wraps* `internal/amqp.Worker`. The amqpextra broker
+declares a **single** durable quorum queue with `x-single-active-consumer`, bound to one
+topic exchange with routing key `#` — all event types are multiplexed through it and
+demuxed by message `Type` (`internal/broker/amqpextra/consumer.go:25`). The in-memory
+broker (`internal/broker/memory`) is the second implementation, used for local/dev and
+tests. Any broadcast capability must be added at the `broker.Broker` level so both
+implementations stay in sync.
+
+### Decisions
+
+1. **Extend `broker.Broker` with broadcast methods.** Add `PublishBroadcast(ctx,
+   Publishable)` and `StartBroadcastConsumer(handler func([]byte) error)`. The
+   `amqpextra` implementation backs them with a **dedicated fanout exchange** and a
+   **server-named, exclusive, auto-delete queue** (one per replica, so every replica
+   receives every config-changed message). The `memory` implementation does an
+   in-process fan-out so single-process tests/dev keep working.
+
+2. **SHA-carrying payload with skip-if-current.** A new `ConfigChangedEvent{SHA string}`
+   implements the existing `broker.Publishable` interface (`Type`/`Marshal`/`Unmarshal`).
+   The broadcast handler compares the SHA to the replica's local master HEAD (new
+   `git.Service.MasterHash()` getter, read under the existing `RLock`) and **skips** the
+   `fetch`+`pull` when already current. This no-ops the publisher's own self-delivered
+   message and coalesces rapid/duplicate pushes for free.
+
+3. **Publish from the webhook via an injected hook.** A `func(context.Context, sha
+   string) error` hook is added to `http.NewServer` (`cmd/server/http/http.go:32`) and
+   threaded into the webhook handler (`cmd/server/http/github_webhook.go:36`), wired in
+   `cmd/server/command/start.go` to `brokerImpl.PublishBroadcast`. The handler calls
+   `SyncMaster`, reads `MasterHash`, then publishes. This matches the existing injected
+   publish-hook idiom on `flow.Service` (`PublishReleaseArtifactID`/`PublishNewArtifact`,
+   `start.go:511`). Broadcast-publish failure is **log-only** — the webhook still returns
+   `200`.
+
+4. **Single-worker broadcast consumer, ack-always.** The per-replica queue is consumed
+   by a single worker so deliveries serialize; with skip-if-current a redundant delivery
+   costs only a HEAD read, not a write-locked pull. The handler **acks unconditionally**
+   and logs on `SyncMaster` failure — no nack/requeue (same data would loop on an
+   exclusive queue), relying on the next broadcast or the ticker to recover.
+
+5. **Coarse ticker backstop.** A configurable (~60s) background `SyncMaster` ticker per
+   replica heals missed broadcasts (reconnects, and the brief cold-start window before a
+   replica's queue is bound). Broadcasts deliver the `< 2s` freshness; the ticker is only
+   a safety net.
+
+### New AMQP primitives
+
+`internal/amqp` currently hardcodes quorum + single-active-consumer + `exclusive: false`
+on every declared queue and `topic` on every declared exchange. The broadcast path needs:
+
+- `ConsumerConfig` gains optional fields for **exclusive / auto-delete / server-named
+  queue** and **omitting single-active-consumer**, plus a **fanout** binding.
+- The publisher (`internal/amqp/publisher.go:96` `declareExchange`) gains support for
+  declaring a `fanout` exchange (currently hardcoded `topic`).
+
+The existing flow-queue declaration (`internal/amqp/consumer.go:121`) stays
+**byte-for-byte unchanged**.
+
+### Lifecycle
+
+`StartBroadcastConsumer` and the ticker each run in their own cancellable goroutine in
+`start.go`, alongside the existing `StartConsumer`. The exclusive auto-delete queue is
+removed automatically by RabbitMQ when the replica's connection closes.
+
+### Verification against success criteria
+
+- **Fresh on every replica / `< 2s` after push** — broadcast → skip-if-current →
+  `SyncMaster` on all replicas.
+- **No read-latency regression** — single-worker + skip-if-current avoids extra
+  write-locked pulls; the write lock is held only for genuine changes, as today.
+- **Failover / convergence** — flow queue unchanged (HA); ticker + initial clone
+  converge new/rejoining replicas with no operator action.
+
+---
+
+## Bottom line
+
+Flows already work across replicas. The one thing standing between you and correct
+multi-replica behavior is **stale reads on replicas that did not receive the git
+webhook**. Fix master-sync propagation via **fanout broadcast** (with an optional ticker
+as a safety net) and you're there.
+
+## Open follow-ups
+
+- [ ] Confirm the production deployment manifest in the deploy/Helm repo (volumes,
+      current replica count, probes).
+- [x] ~~Decide between background sync ticker vs. fanout-broadcast for clone freshness.~~
+      **Decided: fanout broadcast** for near-instant freshness (< 2s target); ticker
+      retained only as a backstop. See **Design**.
+- [x] ~~Design the fanout exchange + per-replica exclusive-queue topology and the
+      config-changed notification payload.~~ See **Design** (SHA-carrying
+      `ConfigChangedEvent`, fanout exchange + server-named exclusive auto-delete queue).
+- [ ] Confirm SQS artifact consumer is competing-consumer (expected, but verify).
+
+## Key references
+
+| Concern | Location |
+|---|---|
+| Master clone init | `internal/git/git.go:56` (`InitMasterRepo`) |
+| Clone copy for reads/writes | `internal/git/git.go:165` (`copyMaster`) |
+| Sync master (write lock) | `internal/git/git.go:105` (`SyncMaster`) |
+| Broker interface (Publish/StartConsumer) | `internal/broker/broker.go:9` |
+| Production broker (wraps internal/amqp) | `internal/broker/amqpextra/consumer.go:25` |
+| Quorum + single-active-consumer queue | `internal/amqp/consumer.go:121` |
+| Exchange declare (hardcoded topic) | `internal/amqp/publisher.go:96` (`declareExchange`) |
+| HTTP server / webhook wiring | `cmd/server/http/http.go:32` (`NewServer`), `:81` |
+| Webhook-triggered sync | `cmd/server/http/github_webhook.go:36` |
+| Write-conflict retry → sync | `internal/flow/flow.go:131` |
+| Broker construction / event hooks | `cmd/server/command/start.go:511`, `:615` |

--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/makasim/amqpextra/consumer"
@@ -32,18 +33,32 @@ func (w *Worker) StartConsumer(consumerConfigs []ConsumerConfig, consumersStarte
 		}
 
 		prefixedQueue := w.prefixed(consumerConfig.Queue)
+
+		// queueSource configures where the consumer reads messages from. In the
+		// default mode it consumes a pre-declared durable queue by name. In fanout
+		// mode each consumer declares its own server-named, auto-delete queue on
+		// its own connection and binds it to the fanout exchange, so every consumer
+		// receives a copy of every published message and the queue is removed when
+		// the connection closes.
+		queueSource := []consumer.Option{consumer.WithQueue(prefixedQueue)}
+		queueDisplayName := prefixedQueue
+		if consumerConfig.Fanout {
+			prefixedExchange := w.prefixed(consumerConfig.Exchange)
+			queueSource = []consumer.Option{consumer.WithExchange(prefixedExchange, "")}
+			queueDisplayName = fmt.Sprintf("server-named fanout queue on exchange '%s'", prefixedExchange)
+		}
+
 		if consumerConfig.Prefetch > 0 {
-			w.logger.Infof("[amqp] Setting prefetch to '%d' for queue '%s'", consumerConfig.Prefetch, prefixedQueue)
+			w.logger.Infof("[amqp] Setting prefetch to '%d' for %s", consumerConfig.Prefetch, queueDisplayName)
 		}
 
 		if consumerConfig.WorkerCount == 0 {
 			consumerConfig.WorkerCount = 1
 		}
-		w.logger.Infof("[amqp] Setting workers to '%d' for queue '%s'", consumerConfig.WorkerCount, prefixedQueue)
+		w.logger.Infof("[amqp] Setting workers to '%d' for %s", consumerConfig.WorkerCount, queueDisplayName)
 
 		consumerState := make(chan consumer.State, 2)
-		amqpConsumer, err := w.dialer.Consumer(
-			consumer.WithQueue(prefixedQueue),
+		consumerOptions := append(queueSource,
 			consumer.WithNotify(consumerState),
 			consumer.WithHandler(consumer.Wrap(handlerFunc(consumerConfig.Handle), loggerMiddleware(w.logger))),
 			consumer.WithLogger(newLogger(w.logger, "consumer")),
@@ -51,8 +66,9 @@ func (w *Worker) StartConsumer(consumerConfigs []ConsumerConfig, consumersStarte
 			consumer.WithQos(consumerConfig.Prefetch, false),
 			consumer.WithWorker(consumer.NewParallelWorker(consumerConfig.WorkerCount)),
 		)
+		amqpConsumer, err := w.dialer.Consumer(consumerOptions...)
 		if err != nil {
-			return errors.WithMessagef(err, "instantiate consumer on exchange %v routing keys %v to queue %v", consumerConfig.Exchange, consumerConfig.RoutingPatterns, prefixedQueue)
+			return errors.WithMessagef(err, "instantiate consumer on exchange %v routing keys %v to %s", consumerConfig.Exchange, consumerConfig.RoutingPatterns, queueDisplayName)
 		}
 
 		// track when the consumer is ready
@@ -64,7 +80,7 @@ func (w *Worker) StartConsumer(consumerConfigs []ConsumerConfig, consumersStarte
 		go func() {
 			defer stopped.Done()
 			<-amqpConsumer.NotifyClosed()
-			w.logger.Infof("[amqp] Consumer on queue %v closed", prefixedQueue)
+			w.logger.Infof("[amqp] Consumer on %s closed", queueDisplayName)
 		}()
 	}
 	// when all consumers are ready, the ready WaitGroup is Done and we signal to
@@ -104,10 +120,14 @@ func (w *Worker) initializeConsumer(c ConsumerConfig) error {
 		return errors.WithMessage(err, "create channel")
 	}
 
-	w.logger.Infof("[amqp] Declaring consumer exchange '%s'", prefixedExchange)
+	exchangeType := amqp.ExchangeTopic
+	if c.Fanout {
+		exchangeType = amqp.ExchangeFanout
+	}
+	w.logger.Infof("[amqp] Declaring consumer exchange '%s' of type '%s'", prefixedExchange, exchangeType)
 	err = channel.ExchangeDeclare(
 		prefixedExchange,
-		amqp.ExchangeTopic,
+		exchangeType,
 		true,
 		false,
 		false,
@@ -115,6 +135,13 @@ func (w *Worker) initializeConsumer(c ConsumerConfig) error {
 		nil)
 	if err != nil {
 		return errors.WithMessagef(err, "declare exchange '%s'", prefixedExchange)
+	}
+
+	// In fanout mode the per-consumer queue is server-named and declared on the
+	// consumer's own connection when the consumer starts, so here we only ensure
+	// the fanout exchange exists for the consumer to bind to.
+	if c.Fanout {
+		return nil
 	}
 
 	w.logger.Infof("[amqp] Declaring queue '%s'", prefixedQueue)
@@ -167,4 +194,10 @@ type ConsumerConfig struct {
 	Handle func(*amqp.Delivery) error
 	// The number of concurrent workers. If it is not set then it will default to 1.
 	WorkerCount int
+	// Fanout enables broadcast delivery. When true the exchange is declared as a
+	// fanout exchange and the consumer declares its own server-named, auto-delete
+	// queue (bound to the exchange) so every consumer receives a copy of every
+	// message. Queue, DurableQueue, RoutingPatterns and single-active-consumer do
+	// not apply in this mode.
+	Fanout bool
 }

--- a/internal/amqp/publisher.go
+++ b/internal/amqp/publisher.go
@@ -20,7 +20,11 @@ import (
 // If ctx is cancelled before completing the publish the operation is cancelled.
 func (w *Worker) Publish(ctx context.Context, dto PublishDto) error {
 	prefixedExchange := w.prefixed(dto.Exchange)
-	err := w.ensureExchangeDeclared(ctx, prefixedExchange)
+	exchangeType := dto.ExchangeType
+	if exchangeType == "" {
+		exchangeType = amqp.ExchangeTopic
+	}
+	err := w.ensureExchangeDeclared(ctx, prefixedExchange, exchangeType)
 	if err != nil {
 		return errors.WithMessage(err, "declare exchange")
 	}
@@ -77,15 +81,16 @@ func (w *Worker) Publish(ctx context.Context, dto PublishDto) error {
 }
 
 // ensureExchangeDeclared ensures that an exchange named prefixedExchange is
-// declared. Once it is declared for an exchange it becomes a noop.
-func (w *Worker) ensureExchangeDeclared(ctx context.Context, prefixedExchange string) error {
+// declared with the given kind. Once it is declared for an exchange it becomes
+// a noop.
+func (w *Worker) ensureExchangeDeclared(ctx context.Context, prefixedExchange, kind string) error {
 	_, ok := w.declaredExchanges[prefixedExchange]
 	if ok {
 		w.logger.Debugf("[amqp] Exchange '%s' already declared", prefixedExchange)
 		return nil
 	}
-	w.logger.Debugf("[amqp] Declaring publishing exchange '%s'", prefixedExchange)
-	err := w.declareExchange(prefixedExchange)
+	w.logger.Debugf("[amqp] Declaring publishing exchange '%s' of type '%s'", prefixedExchange, kind)
+	err := w.declareExchange(prefixedExchange, kind)
 	if err != nil {
 		return err
 	}
@@ -93,7 +98,7 @@ func (w *Worker) ensureExchangeDeclared(ctx context.Context, prefixedExchange st
 	return nil
 }
 
-func (w *Worker) declareExchange(exchange string) error {
+func (w *Worker) declareExchange(exchange, kind string) error {
 	amqpConn, err := w.dialer.Connection(context.Background())
 	if err != nil {
 		return err
@@ -107,12 +112,12 @@ func (w *Worker) declareExchange(exchange string) error {
 
 	err = channel.ExchangeDeclare(
 		exchange,
-		"topic", // kind
-		true,    // durable
-		false,   // autoDelete
-		false,   // internal
-		false,   // noWait
-		nil,     // args
+		kind,  // kind
+		true,  // durable
+		false, // autoDelete
+		false, // internal
+		false, // noWait
+		nil,   // args
 	)
 	if err != nil {
 		return err
@@ -126,4 +131,7 @@ type PublishDto struct {
 	MessageType   string
 	CorrelationID string
 	Message       interface{}
+	// ExchangeType is the kind of exchange to declare for this publish (e.g.
+	// "topic" or "fanout"). When empty it defaults to "topic".
+	ExchangeType string
 }

--- a/internal/broker/amqpextra/config.go
+++ b/internal/broker/amqpextra/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Exchange            string
 	Queue               string
 	RoutingKey          string
+	BroadcastExchange   string
 	Prefetch            int
 	ReconnectionTimeout time.Duration
 	ConnectionTimeout   time.Duration

--- a/internal/broker/amqpextra/consumer.go
+++ b/internal/broker/amqpextra/consumer.go
@@ -42,3 +42,40 @@ func (w *Worker) StartConsumer(handlers map[string]func([]byte) error, eventDrop
 
 	return broker.ErrBrokerClosed
 }
+
+// StartBroadcastConsumer consumes broadcast messages from a per-replica
+// server-named fanout queue. Each replica receives a copy of every broadcast
+// message. The method is blocking and will always return with ErrBrokerClosed
+// after calls to Close.
+//
+// Deliveries are acked unconditionally: the handler is expected to be
+// idempotent (skip-if-current), so a failed handling is logged rather than
+// requeued. Recovery relies on the next broadcast or the background sync ticker.
+func (w *Worker) StartBroadcastConsumer(handler func([]byte) error) error {
+	consumer := internalamqp.ConsumerConfig{
+		Exchange: w.config.BroadcastExchange,
+		Fanout:   true,
+		// Prefetch 1 bounds in-flight unacked deliveries to one, matching the
+		// single worker below and providing backpressure on a burst of broadcasts
+		// (e.g. after a reconnect drains an accumulated queue).
+		Prefetch: 1,
+		Handle: func(message *amqp.Delivery) error {
+			if err := handler(message.Body); err != nil {
+				w.config.Logger.Errorf("[amqp] Broadcast handler failed for message type '%s': %v", message.Type, err)
+			}
+			if err := message.Ack(false); err != nil {
+				w.config.Logger.Errorf("[amqp] Broadcast ack failed for message type '%s': %v", message.Type, err)
+			}
+			return nil
+		},
+		WorkerCount: 1,
+	}
+
+	consumersStarted := make(chan struct{})
+	err := w.worker.StartConsumer([]internalamqp.ConsumerConfig{consumer}, consumersStarted)
+	if err != nil {
+		return err
+	}
+
+	return broker.ErrBrokerClosed
+}

--- a/internal/broker/amqpextra/publish.go
+++ b/internal/broker/amqpextra/publish.go
@@ -30,3 +30,25 @@ func (w *Worker) Publish(ctx context.Context, message broker.Publishable) error 
 	}
 	return nil
 }
+
+// PublishBroadcast publishes a Publishable message to the fanout broadcast
+// exchange so every replica's broadcast consumer receives a copy. It blocks
+// until the message is confirmed on the server.
+//
+// If ctx is cancelled before completing the publish the operation is cancelled.
+func (w *Worker) PublishBroadcast(ctx context.Context, message broker.Publishable) error {
+	correlationID := tracing.RequestIDFromContext(ctx)
+
+	err := w.worker.Publish(ctx, amqp.PublishDto{
+		Exchange:      w.config.BroadcastExchange,
+		RoutingKey:    "", // fanout exchanges ignore the routing key
+		MessageType:   message.Type(),
+		CorrelationID: correlationID,
+		Message:       message,
+		ExchangeType:  "fanout",
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -12,6 +12,13 @@ type Broker interface {
 	// StartConsumer consumes messages on a broker. This method is blocking and
 	// will always return with ErrBrokerClosed after calls to Close.
 	StartConsumer(handlers map[string]func([]byte) error, errorHandler func(msgType string, msgBody []byte, err error)) error
+	// PublishBroadcast publishes a Publishable message to all replicas. Every
+	// running broadcast consumer in the fleet receives a copy of the message.
+	PublishBroadcast(ctx context.Context, message Publishable) error
+	// StartBroadcastConsumer consumes broadcast messages. Each replica receives
+	// every broadcast message. This method is blocking and will always return
+	// with ErrBrokerClosed after calls to Close.
+	StartBroadcastConsumer(handler func([]byte) error) error
 	// Close closes the broker.
 	Close() error
 }

--- a/internal/broker/memory/memory.go
+++ b/internal/broker/memory/memory.go
@@ -10,20 +10,23 @@ import (
 )
 
 type Broker struct {
-	logger *log.Logger
-	queue  chan broker.Publishable
+	logger         *log.Logger
+	queue          chan broker.Publishable
+	broadcastQueue chan broker.Publishable
 }
 
 // New allocates and returns an in-memory Broker with provided queue size.
 func New(logger *log.Logger, queueSize int) *Broker {
 	return &Broker{
-		logger: logger,
-		queue:  make(chan broker.Publishable, queueSize),
+		logger:         logger,
+		queue:          make(chan broker.Publishable, queueSize),
+		broadcastQueue: make(chan broker.Publishable, queueSize),
 	}
 }
 
 func (b *Broker) Close() error {
 	close(b.queue)
+	close(b.broadcastQueue)
 	return nil
 }
 
@@ -39,6 +42,32 @@ func (b *Broker) Publish(ctx context.Context, event broker.Publishable) error {
 			"responseTime": duration,
 		}).Info("[publisher] [OK] Published message successfully")
 	return nil
+}
+
+// PublishBroadcast publishes a message to the in-process broadcast queue. In a
+// single-process broker the only replica is this process, so the message is
+// delivered to this process' broadcast consumer.
+func (b *Broker) PublishBroadcast(ctx context.Context, event broker.Publishable) error {
+	b.logger.WithFields("message", event).Info("Publishing broadcast message")
+	b.broadcastQueue <- event
+	return nil
+}
+
+// StartBroadcastConsumer consumes messages from the in-process broadcast queue.
+// It is blocking and returns ErrBrokerClosed once the broker is closed.
+func (b *Broker) StartBroadcastConsumer(handler func([]byte) error) error {
+	for msg := range b.broadcastQueue {
+		logger := b.logger.With("eventType", msg.Type())
+		body, err := msg.Marshal()
+		if err != nil {
+			logger.Errorf("[broadcast] Could not get body of message: %v", err)
+			continue
+		}
+		if err := handler(body); err != nil {
+			logger.Errorf("[broadcast] Failed to handle message: %v", err)
+		}
+	}
+	return broker.ErrBrokerClosed
 }
 
 func (b *Broker) StartConsumer(handlers map[string]func([]byte) error, errorHandler func(msgType string, msgBody []byte, err error)) error {

--- a/internal/broker/memory/memory_test.go
+++ b/internal/broker/memory/memory_test.go
@@ -101,3 +101,53 @@ func TestBroker_PublishAndConsumer(t *testing.T) {
 	consumerWg.Wait()
 	assert.Equal(t, publishedMessages, int(receivedCount), "received messages count not as expected")
 }
+
+// TestBroker_PublishBroadcastAndConsumer tests that broadcast messages
+// published via PublishBroadcast are delivered to the broadcast consumer.
+func TestBroker_PublishBroadcastAndConsumer(t *testing.T) {
+	logger := log.New(&log.Configuration{
+		Level: log.Level{
+			Level: zapcore.DebugLevel,
+		},
+		Development: true,
+	})
+
+	publishedMessages := 100
+	var receivedCount int32
+	receivedAllEvents := make(chan struct{})
+	memoryBroker := New(logger, 5)
+
+	var consumerWg sync.WaitGroup
+	consumerWg.Add(1)
+	go func() {
+		defer consumerWg.Done()
+		err := memoryBroker.StartBroadcastConsumer(func(d []byte) error {
+			newCount := atomic.AddInt32(&receivedCount, 1)
+			if int(newCount) == publishedMessages {
+				close(receivedAllEvents)
+			}
+			var msg testEvent
+			return json.Unmarshal(d, &msg)
+		})
+		assert.EqualError(t, err, broker.ErrBrokerClosed.Error(), "unexpected broadcast consumer error")
+	}()
+
+	for i := 1; i <= publishedMessages; i++ {
+		err := memoryBroker.PublishBroadcast(context.Background(), &testEvent{
+			Message: fmt.Sprintf("Message %d", i),
+		})
+		assert.NoError(t, err, "unexpected error publishing broadcast message")
+	}
+
+	select {
+	case <-receivedAllEvents:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting to receive all broadcast events")
+	}
+
+	err := memoryBroker.Close()
+	assert.NoError(t, err, "unexpected close error")
+
+	consumerWg.Wait()
+	assert.Equal(t, publishedMessages, int(receivedCount), "received broadcast messages count not as expected")
+}

--- a/internal/events/config_changed_event.go
+++ b/internal/events/config_changed_event.go
@@ -1,0 +1,31 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/lunarway/release-manager/internal/broker"
+)
+
+// ConfigChangedEvent notifies all replicas that the config repository changed.
+// It carries the new master HEAD SHA so receivers can skip syncing when their
+// local clone is already current.
+type ConfigChangedEvent struct {
+	SHA string `json:"sha,omitempty"`
+}
+
+// Marshal implements broker.Publishable.
+func (e ConfigChangedEvent) Marshal() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// Unmarshal implements broker.Publishable.
+func (e *ConfigChangedEvent) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, e)
+}
+
+var _ broker.Publishable = &ConfigChangedEvent{}
+
+// Type implements broker.Publishable.
+func (e ConfigChangedEvent) Type() string {
+	return "config_changed"
+}

--- a/internal/events/config_changed_event_test.go
+++ b/internal/events/config_changed_event_test.go
@@ -1,0 +1,31 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigChangedEvent(t *testing.T) {
+	t.Run("type is correct", func(t *testing.T) {
+		sut := ConfigChangedEvent{}
+
+		actual := sut.Type()
+
+		assert.Equal(t, "config_changed", actual)
+	})
+
+	t.Run("marshal and unmarshal round-trips the SHA", func(t *testing.T) {
+		sut := ConfigChangedEvent{SHA: "abc123"}
+
+		data, err := sut.Marshal()
+		require.NoError(t, err)
+
+		var got ConfigChangedEvent
+		err = got.Unmarshal(data)
+		require.NoError(t, err)
+
+		assert.Equal(t, sut, got)
+	})
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -52,6 +52,21 @@ func (s *Service) MasterPath() string {
 	return s.masterPath
 }
 
+// MasterHash returns the current HEAD commit SHA of the local master clone. It
+// is read under the master read lock so it is safe to call concurrently with
+// reads and syncs.
+func (s *Service) MasterHash(ctx context.Context) (string, error) {
+	span, _ := s.Tracer.FromCtx(ctx, "git.MasterHash")
+	defer span.End()
+	s.masterMutex.RLock()
+	defer s.masterMutex.RUnlock()
+	head, err := s.master.Head()
+	if err != nil {
+		return "", errors.WithMessage(err, "resolve master HEAD")
+	}
+	return head.Hash().String(), nil
+}
+
 // InitMasterRepo clones the configuration repository into a master directory.
 func (s *Service) InitMasterRepo(ctx context.Context) (func(context.Context), error) {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.InitMasterRepo")


### PR DESCRIPTION
## Summary

Enable running the release-manager as **N replicas** with fresh reads on every replica, implementing the fanout-broadcast approach from `docs/multi-replica-analysis.md`.

Today the read APIs (`/status`, `/describe/*`, `/policies`) serve from a per-replica local clone that is refreshed **only** when that replica receives the GitHub push webhook. Behind a load balancer the webhook hits exactly one replica, so the others serve stale data indefinitely. This change makes every replica sync on every push via a fanout broadcast, with a coarse ticker as a backstop.

## Changes

- **Broadcast primitive on `broker.Broker`** — `PublishBroadcast` and `StartBroadcastConsumer`. The `amqpextra` impl backs them with a dedicated fanout exchange and a per-replica server-named, auto-delete queue (every replica receives every message; queue is removed on disconnect). Deliveries are acked unconditionally — skip-if-current makes the handler idempotent. The `memory` broker fans out in-process for dev/test.
- **Low-level AMQP knobs** — `ConsumerConfig.Fanout` (fanout exchange + server-named/auto-delete queue, no single-active-consumer) and `PublishDto.ExchangeType` (defaults to `topic`). The existing flow-queue declaration (quorum + SAC) is byte-for-byte unchanged.
- **`events.ConfigChangedEvent{SHA}`** implementing `broker.Publishable`, and `git.Service.MasterHash(ctx)` reading HEAD under the existing `RLock`.
- **Wiring** — the webhook does `SyncMaster` → read `MasterHash` → broadcast the SHA (log-only on failure, still returns 200), via an injected hook matching the existing publish-hook idiom. `start.go` starts the broadcast consumer (skip-if-current, else `SyncMaster`) and a `~60s` ticker backstop in their own goroutines.
- **New flags** — `--amqp-broadcast-exchange` (default `release-manager-broadcast`) and `--config-repo-sync-interval` (default `60s`).
- Tests: round-trip test for `ConfigChangedEvent` and a behavioral publish→consume test for the memory broadcast path.

## Why

Write flows are already multi-replica safe (the AMQP queue is a quorum queue with `x-single-active-consumer`, giving HA failover). Stale reads on replicas that didn't receive the webhook are the only blocker to running N replicas — this closes that gap with sub-2s freshness propagation while leaving the write path untouched.

## Notes for reviewers

- **Queue declaration deviation:** the design specified a queue-level `exclusive: true`. The makasim/amqpextra consumer treats queue-source options as mutually exclusive, so `WithExchange` is used instead — yielding a server-named, auto-delete queue bound to the fanout exchange. Functionally equivalent here (per-replica, auto-cleaned, no SAC, receives every message); only connection-level exclusivity is dropped, which adds nothing given the queue name is server-generated and only this consumer binds to it.
- Self-reviewed across concurrency, AMQP/messaging, and general-correctness lenses. The `Prefetch` on the broadcast consumer was set to `1` (backpressure for the single worker) and a fanout-mode shutdown log line was corrected as part of that review. No blocking issues found.

Closes DMAT-365

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AMQP topology and fleet-wide git sync behavior; misconfiguration or broadcast failures could leave replicas stale until the ticker heals, but write flows and the existing quorum SAC queue are unchanged.
> 
> **Overview**
> Adds **multi-replica config freshness** so every pod’s local config clone stays aligned after a config-repo push, not only the replica that receives the GitHub webhook.
> 
> **Broker broadcast path:** `broker.Broker` gains `PublishBroadcast` / `StartBroadcastConsumer`. AMQP uses a separate **fanout** exchange and per-replica server-named auto-delete queues (`ConsumerConfig.Fanout`, configurable `ExchangeType` on publish). The in-memory broker mirrors this for dev/tests.
> 
> **Event + git:** New `ConfigChangedEvent` carries the new master **SHA**; replicas call `MasterHash` and **skip** `SyncMaster` when already current.
> 
> **Wiring:** After webhook `SyncMaster`, the handler reads HEAD and broadcasts via an injected hook (failures are log-only, still HTTP 200). `start.go` runs a broadcast consumer plus a **~60s** `SyncMaster` ticker backstop. Flags: `--amqp-broadcast-exchange`, `--config-repo-sync-interval`.
> 
> **Docs/tests:** `docs/multi-replica-analysis.md` documents the design; tests cover the event and memory broadcast delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a62d2e8f3be33beb5c967d3344873e0f1e646a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->