### PR TITLE
perf(git): advance local master mirror after push to avoid self-staleness

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -70,6 +70,17 @@ func (s *Service) InitMasterRepo(ctx context.Context) (func(context.Context), er
 	defer s.masterMutex.Unlock()
 	s.master = repo
 	s.masterPath = path
+
+	// The mirror is a non-bare clone with master checked out, and its working
+	// tree is read by copyMaster. updateInstead lets advanceMirror fast-forward
+	// the mirror's master ref and working tree in one atomic push after a
+	// successful origin push, keeping the next ShallowClone/copyMaster current.
+	err = execCommand(ctx, path, "git", "config", "receive.denyCurrentBranch", "updateInstead")
+	if err != nil {
+		close(ctx)
+		return nil, errors.WithMessage(err, "configure mirror receive.denyCurrentBranch")
+	}
+
 	log.WithContext(ctx).Infof("Master repo cloned into '%s'", path)
 	return close, nil
 }
@@ -378,7 +389,7 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
-	err = gitPush(ctx, rootPath)
+	err = s.gitPush(ctx, rootPath)
 	span.End()
 	if err == nil {
 		return nil
@@ -392,7 +403,28 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 	pushSpan, _ := s.Tracer.FromCtx(ctx, "push after rebase")
 	defer pushSpan.End()
-	return gitPush(ctx, rootPath)
+	return s.gitPush(ctx, rootPath)
+}
+
+// advanceMirror fast-forwards the local master mirror to the commit just pushed
+// from rootPath via a local (no-network) push; updateInstead, set in
+// InitMasterRepo, moves the mirror's ref and working tree atomically.
+//
+// It takes the write lock to exclude concurrent SyncMaster and the RLock-holding
+// readers (ShallowClone, copyMaster). A failure is non-fatal: the release has
+// already shipped, and the existing rebase-on-conflict path recovers any
+// residual staleness, so the error is logged rather than returned.
+func (s *Service) advanceMirror(ctx context.Context, rootPath string) {
+	span, ctx := s.Tracer.FromCtx(ctx, "git.advanceMirror")
+	defer span.End()
+
+	s.masterMutex.Lock()
+	defer s.masterMutex.Unlock()
+
+	err := execCommand(ctx, rootPath, "git", "push", s.masterPath, "HEAD:master")
+	if err != nil {
+		log.WithContext(ctx).WithFields("error", err).Infof("git/advanceMirror: failed to advance local master mirror; next clone may sync via the retry path")
+	}
 }
 
 // rebaseOntoMaster refreshes the local master mirror, then fetches from it and
@@ -463,7 +495,7 @@ func (s *Service) SignedCommit(ctx context.Context, rootPath, changesPath, autho
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
 	defer span.End()
-	return gitPush(ctx, rootPath)
+	return s.gitPush(ctx, rootPath)
 }
 
 func execCommand(ctx context.Context, rootPath string, cmdName string, args ...string) error {
@@ -569,7 +601,11 @@ func checkStatus(ctx context.Context, rootPath string) error {
 	return nil
 }
 
-func gitPush(ctx context.Context, rootPath string) error {
+// gitPush pushes rootPath's master to origin and, on success, advances the
+// local master mirror to match. Keeping the mirror advance inside the single
+// push choke point means no caller can push to origin without the mirror
+// following, so the next ShallowClone/copyMaster never starts behind origin.
+func (s *Service) gitPush(ctx context.Context, rootPath string) error {
 	cmdName := "git"
 	args := []string{"push", "origin", "master", "--porcelain"}
 	logger := log.WithContext(ctx).WithFields("root", rootPath)
@@ -607,6 +643,7 @@ func gitPush(ctx context.Context, rootPath string) error {
 		}
 		return errors.WithMessage(err, "execute command failed")
 	}
+	s.advanceMirror(ctx, rootPath)
 	return nil
 }
 

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lunarway/release-manager/internal/log"
@@ -91,6 +92,70 @@ func TestCommitRebasesOntoSyncedMirrorOnConflict(t *testing.T) {
 	// path never touched the mirror, so this is the behavioural discriminator.
 	assert.FileExists(t, filepath.Join(mirrorDir, "b.txt"),
 		"recovery must sync the local master mirror")
+}
+
+// TestCommitAdvancesMirrorAfterPush verifies the self-staleness fix: after a
+// normal (non-conflicting) push, Commit fast-forwards the local master mirror
+// to the just-pushed commit, so a subsequent ShallowClone starts current rather
+// than one commit behind origin. Without the advance, the mirror would lag by
+// every release commit and the next push would be rejected as behind origin.
+func TestCommitAdvancesMirrorAfterPush(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	ctx := context.Background()
+	root := t.TempDir()
+
+	originDir := filepath.Join(root, "origin")
+	seedDir := filepath.Join(root, "seed")
+	mirrorDir := filepath.Join(root, "mirror")
+	workDir := filepath.Join(root, "work")
+
+	runGit(t, root, "init", "--bare", "-b", "master", originDir)
+	runGit(t, root, "clone", originDir, seedDir)
+	configureIdentity(t, seedDir)
+	writeFile(t, seedDir, "a.txt", "a")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add a")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	// Full-history mirror, configured exactly as InitMasterRepo does so the
+	// post-push advance can update the checked-out master branch in place.
+	runGit(t, root, "clone", originDir, mirrorDir)
+	runGit(t, mirrorDir, "config", "receive.denyCurrentBranch", "updateInstead")
+
+	// Depth-1 shallow working clone from the current mirror.
+	runGit(t, root, "clone", "--depth", "1", "--local", mirrorDir, workDir)
+	runGit(t, workDir, "remote", "set-url", "origin", originDir)
+	configureIdentity(t, workDir)
+
+	writeFile(t, workDir, "c.txt", "c")
+
+	s := &Service{
+		Tracer:        tracing.NewNoop(),
+		Config:        &GitConfig{User: "test", Email: "test@example.com"},
+		ConfigRepoURL: originDir,
+		masterPath:    mirrorDir,
+	}
+
+	err := s.Commit(ctx, workDir, ".", "[env/svc] release c")
+	require.NoError(t, err)
+
+	// The mirror must carry the release commit in both its ref and working tree,
+	// so a later ShallowClone/copyMaster sees it without another origin fetch.
+	assert.FileExists(t, filepath.Join(mirrorDir, "c.txt"),
+		"push must fast-forward the local master mirror")
+	assert.Equal(t, revParse(t, workDir, "HEAD"), revParse(t, mirrorDir, "master"),
+		"mirror master must match the pushed commit")
+}
+
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git rev-parse %s failed: %s", ref, out)
+	return strings.TrimSpace(string(out))
 }
 
 func runGit(t *testing.T, dir string, args ...string) {


### PR DESCRIPTION
## Problem

The local master mirror (read by `ShallowClone`/`copyMaster` to start each release working tree) was only refreshed via the rebase-on-conflict recovery path. After a normal, non-conflicting push to origin, the mirror's `master` ref and working tree were left one commit behind origin. Over a series of releases the mirror lagged by every release commit, so the next push would be rejected as behind origin and pay the full rebase-recovery cost on every release.

## Fix

Advance the local master mirror inside `gitPush` — the single push choke point — immediately after a successful origin push:

- `InitMasterRepo` now configures the mirror with `receive.denyCurrentBranch=updateInstead` so a local push can fast-forward the mirror's checked-out `master` ref **and** working tree atomically.
- New `advanceMirror` does a local (no-network) `git push <mirror> HEAD:master` under the write lock (excludes concurrent `SyncMaster` and the RLock-holding readers `ShallowClone`/`copyMaster`). Failure is non-fatal and logged — the release has already shipped and the existing rebase-on-conflict path recovers any residual staleness.
- `gitPush` calls `advanceMirror` on every successful push, so no caller can push to origin without the mirror following.

## Tests

- `TestCommitAdvancesMirrorAfterPush` configures the mirror with `updateInstead` and verifies that after a normal push the mirror carries the release commit in both its ref and working tree, so a subsequent `ShallowClone` starts current rather than one commit behind origin.

## Notes

Follow-up to the rebase-in-place work (DMAT-336, #627). Resolves DMAT-411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release push and mirror locking behavior on the critical commit/push path; failures are non-fatal but could leave transient mirror staleness until retry/rebase.
> 
> **Overview**
> Fixes **self-staleness** of the local master mirror after normal release pushes: the mirror used by `ShallowClone`/`copyMaster` no longer lags origin by one commit per release, which previously forced repeated “behind origin” rejections and rebase recovery.
> 
> **`InitMasterRepo`** sets `receive.denyCurrentBranch=updateInstead` on the mirror so a local push can fast-forward both `master` and the checked-out working tree.
> 
> **`gitPush`** is now a `Service` method and, after a successful push to origin, calls **`advanceMirror`** to `git push` `HEAD:master` into the mirror under `masterMutex` (write lock). Mirror advance failures are logged only; rebase-on-conflict still recovers.
> 
> Adds **`TestCommitAdvancesMirrorAfterPush`** to assert the mirror ref and working tree match the pushed commit after a non-conflicting `Commit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a61f607e2b4d319819642b4329e2f3f7bdbf048. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->