### PR TITLE
feat(metrics): add release_manager_release_push_duration_seconds histogram

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -43,6 +43,10 @@ var (
 // success).
 type FlowObserver interface {
 	ObserveFlowDuration(operation string, start time.Time, err error)
+	// ObserveReleasePushDuration records the wall-clock duration from release
+	// intent accepted (event enqueue) to push completion. Not called for no-op
+	// releases.
+	ObserveReleasePushDuration(start time.Time, err error)
 }
 
 type Service struct {

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -144,15 +144,13 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 // elapsed time and final outcome via the service Observer (if non-nil).
 func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifactIDEvent) (err error) {
 	start := time.Now()
-	var nothingToCommit bool
 	defer func() {
 		if s.Observer != nil {
 			s.Observer.ObserveFlowDuration("ExecReleaseArtifactID", start, err)
-			// Wall-clock from intent enqueue to push. Skip no-op releases so
-			// they don't distort the latency distribution. EnqueuedAt is zero
-			// for legacy in-flight messages published before this field existed;
-			// skip those too rather than record a bogus epoch-to-now duration.
-			if !nothingToCommit && !event.EnqueuedAt.IsZero() {
+			// EnqueuedAt is zero for no-op releases (zeroed on ErrNothingToCommit
+			// below) and for legacy in-flight messages published before this field
+			// existed. Skip both to avoid distorting the latency distribution.
+			if !event.EnqueuedAt.IsZero() {
 				s.Observer.ObserveReleasePushDuration(event.EnqueuedAt, err)
 			}
 		}
@@ -237,7 +235,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			if errors.Cause(err) == git.ErrNothingToCommit {
 				logger.Infof("Environment is up to date: dropping event: %v", err)
 				// TODO: notify actor that there was nothing to commit
-				nothingToCommit = true
+				event.EnqueuedAt = time.Time{}
 				return true, nil
 			}
 			// we can see races here where other changes are committed to the master repo

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -38,6 +38,7 @@ type ReleaseArtifactIDEvent struct {
 	Branch      string        `json:"branch,omitempty"`
 	Actor       Actor         `json:"actor,omitempty"`
 	Intent      intent.Intent `json:"intent,omitempty"`
+	EnqueuedAt  time.Time     `json:"enqueuedAt,omitempty"`
 }
 
 func (ReleaseArtifactIDEvent) Type() string {
@@ -130,6 +131,7 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 		Namespace:   namespace,
 		Service:     service,
 		Intent:      intent,
+		EnqueuedAt:  time.Now(),
 	})
 	if err != nil {
 		return "", errors.WithMessage(err, "publish event")
@@ -142,9 +144,17 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 // elapsed time and final outcome via the service Observer (if non-nil).
 func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifactIDEvent) (err error) {
 	start := time.Now()
+	var nothingToCommit bool
 	defer func() {
 		if s.Observer != nil {
 			s.Observer.ObserveFlowDuration("ExecReleaseArtifactID", start, err)
+			// Wall-clock from intent enqueue to push. Skip no-op releases so
+			// they don't distort the latency distribution. EnqueuedAt is zero
+			// for legacy in-flight messages published before this field existed;
+			// skip those too rather than record a bogus epoch-to-now duration.
+			if !nothingToCommit && !event.EnqueuedAt.IsZero() {
+				s.Observer.ObserveReleasePushDuration(event.EnqueuedAt, err)
+			}
 		}
 	}()
 	span, ctx := s.Tracer.FromCtx(ctx, "flow.ExecReleaseArtifactID")
@@ -227,6 +237,7 @@ func (s *Service) ExecReleaseArtifactID(ctx context.Context, event ReleaseArtifa
 			if errors.Cause(err) == git.ErrNothingToCommit {
 				logger.Infof("Environment is up to date: dropping event: %v", err)
 				// TODO: notify actor that there was nothing to commit
+				nothingToCommit = true
 				return true, nil
 			}
 			// we can see races here where other changes are committed to the master repo

--- a/internal/flow/release_test.go
+++ b/internal/flow/release_test.go
@@ -1,0 +1,240 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lunarway/release-manager/internal/artifact"
+	"github.com/lunarway/release-manager/internal/copy"
+	internalgit "github.com/lunarway/release-manager/internal/git"
+	"github.com/lunarway/release-manager/internal/intent"
+	"github.com/lunarway/release-manager/internal/log"
+	"github.com/lunarway/release-manager/internal/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestMain(m *testing.M) {
+	log.Init(&log.Configuration{
+		Level:       log.Level{Level: zapcore.ErrorLevel},
+		Development: false,
+	})
+	os.Exit(m.Run())
+}
+
+// fakeObserver captures ObserveFlowDuration and ObserveReleasePushDuration calls.
+type fakeObserver struct {
+	flowCalls []flowCall
+	pushCalls []pushCall
+}
+
+type flowCall struct {
+	operation string
+	start     time.Time
+	err       error
+}
+
+type pushCall struct {
+	start time.Time
+	err   error
+}
+
+func (f *fakeObserver) ObserveFlowDuration(operation string, start time.Time, err error) {
+	f.flowCalls = append(f.flowCalls, flowCall{operation: operation, start: start, err: err})
+}
+
+func (f *fakeObserver) ObserveReleasePushDuration(start time.Time, err error) {
+	f.pushCalls = append(f.pushCalls, pushCall{start: start, err: err})
+}
+
+// fakeStorage is a minimal ArtifactReadStorage backed by files on disk.
+type fakeStorage struct {
+	specPath      string
+	resourcesPath string
+}
+
+func (f *fakeStorage) ArtifactExists(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeStorage) ArtifactSpecification(_ context.Context, _, _ string) (artifact.Spec, error) {
+	return artifact.Spec{}, nil
+}
+
+func (f *fakeStorage) ArtifactPaths(_ context.Context, _, _, _, _ string) (string, string, func(context.Context), error) {
+	return f.specPath, f.resourcesPath, func(context.Context) {}, nil
+}
+
+func (f *fakeStorage) LatestArtifactPaths(_ context.Context, _, _, _ string) (string, string, func(context.Context), error) {
+	return f.specPath, f.resourcesPath, func(context.Context) {}, nil
+}
+
+func (f *fakeStorage) LatestArtifactSpecification(_ context.Context, _, _ string) (artifact.Spec, error) {
+	return artifact.Spec{}, nil
+}
+
+func (f *fakeStorage) ArtifactSpecifications(_ context.Context, _ string, _ int, _ string) ([]artifact.Spec, error) {
+	return nil, nil
+}
+
+// setupArtifactStorage creates a temp dir with a minimal artifact.json.
+func setupArtifactStorage(t *testing.T) *fakeStorage {
+	t.Helper()
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "artifact.json")
+	spec := artifact.Spec{
+		ID:      "master-test-1234",
+		Service: "svc",
+		Application: artifact.Repository{
+			Branch:      "master",
+			AuthorName:  "test",
+			AuthorEmail: "test@example.com",
+		},
+	}
+	b, err := json.Marshal(spec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(specPath, b, 0600))
+	return &fakeStorage{
+		specPath:      specPath,
+		resourcesPath: dir,
+	}
+}
+
+// newTestService builds a Service for ExecReleaseArtifactID unit tests.
+func newTestService(t *testing.T, obs FlowObserver, gitSvc GitService, storage ArtifactReadStorage) *Service {
+	t.Helper()
+	logger := log.New(&log.Configuration{
+		Level:       log.Level{Level: zapcore.ErrorLevel},
+		Development: false,
+	})
+	return &Service{
+		ArtifactFileName: "artifact.json",
+		Git:              gitSvc,
+		Tracer:           tracing.NewNoop(),
+		Storage:          storage,
+		Copier:           copy.New(logger),
+		Observer:         obs,
+		MaxRetries:       1,
+	}
+}
+
+// TestReleaseArtifactIDEvent_EnqueuedAt_roundtrip verifies that EnqueuedAt
+// survives Marshal → Unmarshal intact.
+func TestReleaseArtifactIDEvent_EnqueuedAt_roundtrip(t *testing.T) {
+	t.Parallel()
+
+	// JSON time is RFC3339 — truncate to second precision so round-trip is exact.
+	enqueuedAt := time.Now().UTC().Truncate(time.Second)
+	original := ReleaseArtifactIDEvent{
+		Service:     "svc",
+		Environment: "dev",
+		ArtifactID:  "master-abc-123",
+		EnqueuedAt:  enqueuedAt,
+	}
+
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	var got ReleaseArtifactIDEvent
+	require.NoError(t, got.Unmarshal(data))
+
+	assert.True(t, original.EnqueuedAt.Equal(got.EnqueuedAt),
+		"EnqueuedAt not preserved through Marshal/Unmarshal: want %v got %v",
+		original.EnqueuedAt, got.EnqueuedAt)
+	assert.Equal(t, original.Service, got.Service)
+	assert.Equal(t, original.ArtifactID, got.ArtifactID)
+}
+
+// TestExecReleaseArtifactID_observationWiring tests that ObserveReleasePushDuration
+// is called correctly under different outcome scenarios.
+func TestExecReleaseArtifactID_observationWiring(t *testing.T) {
+	t.Parallel()
+
+	enqueuedAt := time.Now().Add(-5 * time.Second)
+	terminalErr := errors.New("commit failed")
+
+	cases := []struct {
+		name              string
+		enqueuedAt        time.Time
+		commitErr         error
+		wantPushCallCount int
+		wantPushErrNil    bool
+	}{
+		{
+			name:              "success: push succeeds",
+			enqueuedAt:        enqueuedAt,
+			commitErr:         nil,
+			wantPushCallCount: 1,
+			wantPushErrNil:    true,
+		},
+		{
+			name:              "terminal error: ObserveReleasePushDuration called with non-nil err",
+			enqueuedAt:        enqueuedAt,
+			commitErr:         terminalErr,
+			wantPushCallCount: 1,
+			wantPushErrNil:    false,
+		},
+		{
+			name:              "no-op (ErrNothingToCommit): ObserveReleasePushDuration NOT called",
+			enqueuedAt:        enqueuedAt,
+			commitErr:         internalgit.ErrNothingToCommit,
+			wantPushCallCount: 0,
+		},
+		{
+			name:              "zero EnqueuedAt (legacy message): ObserveReleasePushDuration NOT called",
+			enqueuedAt:        time.Time{},
+			commitErr:         nil,
+			wantPushCallCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obs := &fakeObserver{}
+			storage := setupArtifactStorage(t)
+
+			gitSvc := &MockGitService{}
+			gitSvc.Test(t)
+			// ShallowClone is called with a temp dir — match any destination.
+			gitSvc.On("ShallowClone", mock.Anything, mock.AnythingOfType("string")).Return(nil)
+			gitSvc.On("Commit", mock.Anything, mock.AnythingOfType("string"), ".", mock.AnythingOfType("string")).Return(tc.commitErr)
+
+			svc := newTestService(t, obs, gitSvc, storage)
+
+			event := ReleaseArtifactIDEvent{
+				Service:     "svc",
+				Environment: "dev",
+				Namespace:   "dev",
+				ArtifactID:  "master-test-1234",
+				Branch:      "master",
+				Intent:      intent.NewReleaseArtifact(),
+				EnqueuedAt:  tc.enqueuedAt,
+			}
+
+			_ = svc.ExecReleaseArtifactID(context.Background(), event)
+
+			assert.Len(t, obs.pushCalls, tc.wantPushCallCount, "ObserveReleasePushDuration call count")
+			if tc.wantPushCallCount > 0 {
+				call := obs.pushCalls[0]
+				assert.True(t, tc.enqueuedAt.Equal(call.start),
+					"start time: want %v got %v", tc.enqueuedAt, call.start)
+				if tc.wantPushErrNil {
+					assert.NoError(t, call.err)
+				} else {
+					assert.Error(t, call.err)
+				}
+			}
+			// ObserveFlowDuration must always be called exactly once.
+			assert.Len(t, obs.flowCalls, 1, "ObserveFlowDuration must always be called once")
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,8 +9,9 @@ import (
 
 // Observer holds Prometheus metrics for the release manager.
 type Observer struct {
-	releaseCounter *prometheus.CounterVec
-	flowDuration   *prometheus.HistogramVec
+	releaseCounter      *prometheus.CounterVec
+	flowDuration        *prometheus.HistogramVec
+	releasePushDuration *prometheus.HistogramVec
 }
 
 // NewObserver creates and registers all Prometheus metrics.
@@ -31,6 +32,11 @@ func NewObserver() *Observer {
 			Help:    "Duration of flow operations in seconds",
 			Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"operation", "outcome"}),
+		releasePushDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "release_manager_release_push_duration_seconds",
+			Help:    "Wall-clock duration from release intent accepted to release pushed to GitHub, in seconds",
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120},
+		}, []string{"outcome"}),
 	}
 }
 
@@ -63,4 +69,16 @@ func (o *Observer) ObserveFlowDuration(operation string, start time.Time, err er
 		outcome = "error"
 	}
 	o.flowDuration.WithLabelValues(operation, outcome).Observe(time.Since(start).Seconds())
+}
+
+// ObserveReleasePushDuration records the wall-clock time since start for a
+// release that reached a terminal outcome, deriving the outcome label from err
+// (success on nil, error otherwise). It must not be called for no-op releases
+// (nothing to commit).
+func (o *Observer) ObserveReleasePushDuration(start time.Time, err error) {
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	o.releasePushDuration.WithLabelValues(outcome).Observe(time.Since(start).Seconds())
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -23,6 +23,83 @@ func newTestObserver(t *testing.T) (*Observer, *prometheus.Registry) {
 	return &Observer{flowDuration: hist}, reg
 }
 
+// newTestObserverForPushDuration builds an Observer whose releasePushDuration
+// histogram is registered against a fresh, isolated registry.
+func newTestObserverForPushDuration(t *testing.T) (*Observer, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	hist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "release_manager_release_push_duration_seconds",
+		Help:    "Wall-clock duration from release intent accepted to release pushed to GitHub, in seconds",
+		Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120},
+	}, []string{"outcome"})
+	reg.MustRegister(hist)
+	return &Observer{releasePushDuration: hist}, reg
+}
+
+// TestObserveReleasePushDuration verifies that ObserveReleasePushDuration maps
+// nil errors to the "success" outcome and non-nil errors to the "error" outcome,
+// and that exactly one sample is recorded per call.
+func TestObserveReleasePushDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		err             error
+		expectedOutcome string
+	}{
+		{
+			name:            "nil error yields success outcome",
+			err:             nil,
+			expectedOutcome: "success",
+		},
+		{
+			name:            "non-nil error yields error outcome",
+			err:             errors.New("push failed"),
+			expectedOutcome: "error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obs, reg := newTestObserverForPushDuration(t)
+			obs.ObserveReleasePushDuration(time.Now(), tc.err)
+
+			mfs, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gather metrics: %v", err)
+			}
+
+			var found bool
+			for _, mf := range mfs {
+				if mf.GetName() != "release_manager_release_push_duration_seconds" {
+					continue
+				}
+				for _, m := range mf.GetMetric() {
+					var outcome string
+					for _, lp := range m.GetLabel() {
+						if lp.GetName() == "outcome" {
+							outcome = lp.GetValue()
+						}
+					}
+					if outcome == tc.expectedOutcome {
+						got := m.GetHistogram().GetSampleCount()
+						if got != 1 {
+							t.Errorf("expected sample count 1, got %d", got)
+						}
+						found = true
+					}
+				}
+			}
+			if !found {
+				t.Errorf("no metric found for outcome=%q", tc.expectedOutcome)
+			}
+		})
+	}
+}
+
 // TestObserveFlowDuration verifies that ObserveFlowDuration maps nil errors to
 // the "success" outcome and non-nil errors to the "error" outcome, and that
 // exactly one sample is recorded per call.


### PR DESCRIPTION
## Summary

Adds a `release_manager_release_push_duration_seconds` histogram that measures wall-clock time from when a release intent is accepted (event enqueued) to when the push to GitHub completes.

## Changes

- Add `ObserveReleasePushDuration(start time.Time, err error)` to the `FlowObserver` interface
- Add `EnqueuedAt time.Time` field to `ReleaseArtifactIDEvent`, set at enqueue time
- Wire the observation in `ExecReleaseArtifactID` via a deferred call, guarded by `!event.EnqueuedAt.IsZero()`
- Zero `EnqueuedAt` on `ErrNothingToCommit` so no-op releases are excluded from the distribution
- Implement `ObserveReleasePushDuration` on `metrics.Observer` with `outcome` label (success/error)
- Add unit tests for the marshal/unmarshal roundtrip, all observer-call scenarios, and the metric label mapping

## Why

Gives visibility into end-to-end release push latency — from user intent to GitHub push — as a percentile-queryable histogram, enabling alerting on slow releases and baseline for future performance work.

Closes DMAT-412

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to the release flow with backward-compatible event JSON and guarded metric emission; no auth or release policy logic changes.
> 
> **Overview**
> Adds end-to-end **release push latency** observability: wall-clock time from when a release intent is enqueued until `ExecReleaseArtifactID` finishes.
> 
> `ReleaseArtifactIDEvent` now carries **`EnqueuedAt`**, set when the event is published. The executor records **`ObserveReleasePushDuration`** in a deferred hook using that timestamp (success/error via the final error). **No-op** paths (`ErrNothingToCommit`) and **legacy** events with zero `EnqueuedAt` are skipped so the histogram is not skewed.
> 
> The **`FlowObserver`** contract and **`metrics.Observer`** gain a new Prometheus histogram, `release_manager_release_push_duration_seconds`, labeled by `outcome`. Unit tests cover JSON round-trip, observer call wiring, and metric label mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736081a47e4131ee1cc9003e97d609c1740f4738. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->