### PR TITLE
fix(git): suppress verbose git command stdout/stderr logs on success

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -526,16 +526,19 @@ func execCommand(ctx context.Context, rootPath string, cmdName string, args ...s
 	}
 
 	err = cmd.Wait()
-	logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
-	logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
+	knownErr := isKnownGitError(stderrData)
+	if err != nil || knownErr != nil {
+		if len(stdoutData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
+		}
+		if len(stderrData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
+		}
+	}
 	if err != nil {
 		return errors.WithMessage(err, "execute command failed")
 	}
-	err = isKnownGitError(stderrData)
-	if err != nil {
-		return err
-	}
-	return nil
+	return knownErr
 }
 
 // knownGitErrors contains error messages that should be considered as errors by
@@ -590,9 +593,13 @@ func checkStatus(ctx context.Context, rootPath string) error {
 	}
 
 	err = cmd.Wait()
-	logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
-	logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
 	if err != nil {
+		if len(stdoutData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
+		}
+		if len(stderrData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
+		}
 		return errors.WithMessage(err, "execute command failed")
 	}
 	if len(stdoutData) == 0 {
@@ -635,9 +642,13 @@ func (s *Service) gitPush(ctx context.Context, rootPath string) error {
 	}
 
 	err = cmd.Wait()
-	logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
-	logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
 	if err != nil {
+		if len(stdoutData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stdout: %s", cmdName, strings.Join(args, " "), stdoutData)
+		}
+		if len(stderrData) > 0 {
+			logger.Infof("git/commit: exec command '%s %s': stderr: %s", cmdName, strings.Join(args, " "), stderrData)
+		}
 		if isBranchBehindOrigin(stderrData) {
 			return ErrBranchBehindOrigin
 		}


### PR DESCRIPTION
## Summary

Suppress verbose stdout/stderr logging from git command execution on the happy path. Previously all three command-running functions (`execCommand`, `checkStatus`, `gitPush`) logged output unconditionally, producing dozens of noisy "Updating files: X%" progress lines whenever `git clone` ran.

## Changes

- `execCommand`: only logs stdout/stderr when the command fails or a known git error is detected in stderr
- `checkStatus`: only logs stdout/stderr when the command fails
- `gitPush`: only logs stdout/stderr when the command fails

## Why

`git clone` emits checkout progress to stderr even on success. With clones of large repos (27k+ files) this produced 60+ log lines per release with no diagnostic value. Output is still fully captured in memory for error detection (`isKnownGitError`, `isBranchBehindOrigin`) — only the unconditional logging is removed.

Closes DMAT-416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change on success paths; failure handling and stderr-based error detection are preserved.
> 
> **Overview**
> Reduces log noise from git shell helpers by **only emitting captured stdout/stderr when something goes wrong**, instead of on every successful run.
> 
> In **`execCommand`**, **`checkStatus`**, and **`gitPush`**, full output is still read for checks like `isKnownGitError` and `isBranchBehindOrigin`, but info logs are gated on non-zero exit (and, for `execCommand`, on a known stderr pattern). **`execCommand`** also returns **`knownErr`** after a zero exit when stderr matches the known-error list, without dumping progress output on the happy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce371e91a6fad61172f049b3ae7b02c9e63206b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->