### PR TITLE
perf(git): clone master mirror with --local hardlink, dropping --depth 1

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -143,9 +143,12 @@ func (s *Service) Clone(ctx context.Context, destination string) (*git.Repositor
 	return s.copyMaster(ctx, destination)
 }
 
-// ShallowClone creates a depth-1 local clone of the master repository into destination.
-// It sets the remote URL to ConfigRepoURL so subsequent pushes reach the real origin.
-// Use this when the caller only needs the working tree (commit+push), not git history.
+// ShallowClone creates a hardlinked local clone of the master repository into
+// destination. Because the clone is local and not depth-limited, git hardlinks
+// the object store instead of copying it, so it is cheap and retains full
+// history. It sets the remote URL to ConfigRepoURL so subsequent pushes reach
+// the real origin. Use this when the caller only needs the working tree
+// (commit+push); the full history comes along for free.
 func (s *Service) ShallowClone(ctx context.Context, destination string) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.ShallowClone")
 	defer span.End()
@@ -156,11 +159,11 @@ func (s *Service) ShallowClone(ctx context.Context, destination string) error {
 	}
 	defer unlock()
 
-	span, _ = s.Tracer.FromCtx(ctx, "shallow clone")
-	err = execCommand(ctx, filepath.Dir(destination), "git", "clone", "--depth", "1", "--local", s.masterPath, destination)
+	span, _ = s.Tracer.FromCtx(ctx, "local clone")
+	err = execCommand(ctx, filepath.Dir(destination), "git", "clone", "--local", s.masterPath, destination)
 	span.End()
 	if err != nil {
-		return errors.WithMessagef(err, "shallow clone master from '%s'", s.masterPath)
+		return errors.WithMessagef(err, "local clone master from '%s'", s.masterPath)
 	}
 
 	span, _ = s.Tracer.FromCtx(ctx, "set remote url")
@@ -432,11 +435,8 @@ func (s *Service) advanceMirror(ctx context.Context, rootPath string) {
 // push rejection to recover in place without re-cloning.
 //
 // The fetch targets the local mirror rather than the remote origin on purpose:
-// the working tree is a depth-1 shallow clone, so a fetch from the remote
-// origin would also be shallow and leave the branch without a merge base,
-// failing the rebase. The mirror shares full history with the working tree, so
-// the merge base is available locally and the fetch costs no network round
-// trip.
+// the mirror shares full history with the working tree, so the merge base is
+// available locally and the fetch costs no network round trip.
 func (s *Service) rebaseOntoMaster(ctx context.Context, rootPath string) error {
 	span, ctx := s.Tracer.FromCtx(ctx, "git.rebaseOntoMaster")
 	defer span.End()

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/lunarway/release-manager/internal/log"
@@ -151,11 +150,7 @@ func TestCommitAdvancesMirrorAfterPush(t *testing.T) {
 
 func revParse(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", ref)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "git rev-parse %s failed: %s", ref, out)
-	return strings.TrimSpace(string(out))
+	return gitOutput(t, dir, "rev-parse", ref)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/git/shallow_clone_test.go
+++ b/internal/git/shallow_clone_test.go
@@ -1,0 +1,131 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/lunarway/release-manager/internal/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShallowCloneIsFullHistoryHardlink locks in optimisation A: ShallowClone
+// drops --depth 1 and keeps --local, so the resulting working clone carries the
+// full mirror history and git hardlinks the object store instead of copying it.
+// The full-history assertion is the behavioural discriminator against the old
+// depth-1 clone; the shared-inode assertion proves the clone stayed a cheap
+// hardlink rather than a full object copy.
+func TestShallowCloneIsFullHistoryHardlink(t *testing.T) {
+	// Isolate from the developer's global/system git config so the production
+	// exec paths behave deterministically.
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	ctx := context.Background()
+	root := t.TempDir()
+
+	originDir := filepath.Join(root, "origin")
+	seedDir := filepath.Join(root, "seed")
+	mirrorDir := filepath.Join(root, "mirror")
+	workDir := filepath.Join(root, "work")
+
+	// Bare origin (stands in for the config repo) with two commits so a depth-1
+	// clone would visibly truncate history.
+	runGit(t, root, "init", "--bare", "-b", "master", originDir)
+	runGit(t, root, "clone", originDir, seedDir)
+	configureIdentity(t, seedDir)
+	writeFile(t, seedDir, "a.txt", "a")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add a")
+	writeFile(t, seedDir, "b.txt", "b")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add b")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	// Full-history local mirror (Service.masterPath) cloned from origin.
+	runGit(t, root, "clone", originDir, mirrorDir)
+
+	s := &Service{
+		Tracer:        tracing.NewNoop(),
+		Config:        &GitConfig{User: "test", Email: "test@example.com"},
+		ConfigRepoURL: originDir,
+		masterPath:    mirrorDir,
+	}
+
+	err := s.ShallowClone(ctx, workDir)
+	require.NoError(t, err)
+
+	// Full history: both commits are present, unlike a depth-1 clone.
+	assert.Equal(t, 2, commitCount(t, workDir),
+		"clone must retain full history, not a single depth-1 commit")
+
+	// The origin URL is repointed at the real config repo for later pushes.
+	assert.Equal(t, originDir, remoteURL(t, workDir, "origin"))
+
+	// Hardlinked object store: at least one object file in the clone shares an
+	// inode with the mirror, proving --local hardlinked rather than copied.
+	assert.True(t, sharesObjectInode(t, mirrorDir, workDir),
+		"clone object store must be hardlinked to the mirror, not a full copy")
+}
+
+func commitCount(t *testing.T, dir string) int {
+	t.Helper()
+	out := gitOutput(t, dir, "rev-list", "--count", "HEAD")
+	count, err := strconv.Atoi(out)
+	require.NoErrorf(t, err, "unexpected rev-list output: %q", out)
+	return count
+}
+
+func remoteURL(t *testing.T, dir, remote string) string {
+	t.Helper()
+	return gitOutput(t, dir, "remote", "get-url", remote)
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
+// sharesObjectInode reports whether any object file under dst/.git/objects is
+// the same inode as a file under src/.git/objects, which is what a --local
+// hardlink clone produces.
+func sharesObjectInode(t *testing.T, src, dst string) bool {
+	t.Helper()
+	srcInodes := objectInodes(t, src)
+	for ino := range objectInodes(t, dst) {
+		if srcInodes[ino] {
+			return true
+		}
+	}
+	return false
+}
+
+func objectInodes(t *testing.T, repo string) map[uint64]bool {
+	t.Helper()
+	inodes := make(map[uint64]bool)
+	objects := filepath.Join(repo, ".git", "objects")
+	err := filepath.Walk(objects, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if st, ok := info.Sys().(*syscall.Stat_t); ok {
+			inodes[st.Ino] = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return inodes
+}


### PR DESCRIPTION
## What

`ShallowClone` clones the local master mirror into a per-release temp dir before each commit+push. It used `git clone --depth 1 --local`. The `--depth 1` flag **defeats** git's `--local` hardlink fast path, forcing a full object-store copy instead of a cheap hardlink. This drops `--depth 1` (keeping `--local`) so git hardlinks the object store.

## Why

- **Cheaper clone, shorter lock window.** A `--local` hardlink clone is significantly faster than a full object copy (micro-benchmark on a 7.1M `.git`: `clone --depth 1 --local` 0.80s → `clone --local` hardlink 0.58s; the production config repo is larger, so absolute numbers scale). The clone holds the `masterMutex` read lock for its duration, so a shorter clone also shrinks the write-lock wait for the post-push mirror advance that contends against the parallel release clones.
- **Full history comes along for free.** The hardlink clone retains full history, which also makes the depth-1 workaround rationale in `rebaseOntoMaster`'s comment moot (comment trimmed). The fetch-from-mirror rebase recovery itself is unchanged.

## Changes

- `internal/git/git.go`: drop `--depth 1`; rename the trace span and error message from `"shallow clone"` → `"local clone"`; update the `ShallowClone` godoc and trim the now-moot depth-1 explanation in `rebaseOntoMaster`.
- `internal/git/shallow_clone_test.go` (new): asserts the clone retains full history (not depth-1) and that its object store is hardlinked to the mirror.

The method name `ShallowClone` is intentionally left unchanged to keep the diff surgical — renaming would churn the `flow`/`policy` `GitService` interfaces and their mocks.

## Verification

- `go build ./...`, `go vet ./internal/git/...`, `gofmt -l internal/git/` clean
- `go test ./internal/git/... ./internal/flow/... ./internal/policy/...` all pass; existing rebase tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)