### PR TITLE
perf(flow): read env spec from master mirror instead of cloning in ReleaseArtifactID

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -118,6 +118,7 @@ type GitService interface {
 	Clone(context.Context, string) (*git.Repository, error)
 	ShallowClone(ctx context.Context, destination string) error
 	MasterPath() string
+	WithMasterRLock(ctx context.Context, fn func(masterPath string) error) error
 	Commit(ctx context.Context, rootPath, changesPath, msg string) error
 	LocateServiceReleaseRollbackSkip(ctx context.Context, r *git.Repository, env, service string, n uint) (plumbing.Hash, error)
 	Checkout(ctx context.Context, rootPath string, hash plumbing.Hash) error

--- a/internal/flow/mock_GitService.go
+++ b/internal/flow/mock_GitService.go
@@ -118,6 +118,20 @@ func (_m *MockGitService) MasterPath() string {
 	return r0
 }
 
+// WithMasterRLock provides a mock function with given fields: ctx, fn
+func (_m *MockGitService) WithMasterRLock(ctx context.Context, fn func(masterPath string) error) error {
+	ret := _m.Called(ctx, fn)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, func(string) error) error); ok {
+		r0 = rf(ctx, fn)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SyncMaster provides a mock function with given fields: _a0
 func (_m *MockGitService) SyncMaster(_a0 context.Context) error {
 	ret := _m.Called(_a0)

--- a/internal/flow/release.go
+++ b/internal/flow/release.go
@@ -105,16 +105,17 @@ func (s *Service) ReleaseArtifactID(ctx context.Context, actor Actor, environmen
 	// environment. If there is no artifact released to the target environment an
 	// artifact.ErrFileNotFound error is returned. This is OK as the currentSpec
 	// will then be the default value and this its ID will be the empty string.
-	destinationConfigRepoPath, closeDestinationSource, err := git.TempDirAsync(ctx, s.Tracer, "k8s-config-release-artifact-destination")
-	if err != nil {
-		return "", err
-	}
-	defer closeDestinationSource(ctx)
-	err = s.Git.ShallowClone(ctx, destinationConfigRepoPath)
-	if err != nil {
-		return "", errors.WithMessagef(err, "clone into '%s'", destinationConfigRepoPath)
-	}
-	currentSpec, err := envSpec(destinationConfigRepoPath, s.ArtifactFileName, service, environment, namespace)
+	//
+	// The current spec is read straight from the master mirror's working tree
+	// (under the read lock) rather than cloning into a temp dir: this pre-check
+	// only needs to read one spec file, and the authoritative "nothing to
+	// commit" check happens later in ExecReleaseArtifactID via git status.
+	var currentSpec artifact.Spec
+	err = s.Git.WithMasterRLock(ctx, func(masterPath string) error {
+		var err error
+		currentSpec, err = envSpec(masterPath, s.ArtifactFileName, service, environment, namespace)
+		return err
+	})
 	if err != nil && errors.Cause(err) != artifact.ErrFileNotFound {
 		return "", errors.WithMessage(err, "get current released spec")
 	}

--- a/internal/flow/release_test.go
+++ b/internal/flow/release_test.go
@@ -152,6 +152,103 @@ func TestReleaseArtifactIDEvent_EnqueuedAt_roundtrip(t *testing.T) {
 	assert.Equal(t, original.ArtifactID, got.ArtifactID)
 }
 
+// specStorage is an ArtifactReadStorage whose source ArtifactSpecification is
+// configurable, used to drive ReleaseArtifactID's "nothing to release"
+// pre-check.
+type specStorage struct {
+	fakeStorage
+	sourceSpec artifact.Spec
+}
+
+func (s *specStorage) ArtifactSpecification(_ context.Context, _, _ string) (artifact.Spec, error) {
+	return s.sourceSpec, nil
+}
+
+// TestReleaseArtifactID_readsMirrorWithoutCloning asserts that the
+// "nothing to release" pre-check reads the current spec from the master mirror
+// under WithMasterRLock instead of cloning into a temp dir (optimisation C).
+func TestReleaseArtifactID_readsMirrorWithoutCloning(t *testing.T) {
+	t.Parallel()
+
+	// testdata/dev/releases/dev/a/artifact.json holds ID master-default-5678.
+	const currentArtifactID = "master-default-5678"
+
+	cases := []struct {
+		name            string
+		sourceID        string
+		wantErr         error
+		wantPublishCall bool
+	}{
+		{
+			name:            "current differs: publishes release event",
+			sourceID:        "master-new-9999",
+			wantErr:         nil,
+			wantPublishCall: true,
+		},
+		{
+			name:            "current matches: nothing to release",
+			sourceID:        currentArtifactID,
+			wantErr:         ErrNothingToRelease,
+			wantPublishCall: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			storage := &specStorage{
+				fakeStorage: fakeStorage{
+					// resourcesPath must exist for releaseConfigurationExists.
+					specPath:      t.TempDir(),
+					resourcesPath: t.TempDir(),
+				},
+				sourceSpec: artifact.Spec{
+					ID: tc.sourceID,
+					Application: artifact.Repository{
+						Branch: "master",
+					},
+				},
+			}
+
+			gitSvc := &MockGitService{}
+			gitSvc.Test(t)
+			// WithMasterRLock invokes the callback with the testdata mirror tree.
+			gitSvc.On("WithMasterRLock", mock.Anything, mock.AnythingOfType("func(string) error")).
+				Return(func(_ context.Context, fn func(string) error) error {
+					return fn("testdata")
+				})
+
+			svc := newTestService(t, nil, gitSvc, storage)
+			svc.CanRelease = func(context.Context, string, string, string) (bool, error) {
+				return true, nil
+			}
+			var published int
+			svc.PublishReleaseArtifactID = func(context.Context, ReleaseArtifactIDEvent) error {
+				published++
+				return nil
+			}
+
+			_, err := svc.ReleaseArtifactID(context.Background(), Actor{Name: "test", Email: "test@example.com"}, "dev", "a", tc.sourceID, intent.NewReleaseArtifact())
+
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tc.wantPublishCall {
+				assert.Equal(t, 1, published, "expected release event to be published")
+			} else {
+				assert.Equal(t, 0, published, "expected no release event")
+			}
+
+			// optimisation C: the pre-check must not clone.
+			gitSvc.AssertNotCalled(t, "ShallowClone", mock.Anything, mock.Anything)
+			gitSvc.AssertCalled(t, "WithMasterRLock", mock.Anything, mock.Anything)
+		})
+	}
+}
+
 // TestExecReleaseArtifactID_observationWiring tests that ObserveReleasePushDuration
 // is called correctly under different outcome scenarios.
 func TestExecReleaseArtifactID_observationWiring(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -198,6 +198,21 @@ func (s *Service) copyMaster(ctx context.Context, destination string) (*git.Repo
 	return r, nil
 }
 
+// WithMasterRLock invokes fn with the master mirror's path while holding the
+// master read lock. The lock excludes concurrent SyncMaster/advanceMirror
+// writers that mutate the mirror's working tree, so fn observes a consistent
+// tree. Use it for read-only access to the mirror (e.g. reading a spec file)
+// instead of cloning into a temp dir.
+func (s *Service) WithMasterRLock(ctx context.Context, fn func(masterPath string) error) error {
+	span, _ := s.Tracer.FromCtx(ctx, "git.WithMasterRLock")
+	defer span.End()
+
+	s.masterMutex.RLock()
+	defer s.masterMutex.RUnlock()
+
+	return fn(s.masterPath)
+}
+
 // prepareDestination removes destination and acquires the master read lock.
 // The caller must defer the returned unlock function.
 func (s *Service) prepareDestination(ctx context.Context, destination string) (func(), error) {


### PR DESCRIPTION
## What

`ReleaseArtifactID`'s "nothing to release" pre-check used to clone the config
repo into a temp dir (`ShallowClone` into `TempDirAsync`) purely to read a
single spec file and compare its artifact ID against the source spec. This PR
reads the current environment spec straight from the master mirror's working
tree instead.

## Why

That clone cost roughly ~1.5s per environment and ran on the new-artifact
fan-out for **every** target environment — all to read one `artifact.json` and
do an advisory `currentSpec.ID == sourceSpec.ID` check. The authoritative
"nothing to commit" check still happens later in `ExecReleaseArtifactID` via
`git status`, so this pre-check only needs a cheap read.

## How

- Add `git.Service.WithMasterRLock(ctx, fn func(masterPath string) error) error`:
  it runs the callback with the mirror path while holding the master read lock,
  so the read is properly excluded against concurrent `SyncMaster` /
  `advanceMirror` writers. This is a cleaner contract than the existing
  lock-free `MasterPath()` readers and is reusable for migrating those later.
- `ReleaseArtifactID` now calls `WithMasterRLock` + `envSpec(masterPath, ...)`
  in place of the `TempDirAsync` + `ShallowClone` + temp-dir `envSpec` block.
- Add `WithMasterRLock` to the `flow.GitService` interface and its mock.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/git/... ./internal/flow/... ./internal/policy/...` green.
- New `TestReleaseArtifactID_readsMirrorWithoutCloning` asserts the pre-check
  reads via `WithMasterRLock` and never calls `ShallowClone`, covering both the
  "differs → publish event" and "matches → ErrNothingToRelease" branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release enqueue pre-check semantics and mirror locking, but the authoritative no-op path remains in ExecReleaseArtifactID via git status.
> 
> **Overview**
> **`ReleaseArtifactID`** no longer spins up a temp dir and **`ShallowClone`** just to compare the target environment’s current `artifact.json` with the source artifact. That advisory “nothing to release” check now reads the spec via **`git.WithMasterRLock`** and **`envSpec`** on the master mirror working tree, avoiding roughly ~1.5s per environment on multi-env fan-out.
> 
> **`git.Service.WithMasterRLock`** runs a callback with the mirror path while holding the master read lock, so reads stay consistent with concurrent **`SyncMaster`** / **`advanceMirror`** writers. The method is exposed on **`flow.GitService`** and the mock.
> 
> **`TestReleaseArtifactID_readsMirrorWithoutCloning`** covers publish vs **`ErrNothingToRelease`** and asserts **`ShallowClone`** is never called for this pre-check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcaae83ef21c2b8873370e473debc9fe2f0c53c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->