### PR TITLE
perf(git): serialize push step with mutex to eliminate branch conflicts

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -46,10 +46,20 @@ type Service struct {
 	masterPath  string
 	masterMutex sync.RWMutex
 	master      *git.Repository
+
+	// pushSem serializes git push origin calls to prevent branch-behind-origin
+	// conflicts when multiple workers push concurrently.
+	pushSem     chan struct{}
+	pushSemOnce sync.Once
 }
 
 func (s *Service) MasterPath() string {
 	return s.masterPath
+}
+
+func (s *Service) getPushSem() chan struct{} {
+	s.pushSemOnce.Do(func() { s.pushSem = make(chan struct{}, 1) })
+	return s.pushSem
 }
 
 // InitMasterRepo clones the configuration repository into a master directory.
@@ -389,7 +399,12 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
-	err = s.gitPush(ctx, rootPath)
+	sem := s.getPushSem()
+	err = func() error {
+		sem <- struct{}{}
+		defer func() { <-sem }()
+		return s.gitPush(ctx, rootPath)
+	}()
 	span.End()
 	if err == nil {
 		return nil
@@ -403,6 +418,8 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 	pushSpan, _ := s.Tracer.FromCtx(ctx, "push after rebase")
 	defer pushSpan.End()
+	sem <- struct{}{}
+	defer func() { <-sem }()
 	return s.gitPush(ctx, rootPath)
 }
 
@@ -495,6 +512,9 @@ func (s *Service) SignedCommit(ctx context.Context, rootPath, changesPath, autho
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
 	defer span.End()
+	sem := s.getPushSem()
+	sem <- struct{}{}
+	defer func() { <-sem }()
 	return s.gitPush(ctx, rootPath)
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -47,19 +47,13 @@ type Service struct {
 	masterMutex sync.RWMutex
 	master      *git.Repository
 
-	// pushSem serializes git push origin calls to prevent branch-behind-origin
+	// pushMu serializes git push origin calls to prevent branch-behind-origin
 	// conflicts when multiple workers push concurrently.
-	pushSem     chan struct{}
-	pushSemOnce sync.Once
+	pushMu sync.Mutex
 }
 
 func (s *Service) MasterPath() string {
 	return s.masterPath
-}
-
-func (s *Service) getPushSem() chan struct{} {
-	s.pushSemOnce.Do(func() { s.pushSem = make(chan struct{}, 1) })
-	return s.pushSem
 }
 
 // InitMasterRepo clones the configuration repository into a master directory.
@@ -399,10 +393,9 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
-	sem := s.getPushSem()
 	err = func() error {
-		sem <- struct{}{}
-		defer func() { <-sem }()
+		s.pushMu.Lock()
+		defer s.pushMu.Unlock()
 		return s.gitPush(ctx, rootPath)
 	}()
 	span.End()
@@ -418,8 +411,8 @@ func (s *Service) Commit(ctx context.Context, rootPath, changesPath, msg string)
 	}
 	pushSpan, _ := s.Tracer.FromCtx(ctx, "push after rebase")
 	defer pushSpan.End()
-	sem <- struct{}{}
-	defer func() { <-sem }()
+	s.pushMu.Lock()
+	defer s.pushMu.Unlock()
 	return s.gitPush(ctx, rootPath)
 }
 
@@ -512,9 +505,8 @@ func (s *Service) SignedCommit(ctx context.Context, rootPath, changesPath, autho
 
 	span, _ = s.Tracer.FromCtx(ctx, "push")
 	defer span.End()
-	sem := s.getPushSem()
-	sem <- struct{}{}
-	defer func() { <-sem }()
+	s.pushMu.Lock()
+	defer s.pushMu.Unlock()
 	return s.gitPush(ctx, rootPath)
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -599,4 +601,36 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 			assert.Equal(t, tc.isBehind, isBehind, "result not as expected")
 		})
 	}
+}
+
+// TestService_pushSem_serializesConcurrentPushes verifies that getPushSem
+// lazily initializes a size-1 channel and that the channel serializes concurrent
+// acquire/release pairs — the same acquire/release pattern used around gitPush
+// calls in Commit and SignedCommit.
+func TestService_pushSem_serializesConcurrentPushes(t *testing.T) {
+	svc := &Service{}
+
+	const workers = 5
+	var (
+		concurrent int64
+		maxSeen    int64
+		wg         sync.WaitGroup
+	)
+
+	sem := svc.getPushSem()
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			cur := atomic.AddInt64(&concurrent, 1)
+			if cur > atomic.LoadInt64(&maxSeen) {
+				atomic.StoreInt64(&maxSeen, cur)
+			}
+			atomic.AddInt64(&concurrent, -1)
+			<-sem
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(1), maxSeen, "at most one goroutine should hold the push semaphore at a time")
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -603,11 +603,10 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 	}
 }
 
-// TestService_pushSem_serializesConcurrentPushes verifies that getPushSem
-// lazily initializes a size-1 channel and that the channel serializes concurrent
-// acquire/release pairs — the same acquire/release pattern used around gitPush
-// calls in Commit and SignedCommit.
-func TestService_pushSem_serializesConcurrentPushes(t *testing.T) {
+// TestService_pushMu_serializesConcurrentPushes verifies that pushMu serializes
+// concurrent lock/unlock pairs — the same pattern used around gitPush calls in
+// Commit and SignedCommit.
+func TestService_pushMu_serializesConcurrentPushes(t *testing.T) {
 	svc := &Service{}
 
 	const workers = 5
@@ -617,20 +616,19 @@ func TestService_pushSem_serializesConcurrentPushes(t *testing.T) {
 		wg         sync.WaitGroup
 	)
 
-	sem := svc.getPushSem()
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sem <- struct{}{}
+			svc.pushMu.Lock()
 			cur := atomic.AddInt64(&concurrent, 1)
 			if cur > atomic.LoadInt64(&maxSeen) {
 				atomic.StoreInt64(&maxSeen, cur)
 			}
 			atomic.AddInt64(&concurrent, -1)
-			<-sem
+			svc.pushMu.Unlock()
 		}()
 	}
 	wg.Wait()
-	assert.Equal(t, int64(1), maxSeen, "at most one goroutine should hold the push semaphore at a time")
+	assert.Equal(t, int64(1), maxSeen, "at most one goroutine should hold the push mutex at a time")
 }


### PR DESCRIPTION
## Summary

Adds a size-1 channel mutex to `git.Service` that serializes `git push origin` calls across `Commit` and `SignedCommit`. This eliminates branch-behind-origin conflicts between parallel workers without reducing clone/commit parallelism.

## Why

After increasing AMQP consumers from 1 to 5 parallel workers (#633), release flow p99 latency jumped to ~30s. Root cause: 5 workers pushing to GitHub concurrently meant workers 2–5 got rejected with "branch behind origin", triggering `rebaseOntoMaster` → `SyncMaster` write-lock cascades (~8–10s each). Serializing only the push step (which is the actual race point) eliminates the conflicts entirely; the expensive clone (~1.5s) and commit steps remain parallel.

Closes DMAT-421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release git push path used by multiple workers, but the change is narrowly scoped serialization with the existing rebase-on-conflict fallback unchanged.
> 
> **Overview**
> Adds a **lazy-initialized size-1 `pushSem`** on `git.Service` so concurrent workers no longer race on `git push origin` at the same time.
> 
> `Commit` and `SignedCommit` now **acquire/release the semaphore around every `gitPush` call**, including the post-rebase retry in `Commit`, while clone and commit work stay parallel. A unit test checks that only one goroutine holds the semaphore at once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3096c6f9cf51b750fac102a63673ffc6aa67e44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->