### PR TITLE
perf(metrics): extend histogram upper bounds for release duration metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,12 +30,12 @@ func NewObserver() *Observer {
 		flowDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "release_manager_flow_duration_seconds",
 			Help:    "Duration of flow operations in seconds",
-			Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+			Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 300},
 		}, []string{"operation", "outcome"}),
 		releasePushDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "release_manager_release_push_duration_seconds",
 			Help:    "Wall-clock duration from release intent accepted to release pushed to GitHub, in seconds",
-			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120},
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120, 180, 300, 600},
 		}, []string{"outcome"}),
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func newTestObserver(t *testing.T) (*Observer, *prometheus.Registry) {
 	hist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "release_manager_flow_duration_seconds",
 		Help:    "Duration of flow operations in seconds",
-		Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 300},
 	}, []string{"operation", "outcome"})
 	reg.MustRegister(hist)
 	return &Observer{flowDuration: hist}, reg
@@ -31,7 +31,7 @@ func newTestObserverForPushDuration(t *testing.T) (*Observer, *prometheus.Regist
 	hist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "release_manager_release_push_duration_seconds",
 		Help:    "Wall-clock duration from release intent accepted to release pushed to GitHub, in seconds",
-		Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120},
+		Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120, 180, 300, 600},
 	}, []string{"outcome"})
 	reg.MustRegister(hist)
 	return &Observer{releasePushDuration: hist}, reg


### PR DESCRIPTION
## Summary

Extend histogram upper bounds for `release_manager_release_push_duration_seconds` and `release_manager_flow_duration_seconds` to prevent observations from overflowing into `+Inf`.

## Changes

- `release_manager_flow_duration_seconds`: added `120, 300` buckets (was capped at 60s)
- `release_manager_release_push_duration_seconds`: added `180, 300, 600` buckets (was capped at 120s)
- Updated test helper bucket lists in `metrics_test.go` to match production

## Why

p99 for `release_push_duration` was ~58s over a 6h window, clustering near the old 120s ceiling. Individual releases were observed at or above the top finite bucket, causing quantile estimates above p99 to be inaccurate (`+Inf`). `flow_duration` similarly needed headroom for full-flow operations running beyond 60s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only bucket tuning with no change to release logic or metric recording behavior.
> 
> **Overview**
> Extends Prometheus histogram bucket upper bounds for **`release_manager_flow_duration_seconds`** and **`release_manager_release_push_duration_seconds`** so long-running releases and flows are recorded in finite buckets instead of **`+Inf`**, improving tail quantile accuracy.
> 
> **`flow_duration`** gains **120s** and **300s** buckets (previously capped at 60s). **`release_push_duration`** gains **180s**, **300s**, and **600s** (previously capped at 120s). Test helpers in **`metrics_test.go`** use the same bucket lists as production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb644b54e994dba7624ede42c53b95c5fc79bc2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->