### PR TITLE
fix(git): set committer identity in ShallowClone so rebase recovery works

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -196,6 +196,24 @@ func (s *Service) ShallowClone(ctx context.Context, destination string) error {
 		return errors.WithMessage(err, "set remote url")
 	}
 
+	// Set the committer identity locally so any git command that writes a commit
+	// in this working tree has one. Commit injects the identity inline via -c per
+	// invocation, but the rebase recovery path (rebaseOntoMaster) shells out to a
+	// bare `git rebase`, which would otherwise abort with "unable to auto-detect
+	// email address" (exit 128) in the container, where the hostname resolves to
+	// ".(none)". Configuring it once here covers every git command in the clone.
+	span, _ = s.Tracer.FromCtx(ctx, "set identity")
+	err = execCommand(ctx, destination, "git", "config", "user.name", s.Config.User)
+	if err != nil {
+		span.End()
+		return errors.WithMessage(err, "set user name")
+	}
+	err = execCommand(ctx, destination, "git", "config", "user.email", s.Config.Email)
+	span.End()
+	if err != nil {
+		return errors.WithMessage(err, "set user email")
+	}
+
 	return nil
 }
 

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -149,6 +149,72 @@ func TestCommitAdvancesMirrorAfterPush(t *testing.T) {
 		"mirror master must match the pushed commit")
 }
 
+// TestShallowCloneRecoveryUsesConfiguredIdentity reproduces the production
+// failure where the rebase recovery path exits 128 ("unable to auto-detect
+// email address"). Unlike the tests above, it builds the working tree via the
+// real ShallowClone instead of manually configuring an identity, so the working
+// tree carries only whatever identity ShallowClone sets. The rebase that
+// recovers a push conflict writes a commit and therefore needs that identity;
+// without it git aborts fatally and the release never recovers in place.
+func TestShallowCloneRecoveryUsesConfiguredIdentity(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	// Force git to use only the configured identity, never an implicit
+	// user@hostname one. This reproduces the container, where the hostname
+	// resolves to ".(none)" and git refuses the auto-detected address with
+	// "fatal: unable to auto-detect email address". Without this, a developer
+	// machine's resolvable hostname would let the rebase commit succeed and mask
+	// the bug.
+	globalConfig := filepath.Join(root, "gitconfig")
+	require.NoError(t, os.WriteFile(globalConfig, []byte("[user]\n\tuseConfigOnly = true\n"), 0o644))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+
+	originDir := filepath.Join(root, "origin")
+	seedDir := filepath.Join(root, "seed")
+	mirrorDir := filepath.Join(root, "mirror")
+	workDir := filepath.Join(root, "work")
+
+	runGit(t, root, "init", "--bare", "-b", "master", originDir)
+	runGit(t, root, "clone", originDir, seedDir)
+	configureIdentity(t, seedDir)
+	writeFile(t, seedDir, "a.txt", "a")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add a")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	runGit(t, root, "clone", originDir, mirrorDir)
+
+	s := &Service{
+		Tracer:        tracing.NewNoop(),
+		Config:        &GitConfig{User: "test", Email: "test@example.com"},
+		ConfigRepoURL: originDir,
+		masterPath:    mirrorDir,
+	}
+
+	// Build the working tree exactly as the release flow does, via ShallowClone,
+	// rather than cloning and configuring an identity by hand.
+	err := s.ShallowClone(ctx, workDir)
+	require.NoError(t, err)
+
+	// An upstream commit lands after the clones were taken, so the first push
+	// is rejected and Commit must rebase to recover.
+	writeFile(t, seedDir, "b.txt", "b")
+	runGit(t, seedDir, "add", ".")
+	runGit(t, seedDir, "commit", "-m", "add b")
+	runGit(t, seedDir, "push", "origin", "master")
+
+	writeFile(t, workDir, "c.txt", "c")
+
+	err = s.Commit(ctx, workDir, ".", "[env/svc] release c")
+	require.NoError(t, err, "rebase recovery must use the configured identity, not abort with exit 128")
+
+	pullLatest(t, seedDir)
+	assert.FileExists(t, filepath.Join(seedDir, "b.txt"))
+	assert.FileExists(t, filepath.Join(seedDir, "c.txt"))
+}
+
 func revParse(t *testing.T, dir, ref string) string {
 	t.Helper()
 	cmd := exec.Command("git", "rev-parse", ref)


### PR DESCRIPTION
## Problem

Releases that lose the push race fall into the in-place recovery path (`rebaseOntoMaster`), which runs a bare `git rebase`. That rebase writes a commit and so needs a committer identity — but `ShallowClone` never configured one. In the container, where the hostname resolves to `.(none)`, git refuses the auto-detected address and the rebase aborts **fatally**:

```
git/execCommand: running: git rebase FETCH_HEAD
git/commit: exec command 'git rebase FETCH_HEAD': stderr: Rebasing (1/1)
Committer identity unknown

*** Please tell me who you are.

Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
...
fatal: unable to auto-detect email address (got 'root@release-manager-b945b96c9-fptds.(none)')
```

Which surfaces as repeated:

```
{"caller":"flow/release.go:233","message":"git/Commit: rebase onto master failed; falling back to outer retry",
 "fields":{"error":"rebase onto master: execute command failed: exit status 128"}}
```

Note **exit status 128** — a git *fatal*, not a content conflict (which would be exit 1). So this is not two PRs editing the same file; the rebase command itself can never succeed in this environment.

## Why it slipped through

`Commit` injects the identity inline via `-c user.name=… -c user.email=…` on each invocation, so the *initial* commit succeeded and the gap was invisible on the happy path. Only the rebase recovery — a separate bare `git rebase` with no `-c` flags — lacked an identity. The existing rebase tests passed because they configured the identity on the work dir by hand (`configureIdentity`), something production's `ShallowClone` never did.

## Impact

When several PRs are released back-to-back on the same repo (a normal case), later releases reliably lose the push race and route through `rebaseOntoMaster`. Every one of them failed fatally, discarded the whole attempt, and re-cloned — turning the "recovery" into a guaranteed full restart. A trace of one such release showed 3 attempts (~9.8s + 8.7s + 4.2s ≈ 22.8s), the first two ending in the exit-128 rebase, not contention.

## Fix (Option B)

Set `user.name` / `user.email` locally once in `ShallowClone`, so every git command in the working tree — rebase included — has an identity. This is more robust than adding `-c` flags to the one rebase call: it covers any future git command (cherry-pick, amend, …) and avoids the inline-`-c` quoting wart in `Commit`.

All `Commit` callers (`flow/release.go`, `policy/policy.go`) clone via `ShallowClone` first, so every rebase-recovery path is covered. `copyMaster` is read-only and unaffected.

## Test

`TestShallowCloneRecoveryUsesConfiguredIdentity` builds the working tree via the real `ShallowClone` (not a hand-configured identity) and sets `user.useConfigOnly=true` to reproduce the container's missing auto-detected identity. It fails with exit 128 before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release git clone path used before every commit/push, but the change is a small, config-only addition with a targeted regression test for the rebase recovery flow.
> 
> **Overview**
> **`ShallowClone` now writes local `user.name` and `user.email`** from `GitConfig` after the shallow clone and remote URL setup, so any git command in that working tree that creates commits—including the bare `git rebase` in `rebaseOntoMaster`—has a committer identity. Initial commits already passed `-c` flags on `git commit`; the push-race recovery path did not, which in containers (hostname `.(none)`) caused **exit 128** and forced full re-clone retries instead of in-place rebase.
> 
> Adds **`TestShallowCloneRecoveryUsesConfiguredIdentity`**: builds the work tree via real `ShallowClone`, sets `user.useConfigOnly=true` to block implicit `user@hostname` identity, then runs `Commit` through a push conflict so rebase recovery must succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c7d593371cfdeb775802bc861aa421e2909488. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->