### PR TITLE
feat(try): add jittered exponential backoff between retry attempts

### DIFF
--- a/internal/try/try.go
+++ b/internal/try/try.go
@@ -106,10 +106,7 @@ func contextSleep(ctx context.Context, d time.Duration) error {
 func (c config) backoff(attempt int) time.Duration {
 	// attempt 2 is the first wait, exponent should start at 0.
 	exp := max(attempt-2, 0)
-	ceiling := float64(c.baseDelay) * float64(int64(1)<<uint(exp))
-	if max := float64(c.maxDelay); ceiling > max {
-		ceiling = max
-	}
+	ceiling := min(float64(c.baseDelay)*float64(int64(1)<<uint(exp)), float64(c.maxDelay))
 	// full jitter in [ceiling/2, ceiling] keeps delays growing while still
 	// randomizing them so colliding releases spread out.
 	jittered := ceiling/2 + c.jitter()*(ceiling/2)

--- a/internal/try/try.go
+++ b/internal/try/try.go
@@ -3,6 +3,8 @@ package try
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/pkg/errors"
@@ -16,12 +18,116 @@ var (
 	ErrTooManyRetries = fmt.Errorf("too many retries")
 )
 
+const (
+	// defaultBaseDelay is the base unit of the exponential backoff applied
+	// between retry attempts.
+	defaultBaseDelay = 500 * time.Millisecond
+	// defaultMaxDelay caps the exponential backoff so it does not grow
+	// unbounded for high attempt counts.
+	defaultMaxDelay = 30 * time.Second
+)
+
+// Sleeper waits for the given duration or until the context is cancelled,
+// whichever comes first. It returns the context error if the wait was
+// interrupted by cancellation.
+type Sleeper func(ctx context.Context, d time.Duration) error
+
+// JitterSource returns a value in the range [0, 1) used to randomize the
+// backoff delay so concurrent retriers de-synchronize.
+type JitterSource func() float64
+
+// config holds the tunable retry behaviour. The zero value is not valid; use
+// newConfig to obtain defaults.
+type config struct {
+	baseDelay time.Duration
+	maxDelay  time.Duration
+	sleep     Sleeper
+	jitter    JitterSource
+}
+
+// Option configures the retry behaviour of Do.
+type Option func(*config)
+
+// WithBaseDelay sets the base unit of the exponential backoff.
+func WithBaseDelay(d time.Duration) Option {
+	return func(c *config) { c.baseDelay = d }
+}
+
+// WithMaxDelay caps the exponential backoff delay.
+func WithMaxDelay(d time.Duration) Option {
+	return func(c *config) { c.maxDelay = d }
+}
+
+// WithSleeper overrides how Do waits between attempts. Primarily used in tests
+// to avoid sleeping real wall-clock time.
+func WithSleeper(s Sleeper) Option {
+	return func(c *config) { c.sleep = s }
+}
+
+// WithJitterSource overrides the randomness used to jitter the backoff delay.
+// Primarily used in tests to make the delay deterministic.
+func WithJitterSource(j JitterSource) Option {
+	return func(c *config) { c.jitter = j }
+}
+
+func newConfig(opts ...Option) config {
+	c := config{
+		baseDelay: defaultBaseDelay,
+		maxDelay:  defaultMaxDelay,
+		sleep:     contextSleep,
+		jitter:    rand.Float64,
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+}
+
+// contextSleep waits for d or until ctx is cancelled, returning ctx.Err() if
+// the wait was interrupted.
+func contextSleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// backoff computes the jittered exponential backoff delay before the given
+// attempt number (1-indexed). The first attempt has no preceding delay so it is
+// only called for attempt >= 2.
+//
+// It uses "full jitter": the exponential ceiling doubles each attempt (capped
+// at maxDelay) and the actual delay is uniformly sampled within that ceiling,
+// guaranteeing concurrent retriers de-synchronize.
+func (c config) backoff(attempt int) time.Duration {
+	// attempt 2 is the first wait, exponent should start at 0.
+	exp := max(attempt-2, 0)
+	ceiling := float64(c.baseDelay) * float64(int64(1)<<uint(exp))
+	if max := float64(c.maxDelay); ceiling > max {
+		ceiling = max
+	}
+	// full jitter in [ceiling/2, ceiling] keeps delays growing while still
+	// randomizing them so colliding releases spread out.
+	jittered := ceiling/2 + c.jitter()*(ceiling/2)
+	return time.Duration(jittered)
+}
+
 // Do tries the function f until max attempts is reached.
 // If f returns a true bool or a nil error retries are stopped and the error is
 // returned.
 //
-// Context cancellation is respected in between attempts.
-func Do(ctx context.Context, tracer tracing.Tracer, max int, f func(context.Context, int) (bool, error)) error {
+// Between attempts Do waits for a jittered exponential backoff delay. The first
+// attempt is never delayed. The wait honors context cancellation: if the
+// context is cancelled during the wait Do returns promptly with the accumulated
+// error and the context error.
+//
+// Context cancellation is also respected in between attempts.
+func Do(ctx context.Context, tracer tracing.Tracer, max int, f func(context.Context, int) (bool, error), opts ...Option) error {
+	cfg := newConfig(opts...)
 	var errs error
 	attempt := 1
 	parentCtx := ctx
@@ -44,6 +150,11 @@ func Do(ctx context.Context, tracer tracing.Tracer, max int, f func(context.Cont
 			attempt++
 			if attempt > max {
 				return multierr.Append(errs, ErrTooManyRetries)
+			}
+			// Wait before the next attempt with jittered exponential backoff,
+			// returning promptly if the context is cancelled during the wait.
+			if err := cfg.sleep(parentCtx, cfg.backoff(attempt)); err != nil {
+				return multierr.Append(errs, err)
 			}
 		}
 	}

--- a/internal/try/try_test.go
+++ b/internal/try/try_test.go
@@ -3,11 +3,19 @@ package try
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/lunarway/release-manager/internal/tracing"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// noopSleeper returns immediately, keeping timing-agnostic tests fast and
+// deterministic while still respecting context cancellation.
+func noopSleeper(ctx context.Context, _ time.Duration) error {
+	return ctx.Err()
+}
 
 func TestDo(t *testing.T) {
 	tt := []struct {
@@ -98,7 +106,7 @@ func TestDo(t *testing.T) {
 			err := Do(context.Background(), tracing.NewNoop(), tc.max, func(ctx context.Context, attempt int) (bool, error) {
 				c++
 				return tc.f(attempt)
-			})
+			}, WithSleeper(noopSleeper))
 			if tc.err == nil {
 				assert.NoError(t, err, "unexpected error")
 			} else {
@@ -161,7 +169,7 @@ func TestDo_contextCancellation(t *testing.T) {
 				}
 				c++
 				return false, errors.New("an error")
-			})
+			}, WithSleeper(noopSleeper))
 			if tc.err == nil {
 				assert.NoError(t, err, "unexpected error")
 			} else {
@@ -170,4 +178,114 @@ func TestDo_contextCancellation(t *testing.T) {
 			assert.Equal(t, tc.tries, c, "actual retry count not as expected")
 		})
 	}
+}
+
+func TestDo_backoffGrowsAndIsJittered(t *testing.T) {
+	// Two independent runs with the same backoff configuration but different
+	// jitter sources must produce different delays so concurrent retriers
+	// de-synchronize.
+	var slept []time.Duration
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}
+
+	// jitter source returns a fixed fraction so the test is deterministic.
+	jitter := func() float64 { return 0.0 }
+
+	max := 4
+	err := Do(context.Background(), tracing.NewNoop(), max, func(ctx context.Context, attempt int) (bool, error) {
+		return false, errors.New("an error")
+	},
+		WithBaseDelay(100*time.Millisecond),
+		WithSleeper(sleeper),
+		WithJitterSource(jitter),
+	)
+	require.Error(t, err)
+
+	// First attempt must NOT be delayed. With max=4 there are 4 attempts and
+	// therefore 3 waits between them.
+	require.Len(t, slept, max-1, "first attempt must not be delayed; only waits between attempts")
+
+	// With jitter fraction 0.0 the delay is exactly half the exponential base
+	// (full jitter style: delay in [base/2, base]). We assert monotonic growth.
+	for i := 1; i < len(slept); i++ {
+		assert.Greater(t, slept[i], slept[i-1], "backoff must grow between attempts")
+	}
+}
+
+func TestDo_jitterRandomizesDelay(t *testing.T) {
+	// With the same exponential schedule, different jitter values must yield
+	// different delays.
+	runWithJitter := func(j float64) []time.Duration {
+		var slept []time.Duration
+		sleeper := func(ctx context.Context, d time.Duration) error {
+			slept = append(slept, d)
+			return nil
+		}
+		_ = Do(context.Background(), tracing.NewNoop(), 3, func(ctx context.Context, attempt int) (bool, error) {
+			return false, errors.New("an error")
+		},
+			WithBaseDelay(100*time.Millisecond),
+			WithSleeper(sleeper),
+			WithJitterSource(func() float64 { return j }),
+		)
+		return slept
+	}
+
+	low := runWithJitter(0.0)
+	high := runWithJitter(1.0)
+	require.Equal(t, len(low), len(high))
+	require.NotEmpty(t, low)
+	differ := false
+	for i := range low {
+		if low[i] != high[i] {
+			differ = true
+		}
+		// jitter must keep delays positive and bounded.
+		assert.Greater(t, low[i], time.Duration(0))
+		assert.GreaterOrEqual(t, high[i], low[i])
+	}
+	assert.True(t, differ, "different jitter sources must produce different delays")
+}
+
+func TestDo_contextCancellationDuringWait(t *testing.T) {
+	// If the context is cancelled DURING the backoff wait, Do must return
+	// promptly with the accumulated error plus the context error.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// sleeper simulates cancellation arriving during the wait.
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		cancel()
+		return ctx.Err()
+	}
+
+	c := 0
+	err := Do(ctx, tracing.NewNoop(), 5, func(ctx context.Context, attempt int) (bool, error) {
+		c++
+		return false, errors.New("an error")
+	},
+		WithBaseDelay(time.Second),
+		WithSleeper(sleeper),
+		WithJitterSource(func() float64 { return 0.5 }),
+	)
+	require.Error(t, err)
+	assert.EqualError(t, err, "retry 1: an error; context canceled")
+	assert.Equal(t, 1, c, "should not attempt again after cancellation during wait")
+}
+
+func TestDo_firstAttemptNotDelayedOnSuccess(t *testing.T) {
+	var slept []time.Duration
+	sleeper := func(ctx context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}
+	err := Do(context.Background(), tracing.NewNoop(), 5, func(ctx context.Context, attempt int) (bool, error) {
+		return false, nil
+	},
+		WithBaseDelay(time.Second),
+		WithSleeper(sleeper),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, slept, "successful first attempt must not sleep")
 }


### PR DESCRIPTION
## Problem

`internal/try/try.go`'s `Do` retried on a non-stop error by immediately looping and calling `f` again with **no delay** between attempts — only `ctx.Done()` could interrupt the loop.

This is used by the release flow (`internal/flow/flow.go` `retry` → `internal/flow/release.go ExecReleaseArtifactID`) to retry git push conflicts (`ErrBranchBehindOrigin`). When multiple releases land back-to-back on the same repo, the losers retry **instantly**, re-race the same in-flight winner, and dogpile. Each retry is expensive (shallow clone + commit + sync), so instant retries pile on load.

Crucially, the conflict is resolved by **elapsed time** — the competing push landing and the mirror advancing — not by the retry itself. An immediate retry is therefore wasted work that just adds contention.

## Change

Add a **jittered exponential backoff** between attempts in `Do`:

- **Exponential**: the ceiling doubles per attempt (base `500ms`, capped at `30s`).
- **Jitter**: full jitter samples the delay within the ceiling. This de-synchronizes colliding releases so they stop retrying in lockstep against the same origin branch — the key property for breaking the dogpile.
- **First attempt is never delayed** — only the waits *between* attempts.
- **Context-aware wait**: the wait is a `select` on a timer vs `ctx.Done()`; if the context is cancelled during the wait, `Do` returns promptly with the accumulated error plus the context error.

Success/stop semantics, `multierr` accumulation, and `ErrTooManyRetries` behavior are unchanged.

## Backward compatibility

Backoff is configured via **functional options** (`WithBaseDelay`, `WithMaxDelay`, `WithSleeper`, `WithJitterSource`) with real production defaults. The existing callers (`internal/flow/flow.go`, `internal/policy/policy.go`) pass no options and keep working unchanged.

## Tests (TDD, deterministic, fast)

The sleeper and jitter source are injected so tests never sleep real wall-clock time:

- `TestDo_backoffGrowsAndIsJittered` — only waits between attempts (first attempt not delayed) and the delay grows monotonically.
- `TestDo_jitterRandomizesDelay` — different jitter values produce different delays, bounded and positive.
- `TestDo_contextCancellationDuringWait` — cancellation during the wait returns promptly with the accumulated + context error and does not attempt again.
- `TestDo_firstAttemptNotDelayedOnSuccess` — a successful first attempt never sleeps.
- The existing `TestDo` / `TestDo_contextCancellation` tables now inject a no-op sleeper so success/stop/max/cancellation semantics stay covered and fast.

`go build ./...`, `go vet ./internal/try/...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared retry timing used by release and policy flows, which can affect latency and contention under git push conflicts, though the API stays backward compatible and behavior is otherwise the same aside from delays.
> 
> **Overview**
> **`try.Do`** no longer retries failed attempts in a tight loop. It now waits between attempts using **jittered exponential backoff** (default base **500ms**, cap **30s**), with the **first attempt unchanged** (no upfront delay).
> 
> Backoff is tunable via **`WithBaseDelay`**, **`WithMaxDelay`**, **`WithSleeper`**, and **`WithJitterSource`**; production callers can keep the existing `Do(...)` signature and get the new defaults. Waits use a context-aware sleeper so **cancellation during a wait** returns the accumulated errors plus **`ctx.Err()`** without starting another attempt. Stop/success semantics, **`multierr`** chaining, and **`ErrTooManyRetries`** are unchanged.
> 
> Tests inject a **no-op sleeper** for existing table cases and add coverage for growing delays, jitter spread, cancellation mid-wait, and no sleep on immediate success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0883f541a9b7b874ff86e6d923426f9bc0ccd844. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->